### PR TITLE
fix(civisibility): isolate quarantined race tests

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package coverage
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
+)
+
+// ProcessTestCoverageFile is the serializable per-test coverage produced by an
+// isolated first-attempt process.
+type ProcessTestCoverageFile struct {
+	Name   string `json:"name"`
+	Bitmap []byte `json:"bitmap,omitempty"`
+}
+
+// ProcessTestCoverage owns one serialized runtime-coverage delta.
+type ProcessTestCoverage struct {
+	testFile string
+	before   map[string][]coverageBlock
+	active   bool
+}
+
+var processTestCoverageMu sync.Mutex
+
+// BeginProcessTestCoverage starts a serialized coverage delta when count-based
+// runtime coverage is available.
+func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
+	if !CanCollect() {
+		return nil
+	}
+	processTestCoverageMu.Lock()
+	before, err := processRuntimeCoverageSnapshot()
+	if err != nil {
+		processTestCoverageMu.Unlock()
+		return nil
+	}
+	return &ProcessTestCoverage{
+		testFile: utils.GetRelativePathFromCITagsSourceRoot(testFile),
+		before:   before,
+		active:   true,
+	}
+}
+
+// Finish returns the coverage delta and releases the serialized collector.
+func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
+	if c == nil || !c.active {
+		return nil
+	}
+	c.active = false
+	defer processTestCoverageMu.Unlock()
+	after, err := processRuntimeCoverageSnapshot()
+	if err != nil {
+		return nil
+	}
+	covered := getFilesCovered(c.testFile, c.before, after)
+	files := make([]ProcessTestCoverageFile, 0, len(covered))
+	for _, file := range covered {
+		files = append(files, ProcessTestCoverageFile{Name: file.name, Bitmap: append([]byte(nil), file.bitmap...)})
+	}
+	return files
+}
+
+func processRuntimeCoverageSnapshot() (map[string][]coverageBlock, error) {
+	file, err := os.CreateTemp("", "dd-process-coverage-*.out")
+	if err != nil {
+		return nil, err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	defer func() { _ = os.Remove(path) }()
+	if _, err := tearDown(path, ""); err != nil {
+		return nil, err
+	}
+	return parseCoverProfile(path)
+}
+
+// WriteProcessCoverageProfile writes the isolated process aggregate profile.
+func WriteProcessCoverageProfile(path string) error {
+	if !CanComputeCoverageProfile() {
+		return nil
+	}
+	processTestCoverageMu.Lock()
+	defer processTestCoverageMu.Unlock()
+	_, err := tearDown(path, "")
+	return err
+}
+
+// MergeProcessCoverageProfile merges an isolated process profile into the
+// parent runtime snapshot used for Go and CI Visibility aggregate coverage.
+func MergeProcessCoverageProfile(childPath string) error {
+	if !CanComputeCoverageProfile() {
+		return nil
+	}
+	processTestCoverageMu.Lock()
+	defer processTestCoverageMu.Unlock()
+	parentSnapshot, err := RuntimeCoverageSnapshot()
+	if err != nil {
+		return err
+	}
+	parent, err := parseOrderedCoverProfile(parentSnapshot.path)
+	if err != nil {
+		return err
+	}
+	child, err := parseOrderedCoverProfile(childPath)
+	if err != nil {
+		return err
+	}
+	if err := mergeProcessCoverageProfiles(parent, child); err != nil {
+		return err
+	}
+	return parent.writeAtomic(parentSnapshot.path)
+}
+
+func mergeProcessCoverageProfiles(parent, child *orderedCoverProfile) error {
+	if parent == nil || child == nil {
+		return errors.New("coverage profile missing")
+	}
+	if len(parent.lines) == 0 || len(child.lines) == 0 || strings.TrimSpace(parent.lines[0].raw) != strings.TrimSpace(child.lines[0].raw) {
+		return errors.New("coverage profile modes differ")
+	}
+	mode := strings.TrimSpace(strings.TrimPrefix(parent.lines[0].raw, "mode:"))
+	byBlock := make(map[string]*coverageBlock)
+	for idx := range parent.lines {
+		line := &parent.lines[idx]
+		if line.block != nil {
+			byBlock[processCoverageBlockKey(line.fileName, line.block)] = line.block
+		}
+	}
+	for idx := range child.lines {
+		line := &child.lines[idx]
+		if line.block == nil {
+			continue
+		}
+		block := byBlock[processCoverageBlockKey(line.fileName, line.block)]
+		if block == nil {
+			copyLine := *line
+			copyBlock := *line.block
+			copyLine.block = &copyBlock
+			parent.lines = append(parent.lines, copyLine)
+			byBlock[processCoverageBlockKey(line.fileName, line.block)] = copyLine.block
+			continue
+		}
+		if mode == "set" {
+			block.count = max(block.count, line.block.count)
+		} else if line.block.count > math.MaxInt-block.count {
+			block.count = math.MaxInt
+		} else {
+			block.count += line.block.count
+		}
+	}
+	return nil
+}
+
+func processCoverageBlockKey(fileName string, block *coverageBlock) string {
+	return fmt.Sprintf("%s:%d.%d,%d.%d %d", fileName, block.startLine, block.startCol, block.endLine, block.endCol, block.numStmt)
+}
+
+// SubmitProcessTestCoverage attaches child-produced coverage to the parent test
+// event identifiers and queues it on the existing coverage writer.
+func SubmitProcessTestCoverage(sessionID, suiteID, testID uint64, files []ProcessTestCoverageFile) {
+	if !CanCollectPerTestCoverage() || covWriter == nil || len(files) == 0 {
+		return
+	}
+	covered := make([]coveredFile, 0, len(files))
+	for _, file := range files {
+		covered = append(covered, coveredFile{name: file.Name, bitmap: append([]byte(nil), file.Bitmap...)})
+	}
+	telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
+	covWriter.add(&testCoverage{sessionID: sessionID, suiteID: suiteID, testID: testID, filesCovered: covered})
+	telemetry.CodeCoverageFinished(testFramework, telemetry.DefaultCoverageLibraryType)
+}

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -85,15 +85,87 @@ func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
 	return files
 }
 
-// WriteProcessCoverageProfile writes the isolated process aggregate profile.
-func WriteProcessCoverageProfile(path string) error {
+// ProcessCoverageProfile owns the aggregate coverage snapshot captured before
+// an isolated workload starts.
+type ProcessCoverageProfile struct {
+	before *orderedCoverProfile
+}
+
+// BeginProcessCoverageProfile captures the aggregate coverage present before
+// an isolated workload starts.
+func BeginProcessCoverageProfile() (*ProcessCoverageProfile, error) {
 	if !CanComputeCoverageProfile() {
+		return nil, nil
+	}
+	processTestCoverageMu.Lock()
+	defer processTestCoverageMu.Unlock()
+	before, err := snapshotProcessCoverageProfile()
+	if err != nil {
+		return nil, err
+	}
+	return &ProcessCoverageProfile{before: before}, nil
+}
+
+// WriteDelta writes only coverage added since BeginProcessCoverageProfile.
+func (p *ProcessCoverageProfile) WriteDelta(path string) error {
+	if p == nil {
 		return nil
 	}
 	processTestCoverageMu.Lock()
 	defer processTestCoverageMu.Unlock()
-	_, err := tearDown(path, "")
-	return err
+	after, err := snapshotProcessCoverageProfile()
+	if err != nil {
+		return err
+	}
+	if err := subtractProcessCoverageProfiles(p.before, after); err != nil {
+		return err
+	}
+	return after.writeAtomic(path)
+}
+
+func snapshotProcessCoverageProfile() (*orderedCoverProfile, error) {
+	temporaryDir, err := os.MkdirTemp("", "dd-process-profile-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(temporaryDir) }()
+	path := filepath.Join(temporaryDir, "coverage.out")
+	if _, err := tearDown(path, ""); err != nil {
+		return nil, err
+	}
+	return parseOrderedCoverProfile(path)
+}
+
+func subtractProcessCoverageProfiles(before, after *orderedCoverProfile) error {
+	if before == nil || after == nil {
+		return errors.New("coverage profile missing")
+	}
+	if len(before.lines) == 0 || len(after.lines) == 0 || strings.TrimSpace(before.lines[0].raw) != strings.TrimSpace(after.lines[0].raw) {
+		return errors.New("coverage profile modes differ")
+	}
+	mode := strings.TrimSpace(strings.TrimPrefix(after.lines[0].raw, "mode:"))
+	beforeByBlock := make(map[string]int)
+	for idx := range before.lines {
+		line := &before.lines[idx]
+		if line.block != nil {
+			beforeByBlock[processCoverageBlockKey(line.fileName, line.block)] = line.block.count
+		}
+	}
+	for idx := range after.lines {
+		line := &after.lines[idx]
+		if line.block == nil {
+			continue
+		}
+		beforeCount := beforeByBlock[processCoverageBlockKey(line.fileName, line.block)]
+		if mode == "set" {
+			if line.block.count <= beforeCount {
+				line.block.count = 0
+			}
+		} else {
+			line.block.count = max(line.block.count-beforeCount, 0)
+		}
+	}
+	return nil
 }
 
 // MergeProcessCoverageProfile merges an isolated process profile into the

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -10,11 +10,13 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 // ProcessTestCoverageFile is the serializable per-test coverage produced by an
@@ -26,9 +28,9 @@ type ProcessTestCoverageFile struct {
 
 // ProcessTestCoverage owns one serialized runtime-coverage delta.
 type ProcessTestCoverage struct {
-	testFile string
-	before   map[string][]coverageBlock
-	active   bool
+	coverage     *testCoverage
+	temporaryDir string
+	active       bool
 }
 
 var processTestCoverageMu sync.Mutex
@@ -40,16 +42,26 @@ func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 		return nil
 	}
 	processTestCoverageMu.Lock()
-	before, err := processRuntimeCoverageSnapshot()
+	temporaryDir, err := os.MkdirTemp("", "dd-process-coverage-*")
 	if err != nil {
+		log.Debug("civisibility.cov: error creating process coverage directory: %s", err.Error())
+		telemetry.CodeCoverageErrors()
 		processTestCoverageMu.Unlock()
 		return nil
 	}
-	return &ProcessTestCoverage{
-		testFile: utils.GetRelativePathFromCITagsSourceRoot(testFile),
-		before:   before,
-		active:   true,
+	collector := &testCoverage{
+		testFile:             utils.GetRelativePathFromCITagsSourceRoot(testFile),
+		preCoverageFilename:  filepath.Join(temporaryDir, "pre.out"),
+		postCoverageFilename: filepath.Join(temporaryDir, "post.out"),
 	}
+	if err := collector.collectCoverageBeforeTestExecution(); err != nil {
+		log.Debug("civisibility.cov: error getting process coverage file: %s", err.Error())
+		telemetry.CodeCoverageErrors()
+		_ = os.RemoveAll(temporaryDir)
+		processTestCoverageMu.Unlock()
+		return nil
+	}
+	return &ProcessTestCoverage{coverage: collector, temporaryDir: temporaryDir, active: true}
 }
 
 // Finish returns the coverage delta and releases the serialized collector.
@@ -59,33 +71,18 @@ func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
 	}
 	c.active = false
 	defer processTestCoverageMu.Unlock()
-	after, err := processRuntimeCoverageSnapshot()
-	if err != nil {
+	defer func() { _ = os.RemoveAll(c.temporaryDir) }()
+	if err := c.coverage.collectCoverageAfterTestExecution(); err != nil {
 		return nil
 	}
-	covered := getFilesCovered(c.testFile, c.before, after)
-	files := make([]ProcessTestCoverageFile, 0, len(covered))
-	for _, file := range covered {
-		files = append(files, ProcessTestCoverageFile{Name: file.name, Bitmap: append([]byte(nil), file.bitmap...)})
+	if !c.coverage.loadCoverageData() {
+		return nil
+	}
+	files := make([]ProcessTestCoverageFile, 0, len(c.coverage.filesCovered))
+	for _, file := range c.coverage.filesCovered {
+		files = append(files, ProcessTestCoverageFile{Name: file.name, Bitmap: file.bitmap})
 	}
 	return files
-}
-
-func processRuntimeCoverageSnapshot() (map[string][]coverageBlock, error) {
-	file, err := os.CreateTemp("", "dd-process-coverage-*.out")
-	if err != nil {
-		return nil, err
-	}
-	path := file.Name()
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return nil, err
-	}
-	defer func() { _ = os.Remove(path) }()
-	if _, err := tearDown(path, ""); err != nil {
-		return nil, err
-	}
-	return parseCoverProfile(path)
 }
 
 // WriteProcessCoverageProfile writes the isolated process aggregate profile.
@@ -177,9 +174,8 @@ func SubmitProcessTestCoverage(sessionID, suiteID, testID uint64, files []Proces
 	}
 	covered := make([]coveredFile, 0, len(files))
 	for _, file := range files {
-		covered = append(covered, coveredFile{name: file.Name, bitmap: append([]byte(nil), file.Bitmap...)})
+		covered = append(covered, coveredFile{name: file.Name, bitmap: file.Bitmap})
 	}
 	telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
-	covWriter.add(&testCoverage{sessionID: sessionID, suiteID: suiteID, testID: testID, filesCovered: covered})
-	telemetry.CodeCoverageFinished(testFramework, telemetry.DefaultCoverageLibraryType)
+	(&testCoverage{sessionID: sessionID, suiteID: suiteID, testID: testID, filesCovered: covered}).submitCoverageData()
 }

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -26,7 +26,8 @@ type ProcessTestCoverageFile struct {
 	Bitmap []byte `json:"bitmap,omitempty"`
 }
 
-// ProcessTestCoverage owns one serialized runtime-coverage delta.
+// ProcessTestCoverage owns one runtime-coverage delta. Callers must serialize
+// covered test bodies because the runtime counters are process-global.
 type ProcessTestCoverage struct {
 	coverage     *testCoverage
 	temporaryDir string
@@ -35,18 +36,18 @@ type ProcessTestCoverage struct {
 
 var processTestCoverageMu sync.Mutex
 
-// BeginProcessTestCoverage starts a serialized coverage delta when count-based
-// runtime coverage is available.
+// BeginProcessTestCoverage starts a coverage delta when count-based runtime
+// coverage is available. The caller must serialize the covered test body.
 func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 	if !CanCollect() {
 		return nil
 	}
 	processTestCoverageMu.Lock()
+	defer processTestCoverageMu.Unlock()
 	temporaryDir, err := os.MkdirTemp("", "dd-process-coverage-*")
 	if err != nil {
 		log.Debug("civisibility.cov: error creating process coverage directory: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		processTestCoverageMu.Unlock()
 		return nil
 	}
 	collector := &testCoverage{
@@ -58,18 +59,18 @@ func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 		log.Debug("civisibility.cov: error getting process coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
 		_ = os.RemoveAll(temporaryDir)
-		processTestCoverageMu.Unlock()
 		return nil
 	}
 	return &ProcessTestCoverage{coverage: collector, temporaryDir: temporaryDir, active: true}
 }
 
-// Finish returns the coverage delta and releases the serialized collector.
+// Finish returns the coverage delta and releases the collector resources.
 func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
 	if c == nil || !c.active {
 		return nil
 	}
 	c.active = false
+	processTestCoverageMu.Lock()
 	defer processTestCoverageMu.Unlock()
 	defer func() { _ = os.RemoveAll(c.temporaryDir) }()
 	if err := c.coverage.collectCoverageAfterTestExecution(); err != nil {

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -39,6 +39,33 @@ func TestMergeProcessCoverageProfilesRejectsDifferentModes(t *testing.T) {
 	require.Error(t, mergeProcessCoverageProfiles(parent, child))
 }
 
+func TestProcessTestCoverageUsesTestCoverageCollector(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() {
+		mode, tearDown = oldMode, oldTearDown
+	})
+	mode = "count"
+	profiles := [][]byte{
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 0\n"),
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 1\n"),
+	}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		snapshots++
+		return path, os.WriteFile(path, profiles[snapshots-1], 0o600)
+	}
+
+	collector := BeginProcessTestCoverage("pkg/source_test.go")
+	require.NotNil(t, collector)
+	files := collector.Finish()
+
+	require.Equal(t, 2, snapshots)
+	require.Equal(t, []ProcessTestCoverageFile{
+		{Name: "pkg/source_test.go"},
+		{Name: "pkg/source.go", Bitmap: []byte{0x80}},
+	}, files)
+}
+
 func TestSubmitProcessTestCoverageUsesParentEventIdentifiers(t *testing.T) {
 	oldMode, oldUpload, oldWriter := mode, coverageUploadEnabled, covWriter
 	t.Cleanup(func() {

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package coverage
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMergeProcessCoverageProfilesAddsIsolatedCounts(t *testing.T) {
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent.out")
+	childPath := filepath.Join(dir, "child.out")
+	require.NoError(t, os.WriteFile(parentPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 2\npkg/file.go:2.1,2.2 1 0\n"), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 3\npkg/file.go:2.1,2.2 1 1\n"), 0o600))
+	parent, err := parseOrderedCoverProfile(parentPath)
+	require.NoError(t, err)
+	child, err := parseOrderedCoverProfile(childPath)
+	require.NoError(t, err)
+
+	require.NoError(t, mergeProcessCoverageProfiles(parent, child))
+
+	require.Equal(t, 5, parent.lines[1].block.count)
+	require.Equal(t, 1, parent.lines[2].block.count)
+}
+
+func TestMergeProcessCoverageProfilesRejectsDifferentModes(t *testing.T) {
+	parent := &orderedCoverProfile{lines: []orderedCoverProfileLine{{raw: "mode: count"}}}
+	child := &orderedCoverProfile{lines: []orderedCoverProfileLine{{raw: "mode: atomic"}}}
+	require.Error(t, mergeProcessCoverageProfiles(parent, child))
+}
+
+func TestSubmitProcessTestCoverageUsesParentEventIdentifiers(t *testing.T) {
+	oldMode, oldUpload, oldWriter := mode, coverageUploadEnabled, covWriter
+	t.Cleanup(func() {
+		mode, coverageUploadEnabled, covWriter = oldMode, oldUpload, oldWriter
+	})
+	mode = "count"
+	coverageUploadEnabled = true
+	covWriter = &coverageWriter{payload: newCoveragePayload(), climit: make(chan struct{}, 1)}
+
+	SubmitProcessTestCoverage(11, 22, 33, []ProcessTestCoverageFile{
+		{Name: "pkg/test_file.go"},
+		{Name: "pkg/source.go", Bitmap: []byte{0x03}},
+	})
+
+	var got ciTestCoverages
+	payload, err := io.ReadAll(covWriter.payload)
+	require.NoError(t, err)
+	require.NoError(t, msgp.Decode(bytes.NewReader(payload), &got))
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(11), got[0].SessionID)
+	require.Equal(t, uint64(22), got[0].SuiteID)
+	require.Equal(t, uint64(33), got[0].SpanID)
+	require.Equal(t, "pkg/test_file.go", got[0].Files[0].FileName)
+	require.Equal(t, []byte{0x03}, got[0].Files[1].Bitmap)
+}

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -7,6 +7,7 @@ package coverage
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,6 +38,66 @@ func TestMergeProcessCoverageProfilesRejectsDifferentModes(t *testing.T) {
 	parent := &orderedCoverProfile{lines: []orderedCoverProfileLine{{raw: "mode: count"}}}
 	child := &orderedCoverProfile{lines: []orderedCoverProfileLine{{raw: "mode: atomic"}}}
 	require.Error(t, mergeProcessCoverageProfiles(parent, child))
+}
+
+func TestProcessCoverageProfileWritesOnlyWorkloadDelta(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() {
+		mode, tearDown = oldMode, oldTearDown
+	})
+	mode = "count"
+	profiles := [][]byte{
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 2\npkg/source.go:2.1,2.2 1 0\n"),
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 2\npkg/source.go:2.1,2.2 1 3\n"),
+	}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		profile := profiles[snapshots]
+		snapshots++
+		return path, os.WriteFile(path, profile, 0o600)
+	}
+
+	profile, err := BeginProcessCoverageProfile()
+	require.NoError(t, err)
+	output := filepath.Join(t.TempDir(), "delta.out")
+	require.NoError(t, profile.WriteDelta(output))
+
+	delta, err := parseOrderedCoverProfile(output)
+	require.NoError(t, err)
+	require.Equal(t, 0, delta.lines[1].block.count)
+	require.Equal(t, 3, delta.lines[2].block.count)
+	require.Equal(t, 2, snapshots)
+}
+
+func TestSubtractProcessCoverageProfilesUsesModeSemantics(t *testing.T) {
+	for _, tt := range []struct {
+		mode        string
+		beforeCount int
+		afterCount  int
+		want        int
+	}{
+		{mode: "count", beforeCount: 4, afterCount: 7, want: 3},
+		{mode: "atomic", beforeCount: 4, afterCount: 7, want: 3},
+		{mode: "set", beforeCount: 1, afterCount: 1, want: 0},
+		{mode: "set", beforeCount: 0, afterCount: 1, want: 1},
+	} {
+		t.Run(fmt.Sprintf("%s/%d-%d", tt.mode, tt.beforeCount, tt.afterCount), func(t *testing.T) {
+			before := processCoverageProfileForTest(t, tt.mode, tt.beforeCount)
+			after := processCoverageProfileForTest(t, tt.mode, tt.afterCount)
+
+			require.NoError(t, subtractProcessCoverageProfiles(before, after))
+			require.Equal(t, tt.want, after.lines[1].block.count)
+		})
+	}
+}
+
+func processCoverageProfileForTest(t *testing.T, profileMode string, count int) *orderedCoverProfile {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.out")
+	require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, "mode: %s\npkg/source.go:1.1,1.2 1 %d\n", profileMode, count), 0o600))
+	profile, err := parseOrderedCoverProfile(path)
+	require.NoError(t, err)
+	return profile
 }
 
 func TestProcessTestCoverageUsesTestCoverageCollector(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -127,6 +127,38 @@ func TestProcessTestCoverageUsesTestCoverageCollector(t *testing.T) {
 	}, files)
 }
 
+func TestProcessTestCoverageSupportsNestedSerializedCollectors(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() {
+		mode, tearDown = oldMode, oldTearDown
+	})
+	mode = "count"
+	counts := []int{0, 1, 2, 3}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		count := counts[snapshots]
+		snapshots++
+		return path, os.WriteFile(path, fmt.Appendf(nil, "mode: count\npkg/source.go:1.1,1.2 1 %d\n", count), 0o600)
+	}
+
+	outer := BeginProcessTestCoverage("pkg/outer_test.go")
+	require.NotNil(t, outer)
+	inner := BeginProcessTestCoverage("pkg/inner_test.go")
+	require.NotNil(t, inner)
+	innerFiles := inner.Finish()
+	outerFiles := outer.Finish()
+
+	require.Equal(t, 4, snapshots)
+	require.Equal(t, []ProcessTestCoverageFile{
+		{Name: "pkg/inner_test.go"},
+		{Name: "pkg/source.go", Bitmap: []byte{0x80}},
+	}, innerFiles)
+	require.Equal(t, []ProcessTestCoverageFile{
+		{Name: "pkg/outer_test.go"},
+		{Name: "pkg/source.go", Bitmap: []byte{0x80}},
+	}, outerFiles)
+}
+
 func TestSubmitProcessTestCoverageUsesParentEventIdentifiers(t *testing.T) {
 	oldMode, oldUpload, oldWriter := mode, coverageUploadEnabled, covWriter
 	t.Cleanup(func() {

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -466,14 +466,20 @@ func (t *testCoverage) CollectCoverageBeforeTestExecution() {
 		return
 	}
 
-	t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
-	_, err := tearDown(t.preCoverageFilename, "")
-	if err != nil {
+	if err := t.collectCoverageBeforeTestExecution(); err != nil {
 		log.Debug("civisibility.cov: error getting coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
 	} else {
 		telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
 	}
+}
+
+func (t *testCoverage) collectCoverageBeforeTestExecution() error {
+	if t.preCoverageFilename == "" {
+		t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
+	}
+	_, err := tearDown(t.preCoverageFilename, "")
+	return err
 }
 
 // CollectCoverageAfterTestExecution collects coverage after test execution.
@@ -502,7 +508,13 @@ func (t *testCoverage) getCoverageData() error {
 		return nil
 	}
 
-	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
+	return t.collectCoverageAfterTestExecution()
+}
+
+func (t *testCoverage) collectCoverageAfterTestExecution() error {
+	if t.postCoverageFilename == "" {
+		t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
+	}
 	_, err := tearDown(t.postCoverageFilename, "")
 	if err != nil {
 		log.Debug("civisibility.cov: error getting coverage file: %s", err.Error())
@@ -514,35 +526,49 @@ func (t *testCoverage) getCoverageData() error {
 
 // processCoverageData processes the coverage data.
 func (t *testCoverage) processCoverageData() {
+	if !t.loadCoverageData() {
+		return
+	}
+	t.submitCoverageData()
+	t.removeCoverageFiles()
+}
+
+func (t *testCoverage) loadCoverageData() bool {
 	if t.preCoverageFilename == "" ||
 		t.postCoverageFilename == "" ||
 		t.preCoverageFilename == t.postCoverageFilename {
 		log.Debug("civisibility.cov: no coverage data to process")
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 	preCoverage, err := parseCoverProfile(t.preCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error parsing pre-coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 	postCoverage, err := parseCoverProfile(t.postCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error parsing post-coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 
 	t.filesCovered = getFilesCovered(t.testFile, preCoverage, postCoverage)
+	return true
+}
+
+func (t *testCoverage) submitCoverageData() {
 	telemetry.CodeCoverageFinished(testFramework, telemetry.DefaultCoverageLibraryType)
 	if len(t.filesCovered) == 0 {
 		telemetry.CodeCoverageIsEmpty()
 	}
 
 	covWriter.add(t)
+}
 
-	err = os.Remove(t.preCoverageFilename)
+func (t *testCoverage) removeCoverageFiles() {
+	err := os.Remove(t.preCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error removing pre-coverage file: %s", err.Error())
 	}

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -133,6 +133,7 @@ type (
 		processRetryCoordinator    *processRetryCoordinator
 		efdFaultySessionGuard      earlyFlakeDetectionFaultySession
 		retryAttemptObserveOutput  bool
+		quarantinedRaceIsolation   bool
 	}
 
 	// executionOptions holds the execution options for the test
@@ -705,7 +706,7 @@ func applyAdditionalFeaturesToTestFunc(
 
 		var outcomes retryOutcomeAccumulator
 
-		runTestWithRetry(&runTestWithRetryOptions{
+		runOptions := &runTestWithRetryOptions{
 			targetFunc:                    f,
 			t:                             t,
 			parallelEFDAllowed:            wrapperOpts.parallelEFDAllowed,
@@ -918,7 +919,12 @@ func applyAdditionalFeaturesToTestFunc(
 					tParentCommonPrivates.SetFailed(true)
 				}
 			},
-		})
+		}
+		if wrapperOpts.quarantinedRaceIsolation && ptrMeta.isQuarantined {
+			deferQuarantinedRaceFirstAttempt(runOptions)
+			return
+		}
+		runTestWithRetry(runOptions)
 	}
 
 	// Mark the wrapper as instrumented.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -47,6 +47,7 @@ type (
 		isEarlyFlakeDetectionEnabled bool // flag to tag if Early Flake Detection is enabled for this execution
 		isFlakyTestRetriesEnabled    bool // flag to tag if Flaky Test Retries is enabled for this execution
 		isItrForcedRun               bool // flag to preserve ITR forced-run state across parent-owned process retries
+		isItrSkipped                 bool // flag to report an ITR skip reconstructed from an isolated process
 		flakyRetryBudgetReservation  *flakyRetryBudgetReservation
 		isQuarantined                bool          // flag to check if the test is quarantined
 		isDisabled                   bool          // flag to check if the test is disabled

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -104,6 +104,7 @@ type (
 		retryAttemptObserveOutputSet  bool
 		retryAttemptMaskingFallback   bool
 		allowProcessRetryChildRetries bool
+		allowRetryAfterRace           bool
 		failfastEnabled               func() bool
 		nativeFailfastObserved        func() bool
 		postRetryFamilyTransition     func(*testExecutionMetadata)

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -692,17 +692,16 @@ func applyAdditionalFeaturesToTestFunc(
 
 	switch selection.path {
 	case additionalFeaturePathNone:
-		return observeProcessRetryNativeFailure(f, identity, wrapperOpts)
+		return f
 	case additionalFeaturePathMetadataOnly:
-		return observeProcessRetryNativeFailure(wrapWithAdditionalFeatureMetadata(f, ptrMeta, needsMetadataOnly, false), identity, wrapperOpts)
+		return wrapWithAdditionalFeatureMetadata(f, ptrMeta, needsMetadataOnly, false)
 	case additionalFeaturePathDisabledFast:
-		return observeProcessRetryNativeFailure(wrapWithAdditionalFeatureMetadata(f, ptrMeta, false, true), identity, wrapperOpts)
+		return wrapWithAdditionalFeatureMetadata(f, ptrMeta, false, true)
 	}
 
 	// Create a unified wrapper that will use a single runTestWithRetry call.
 	wrapper := func(t *testing.T) {
 		t.Helper()
-		defer observeProcessRetryNativeTerminal(t, identity, wrapperOpts)
 		originalExecMeta := getTestMetadata(t)
 
 		var outcomes retryOutcomeAccumulator
@@ -931,34 +930,6 @@ func applyAdditionalFeaturesToTestFunc(
 	// Mark the wrapper as instrumented.
 	setInstrumentationMetadata(runtime.FuncForPC(reflect.ValueOf(wrapper).Pointer()), &instrumentationMetadata{IsInternal: true})
 	return wrapper
-}
-
-func observeProcessRetryNativeFailure(f func(*testing.T), identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) func(*testing.T) {
-	if f == nil || identity == nil || len(identity.Segments) != 1 || wrapperOpts.processRetryCoordinator == nil || wrapperOpts.mRunInvocations == nil {
-		return f
-	}
-	return func(t *testing.T) {
-		defer observeProcessRetryNativeTerminal(t, identity, wrapperOpts)
-		f(t)
-	}
-}
-
-func observeProcessRetryNativeTerminal(t *testing.T, identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) {
-	panicData := recover()
-	if panicData != nil {
-		if identity != nil && len(identity.Segments) == 1 && wrapperOpts.processRetryCoordinator != nil && wrapperOpts.mRunInvocations != nil {
-			wrapperOpts.processRetryCoordinator.observeNativeFailure(wrapperOpts.mRunInvocations.Load())
-		}
-		panic(panicData)
-	}
-	recordProcessRetryNativeFailure(t, identity, wrapperOpts)
-}
-
-func recordProcessRetryNativeFailure(t *testing.T, identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) {
-	if t == nil || !t.Failed() || identity == nil || len(identity.Segments) != 1 || wrapperOpts.processRetryCoordinator == nil || wrapperOpts.mRunInvocations == nil {
-		return
-	}
-	wrapperOpts.processRetryCoordinator.observeNativeFailure(wrapperOpts.mRunInvocations.Load())
 }
 
 // runTestWithRetry encapsulates the common retry logic for test functions.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -656,9 +656,9 @@ func applyAdditionalFeaturesToTestFunc(
 		// Record whether the test is new so we can surface it in spans later.
 		isKnown, hasKnownData := isKnownTest(testInfo)
 		meta.isNew = hasKnownData && !isKnown
-		if !meta.isNew && settings.ImpactedTestsEnabled {
-			meta.isModified = integrations.IsTestFuncModified(testInfo.testName, testInfo.sourceFunc)
-		}
+	}
+	if !meta.isNew && settings.ImpactedTestsEnabled {
+		meta.isModified = integrations.IsTestFuncModified(testInfo.testName, testInfo.sourceFunc)
 	}
 
 	var flakyRetryCount int64

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -692,16 +692,17 @@ func applyAdditionalFeaturesToTestFunc(
 
 	switch selection.path {
 	case additionalFeaturePathNone:
-		return f
+		return observeProcessRetryNativeFailure(f, identity, wrapperOpts)
 	case additionalFeaturePathMetadataOnly:
-		return wrapWithAdditionalFeatureMetadata(f, ptrMeta, needsMetadataOnly, false)
+		return observeProcessRetryNativeFailure(wrapWithAdditionalFeatureMetadata(f, ptrMeta, needsMetadataOnly, false), identity, wrapperOpts)
 	case additionalFeaturePathDisabledFast:
-		return wrapWithAdditionalFeatureMetadata(f, ptrMeta, false, true)
+		return observeProcessRetryNativeFailure(wrapWithAdditionalFeatureMetadata(f, ptrMeta, false, true), identity, wrapperOpts)
 	}
 
 	// Create a unified wrapper that will use a single runTestWithRetry call.
 	wrapper := func(t *testing.T) {
 		t.Helper()
+		defer observeProcessRetryNativeTerminal(t, identity, wrapperOpts)
 		originalExecMeta := getTestMetadata(t)
 
 		var outcomes retryOutcomeAccumulator
@@ -930,6 +931,34 @@ func applyAdditionalFeaturesToTestFunc(
 	// Mark the wrapper as instrumented.
 	setInstrumentationMetadata(runtime.FuncForPC(reflect.ValueOf(wrapper).Pointer()), &instrumentationMetadata{IsInternal: true})
 	return wrapper
+}
+
+func observeProcessRetryNativeFailure(f func(*testing.T), identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) func(*testing.T) {
+	if f == nil || identity == nil || len(identity.Segments) != 1 || wrapperOpts.processRetryCoordinator == nil || wrapperOpts.mRunInvocations == nil {
+		return f
+	}
+	return func(t *testing.T) {
+		defer observeProcessRetryNativeTerminal(t, identity, wrapperOpts)
+		f(t)
+	}
+}
+
+func observeProcessRetryNativeTerminal(t *testing.T, identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) {
+	panicData := recover()
+	if panicData != nil {
+		if identity != nil && len(identity.Segments) == 1 && wrapperOpts.processRetryCoordinator != nil && wrapperOpts.mRunInvocations != nil {
+			wrapperOpts.processRetryCoordinator.observeNativeFailure(wrapperOpts.mRunInvocations.Load())
+		}
+		panic(panicData)
+	}
+	recordProcessRetryNativeFailure(t, identity, wrapperOpts)
+}
+
+func recordProcessRetryNativeFailure(t *testing.T, identity *testIdentity, wrapperOpts additionalFeatureWrapperOptions) {
+	if t == nil || !t.Failed() || identity == nil || len(identity.Segments) != 1 || wrapperOpts.processRetryCoordinator == nil || wrapperOpts.mRunInvocations == nil {
+		return
+	}
+	wrapperOpts.processRetryCoordinator.observeNativeFailure(wrapperOpts.mRunInvocations.Load())
 }
 
 // runTestWithRetry encapsulates the common retry logic for test functions.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -41,6 +41,7 @@ type (
 		processRetrySkipReason       atomic.Pointer[string]
 		processRetryPanic            atomic.Pointer[processRetryErrorInfo]
 		processRetryOwner            *testExecutionMetadata
+		freshRetryAttemptTest        *testing.T
 		isARetry                     bool // flag to tag if a current test execution is a retry
 		isANewTest                   bool // flag to tag if a current test a new test
 		isAModifiedTest              bool // flag to tag if a current test a modified test
@@ -102,6 +103,7 @@ type (
 		retryAttemptObserveOutput     bool
 		retryAttemptObserveOutputSet  bool
 		retryAttemptMaskingFallback   bool
+		allowProcessRetryChildRetries bool
 		failfastEnabled               func() bool
 		nativeFailfastObserved        func() bool
 		postRetryFamilyTransition     func(*testExecutionMetadata)
@@ -991,7 +993,7 @@ func runTestWithRetry(options *runTestWithRetryOptions) {
 	if execOpts.deferredQueued {
 		return
 	}
-	if shouldRetry && !isProcessRetryChild() {
+	if shouldRetry && (!isProcessRetryChild() || options.allowProcessRetryChildRetries) {
 		calculatedRetryCount := execOpts.retryCount
 		remainingAttempts := calculatedRetryCount + 1
 		runSequentialRetries := func() {

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -95,6 +95,7 @@ type (
 		processRetryFuzzGuard         *processRetryFuzzGuardSnapshot
 		processRetryLaunchTemplate    *processRetryLaunchBaseline
 		processRetryCoordinator       *processRetryCoordinator
+		quarantinedRaceNativeOrder    bool
 		efdFaultySessionGuard         earlyFlakeDetectionFaultySession
 		retryAttemptGroupFactory      func(*testing.T) (*retryAttemptGroup, string)
 		retryAttemptObserveOutput     bool
@@ -134,6 +135,7 @@ type (
 		efdFaultySessionGuard      earlyFlakeDetectionFaultySession
 		retryAttemptObserveOutput  bool
 		quarantinedRaceIsolation   bool
+		quarantinedRaceNativeOrder bool
 	}
 
 	// executionOptions holds the execution options for the test
@@ -698,6 +700,15 @@ func applyAdditionalFeaturesToTestFunc(
 	case additionalFeaturePathDisabledFast:
 		return wrapWithAdditionalFeatureMetadata(f, ptrMeta, false, true)
 	}
+	if wrapperOpts.quarantinedRaceNativeOrder && ptrMeta.isQuarantined && !isSubtest && wrapperOpts.processRetryCoordinator != nil {
+		execMeta := &testExecutionMetadata{}
+		applyAdditionalFeatureMetadataToExecution(execMeta, ptrMeta)
+		info := &testingTInfo{commonInfo: *testInfo}
+		itrDecision := currentITRState().decisionFor(info, execMeta, integrations.IsTestFuncUnskippable(testInfo.sourceFunc))
+		if !itrDecision.skip {
+			wrapperOpts.processRetryCoordinator.registerNativeScheduledTest(*identity)
+		}
+	}
 
 	// Create a unified wrapper that will use a single runTestWithRetry call.
 	wrapper := func(t *testing.T) {
@@ -716,6 +727,7 @@ func applyAdditionalFeaturesToTestFunc(
 			processRetryInvocationCounter: wrapperOpts.mRunInvocations,
 			processRetryLaunchTemplate:    wrapperOpts.processRetryLaunchTemplate,
 			processRetryCoordinator:       wrapperOpts.processRetryCoordinator,
+			quarantinedRaceNativeOrder:    wrapperOpts.quarantinedRaceNativeOrder,
 			efdFaultySessionGuard:         wrapperOpts.efdFaultySessionGuard,
 			processRetryFuzzGuard:         wrapperOpts.processRetryFuzzGuard,
 			retryAttemptObserveOutput:     wrapperOpts.retryAttemptObserveOutput,

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -68,7 +68,7 @@ func instrumentCaptureFormattedSkip(tb testing.TB, skipType, reason string) stri
 		reason = strings.TrimSuffix(reason, "\n")
 	}
 	if isProcessRetryChild() {
-		if execMeta := getTestMetadata(tb); execMeta != nil && processRetryChildOwnerMetadata(execMeta) == execMeta {
+		if execMeta := getTestMetadata(tb); execMeta != nil {
 			execMeta.processRetrySkipReason.CompareAndSwap(nil, &reason)
 		}
 		return formatted

--- a/internal/civisibility/integrations/gotesting/itr_state.go
+++ b/internal/civisibility/integrations/gotesting/itr_state.go
@@ -179,26 +179,23 @@ func (s *itrState) decisionFor(testInfo *testingTInfo, execMeta *testExecutionMe
 	}
 
 	candidates := s.skippableCandidates(testInfo)
-	if len(candidates) == 0 {
+	missingLineCoverage := false
+	for _, candidate := range candidates {
+		missingLineCoverage = missingLineCoverage || candidate.MissingLineCodeCoverage
+	}
+	return decideITRSkip(s.testsSkippingEnabled() && len(candidates) > 0, missingLineCoverage, s.coverageActive, execMeta, isUnskippable)
+}
+
+func decideITRSkip(candidate, missingLineCoverage, coverageActive bool, execMeta *testExecutionMetadata, isUnskippable bool) itrSkipDecision {
+	if !candidate || execMeta == nil || execMeta.isAttemptToFix || execMeta.isAModifiedTest {
 		return itrSkipDecision{}
 	}
-
-	if !s.testsSkippingEnabled() || execMeta.isAttemptToFix || execMeta.isAModifiedTest {
-		return itrSkipDecision{}
-	}
-
 	if isUnskippable {
 		return itrSkipDecision{forcedRun: true}
 	}
-
-	if s.coverageActive {
-		for _, candidate := range candidates {
-			if candidate.MissingLineCodeCoverage {
-				return itrSkipDecision{}
-			}
-		}
+	if coverageActive && missingLineCoverage {
+		return itrSkipDecision{}
 	}
-
 	return itrSkipDecision{skip: true}
 }
 

--- a/internal/civisibility/integrations/gotesting/itr_state_test.go
+++ b/internal/civisibility/integrations/gotesting/itr_state_test.go
@@ -131,6 +131,36 @@ func exerciseNarrowingFlagParsing(t *testing.T) {
 	}
 }
 
+func TestProcessRetryITRDecisionPreservesNormalPrecedence(t *testing.T) {
+	tests := []struct {
+		name                string
+		candidate           bool
+		missingLineCoverage bool
+		coverageActive      bool
+		modified            bool
+		attemptToFix        bool
+		unskippable         bool
+		want                itrSkipDecision
+	}{
+		{name: "skippable", candidate: true, want: itrSkipDecision{skip: true}},
+		{name: "forced run", candidate: true, unskippable: true, want: itrSkipDecision{forcedRun: true}},
+		{name: "modified", candidate: true, modified: true},
+		{name: "attempt to fix", candidate: true, attemptToFix: true},
+		{name: "missing coverage", candidate: true, missingLineCoverage: true, coverageActive: true},
+		{name: "coverage disabled", candidate: true, missingLineCoverage: true, want: itrSkipDecision{skip: true}},
+		{name: "not a candidate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := &testExecutionMetadata{isAModifiedTest: tt.modified, isAttemptToFix: tt.attemptToFix}
+			got := decideITRSkip(tt.candidate, tt.missingLineCoverage, tt.coverageActive, metadata, tt.unskippable)
+			if got != tt.want {
+				t.Fatalf("decision = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 func newExerciseITRState() *itrState {
 	return &itrState{
 		settings:              &net.SettingsResponseData{ItrEnabled: true, TestsSkipping: true},

--- a/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
@@ -1,0 +1,26 @@
+//go:build !race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import "testing"
+
+const quarantinedRacePIDDirEnv = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+
+func quarantinedRaceScenarioAvailable() bool { return false }
+
+func unquarantinedRaceFixtureSelected() bool { return false }
+
+func quarantinedRaceInProcessFixtureSelected() bool { return false }
+
+func runQuarantinedRaceTests(*testing.M, string) {
+	panic("quarantined race scenario requires a race-enabled test binary")
+}
+
+func runUnquarantinedRaceFixture(*testing.M) {
+	panic("unquarantined race scenario requires a race-enabled test binary")
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
@@ -11,6 +11,7 @@ import "testing"
 
 const (
 	quarantinedRacePIDDirEnv            = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+	quarantinedRaceStateDirEnv          = "DD_TEST_QUARANTINED_RACE_STATE_DIR"
 	quarantinedRaceCustomTestMainEnv    = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
 	quarantinedRaceCustomTestMainPIDEnv = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
 )

--- a/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_norace_test.go
@@ -9,7 +9,11 @@ package gotesting
 
 import "testing"
 
-const quarantinedRacePIDDirEnv = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+const (
+	quarantinedRacePIDDirEnv            = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+	quarantinedRaceCustomTestMainEnv    = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
+	quarantinedRaceCustomTestMainPIDEnv = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
+)
 
 func quarantinedRaceScenarioAvailable() bool { return false }
 
@@ -17,10 +21,16 @@ func unquarantinedRaceFixtureSelected() bool { return false }
 
 func quarantinedRaceInProcessFixtureSelected() bool { return false }
 
+func acquireQuarantinedRaceCustomTestMainResource() func() { return func() {} }
+
 func runQuarantinedRaceTests(*testing.M, string) {
 	panic("quarantined race scenario requires a race-enabled test binary")
 }
 
 func runUnquarantinedRaceFixture(*testing.M) {
 	panic("unquarantined race scenario requires a race-enabled test binary")
+}
+
+func runQuarantinedRaceCustomTestMainTests(*testing.M) {
+	panic("quarantined race custom TestMain scenario requires a race-enabled test binary")
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -81,6 +81,9 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 	}
 
 	exitCode := RunM(m)
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" && mockCoverageRequests.Load() == 0 {
+		panic("expected quarantined process retries to upload test coverage")
+	}
 	if isolated && exitCode != 0 {
 		panic("expected a quarantined race not to affect the test run exit code; got " + strconv.Itoa(exitCode))
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -38,7 +38,10 @@ const (
 	quarantinedRaceCustomTestMainPIDEnv     = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
 )
 
-var quarantinedRaceSecondFinished = make(chan struct{}, 1)
+var (
+	quarantinedRaceSecondReady = make(chan struct{})
+	quarantinedRaceFinished    = make(chan struct{})
+)
 
 func unquarantinedRaceFixtureSelected() bool {
 	return os.Getenv(unquarantinedRaceFixtureEnv) == "true"
@@ -76,6 +79,11 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 									},
 								},
 								"TestQuarantinedRaceSecond": {
+									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
+										Quarantined: true,
+									},
+								},
+								"TestQuarantinedSerialOrderProducer": {
 									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
 										Quarantined: true,
 									},
@@ -133,9 +141,10 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		panic(fmt.Sprintf("expected one parent-owned test module, got %d", spanTypeCounts[constants.SpanTypeTestModule]))
 	}
 	resources := map[string]string{
-		"TestQuarantinedRace":       "quarantine_race_test.go.TestQuarantinedRace",
-		"TestQuarantinedRaceSecond": "quarantine_race_test.go.TestQuarantinedRaceSecond",
-		"Test_Foo":                  "testing_test.go.Test_Foo",
+		"TestQuarantinedRace":                "quarantine_race_test.go.TestQuarantinedRace",
+		"TestQuarantinedRaceSecond":          "quarantine_race_test.go.TestQuarantinedRaceSecond",
+		"TestQuarantinedSerialOrderProducer": "quarantine_race_test.go.TestQuarantinedSerialOrderProducer",
+		"Test_Foo":                           "testing_test.go.Test_Foo",
 	}
 	for testName, resource := range resources {
 		spans := checkSpansByResourceName(finishedSpans, resource, 1)
@@ -149,7 +158,7 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			failedSpans++
 		}
 		wantStatus := any(constants.TestStatusPass)
-		if testName == "TestQuarantinedRace" {
+		if testName == "TestQuarantinedRace" || testName == "TestQuarantinedRaceSecond" && os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
 			wantStatus = constants.TestStatusFail
 		}
 		if status != wantStatus {
@@ -169,9 +178,15 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			panic("quarantined race tests did not share one batch child")
 		}
 	}
-	if failedSpans != 1 {
-		panic(fmt.Sprintf("expected exactly one quarantined batch race failure, got %d", failedSpans))
+	wantFailedSpans := 2
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
+		wantFailedSpans = 1
 	}
+	if failedSpans != wantFailedSpans {
+		panic(fmt.Sprintf("expected %d quarantined batch race failures, got %d", wantFailedSpans, failedSpans))
+	}
+	consumerSpans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go.TestQuarantinedSerialOrderConsumer", 1)
+	checkSpansByTagValue(consumerSpans, constants.TestStatus, constants.TestStatusPass, 1)
 	parentPID := strconv.Itoa(os.Getpid())
 	if isolated && childPID == parentPID {
 		panic("process mode executed quarantined race bodies in the parent")
@@ -301,10 +316,16 @@ func TestQuarantinedRace(t *testing.T) {
 	}
 	t.Parallel()
 
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
+		select {
+		case <-quarantinedRaceSecondReady:
+		case <-time.After(time.Second):
+			t.Fatal("parallel peer was not admitted")
+		}
+	}
 	runRaceFixture()
-	select {
-	case <-quarantinedRaceSecondFinished:
-	case <-time.After(250 * time.Millisecond):
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
+		close(quarantinedRaceFinished)
 	}
 	writeQuarantinedRacePID(t)
 	fmt.Fprint(os.Stdout, "quarantined race fixture completed")
@@ -315,10 +336,29 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
 	}
 	t.Parallel()
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
+		close(quarantinedRaceSecondReady)
+		<-quarantinedRaceFinished
+	}
 	writeQuarantinedRacePID(t)
-	select {
-	case quarantinedRaceSecondFinished <- struct{}{}:
-	default:
+}
+
+func TestQuarantinedSerialOrderProducer(t *testing.T) {
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping order fixture")
+	}
+	if err := os.WriteFile(filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), "serial-order"), []byte("ready"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeQuarantinedRacePID(t)
+}
+
+func TestQuarantinedSerialOrderConsumer(t *testing.T) {
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
+		return
+	}
+	if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), "serial-order")); err != nil {
+		t.Fatalf("quarantined predecessor did not run at its native position: %v", err)
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -47,11 +47,21 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		panic(err)
 	}
 	isolated := executionMode == "process"
-	server := setUpHTTPServer(false, false, false, nil, false, nil, true,
+	server := setUpHTTPServer(false, false, false, nil, true, []net.SkippableResponseDataAttributes{{
+		Suite: "testing_test.go",
+		Name:  "Test_Foo",
+	}}, true,
 		&net.TestManagementTestsResponseDataModules{
 			Modules: map[string]net.TestManagementTestsResponseDataSuites{
 				"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting": {
 					Suites: map[string]net.TestManagementTestsResponseDataTests{
+						"testing_test.go": {
+							Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+								"Test_Foo": {
+									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+								},
+							},
+						},
 						"quarantine_race_test.go": {
 							Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 								"TestQuarantinedRace": {
@@ -70,8 +80,9 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 				},
 			},
 		},
-		false, nil)
+		true, nil)
 	defer server.Close()
+	configureImpactedTestsGitDiff()
 
 	currentM = m
 	mTracer = integrations.InitializeCIVisibilityMock()
@@ -106,10 +117,18 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 	if spanTypeCounts[constants.SpanTypeTestModule] != 1 {
 		panic(fmt.Sprintf("expected one parent-owned test module, got %d", spanTypeCounts[constants.SpanTypeTestModule]))
 	}
-	for _, testName := range []string{"TestQuarantinedRace", "TestQuarantinedRaceSecond"} {
-		spans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go."+testName, 1)
+	resources := map[string]string{
+		"TestQuarantinedRace":       "quarantine_race_test.go.TestQuarantinedRace",
+		"TestQuarantinedRaceSecond": "quarantine_race_test.go.TestQuarantinedRaceSecond",
+		"Test_Foo":                  "testing_test.go.Test_Foo",
+	}
+	for testName, resource := range resources {
+		spans := checkSpansByResourceName(finishedSpans, resource, 1)
 		checkSpansByTagValue(spans, constants.TestIsQuarantined, "true", 1)
 		checkSpansByTagValue(spans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		if testName == "Test_Foo" {
+			checkSpansByTagValue(spans, constants.TestIsModified, "true", 1)
+		}
 		if spans[0].Tag(constants.TestStatus) == constants.TestStatusFail {
 			failedSpans++
 		}
@@ -216,17 +235,6 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	}
 	t.Parallel()
 	writeQuarantinedRacePID(t)
-}
-
-func writeQuarantinedRacePID(t *testing.T) {
-	t.Helper()
-	dir := os.Getenv(quarantinedRacePIDDirEnv)
-	if dir == "" {
-		t.Fatal("missing quarantined race PID directory")
-	}
-	if err := os.WriteFile(filepath.Join(dir, t.Name()), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestUnquarantinedRace(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -354,9 +354,6 @@ func TestQuarantinedSerialOrderProducer(t *testing.T) {
 }
 
 func TestQuarantinedSerialOrderConsumer(t *testing.T) {
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
-		return
-	}
 	if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), "serial-order")); err != nil {
 		t.Fatalf("quarantined predecessor did not run at its native position: %v", err)
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -127,8 +127,8 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			panic("quarantined race tests did not share one batch child")
 		}
 	}
-	if failedSpans == 0 {
-		panic("expected the quarantined batch to report at least one race failure")
+	if failedSpans != 1 {
+		panic(fmt.Sprintf("expected exactly one quarantined batch race failure, got %d", failedSpans))
 	}
 	parentPID := strconv.Itoa(os.Getpid())
 	if isolated && childPID == parentPID {
@@ -214,7 +214,7 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
 		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
 	}
-	runRaceFixture()
+	t.Parallel()
 	writeQuarantinedRacePID(t)
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -36,6 +36,8 @@ const (
 	quarantinedRacePIDDirEnv                = "DD_TEST_QUARANTINED_RACE_PID_DIR"
 	quarantinedRaceStateDirEnv              = "DD_TEST_QUARANTINED_RACE_STATE_DIR"
 	quarantinedRaceMutableEnv               = "DD_TEST_QUARANTINED_RACE_MUTABLE"
+	quarantinedRaceParallelStartedFile      = "parallel-started"
+	quarantinedRaceParentEnumeratedFile     = "parent-enumerated"
 	quarantinedRaceCustomTestMainEnv        = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
 	quarantinedRaceCustomTestMainPIDEnv     = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
 )
@@ -58,6 +60,28 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		panic(err)
 	}
 	isolated := executionMode == "process"
+	cleanupPanicScenario := os.Getenv("TestQuarantinedCleanupPanic") == "true"
+	quarantinedTests := map[string]net.TestManagementTestsResponseDataTestProperties{
+		"TestQuarantinedRace": {
+			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+		},
+		"TestQuarantinedRaceSecond": {
+			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+		},
+		"TestQuarantinedSerialOrderProducer": {
+			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+		},
+	}
+	if cleanupPanicScenario {
+		quarantinedTests = map[string]net.TestManagementTestsResponseDataTestProperties{
+			"TestQuarantinedCleanupPanic": {
+				Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+			},
+			"TestQuarantinedAfterCleanupPanic": {
+				Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+			},
+		}
+	}
 	server := setUpHTTPServer(false, false, false, nil, true, []net.SkippableResponseDataAttributes{{
 		Suite: "testing_test.go",
 		Name:  "Test_Foo",
@@ -74,23 +98,7 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 							},
 						},
 						"quarantine_race_test.go": {
-							Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
-								"TestQuarantinedRace": {
-									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
-										Quarantined: true,
-									},
-								},
-								"TestQuarantinedRaceSecond": {
-									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
-										Quarantined: true,
-									},
-								},
-								"TestQuarantinedSerialOrderProducer": {
-									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
-										Quarantined: true,
-									},
-								},
-							},
+							Tests: quarantinedTests,
 						},
 					},
 				},
@@ -127,7 +135,8 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		panic("expected in-process race accounting to preserve the native failing exit code")
 	}
 
-	var childPID string
+	var childPID, fallbackChildPID string
+	coverageEnabled := os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true"
 	failedSpans := 0
 	finishedSpans := mTracer.FinishedSpans()
 	spanTypeCounts := map[string]int{}
@@ -148,6 +157,12 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		"TestQuarantinedSerialOrderProducer": "quarantine_race_test.go.TestQuarantinedSerialOrderProducer",
 		"Test_Foo":                           "testing_test.go.Test_Foo",
 	}
+	if cleanupPanicScenario {
+		resources = map[string]string{
+			"TestQuarantinedCleanupPanic":      "quarantine_race_test.go.TestQuarantinedCleanupPanic",
+			"TestQuarantinedAfterCleanupPanic": "quarantine_race_test.go.TestQuarantinedAfterCleanupPanic",
+		}
+	}
 	for testName, resource := range resources {
 		spans := checkSpansByResourceName(finishedSpans, resource, 1)
 		checkSpansByTagValue(spans, constants.TestIsQuarantined, "true", 1)
@@ -160,7 +175,8 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			failedSpans++
 		}
 		wantStatus := any(constants.TestStatusPass)
-		if testName == "TestQuarantinedRace" || testName == "TestQuarantinedRaceSecond" && os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
+		if testName == "TestQuarantinedRace" || testName == "TestQuarantinedCleanupPanic" ||
+			testName == "TestQuarantinedRaceSecond" && !coverageEnabled {
 			wantStatus = constants.TestStatusFail
 		}
 		if status != wantStatus {
@@ -174,24 +190,36 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		if pid == "" {
 			panic("missing quarantined race child PID")
 		}
-		if childPID == "" {
+		fallback := cleanupPanicScenario && testName == "TestQuarantinedAfterCleanupPanic"
+		if isolated && fallback {
+			if fallbackChildPID == "" {
+				fallbackChildPID = pid
+			} else if fallbackChildPID != pid {
+				panic("missing quarantined tests did not share one replacement batch child")
+			}
+		} else if childPID == "" {
 			childPID = pid
 		} else if childPID != pid {
 			panic("quarantined race tests did not share one batch child")
 		}
 	}
-	wantFailedSpans := 2
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
-		wantFailedSpans = 1
+	wantFailedSpans := 1
+	if !cleanupPanicScenario && !coverageEnabled {
+		wantFailedSpans = 2
 	}
 	if failedSpans != wantFailedSpans {
 		panic(fmt.Sprintf("expected %d quarantined batch race failures, got %d", wantFailedSpans, failedSpans))
 	}
-	consumerSpans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go.TestQuarantinedSerialOrderConsumer", 1)
-	checkSpansByTagValue(consumerSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	if !cleanupPanicScenario {
+		consumerSpans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go.TestQuarantinedSerialOrderConsumer", 1)
+		checkSpansByTagValue(consumerSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	}
 	parentPID := strconv.Itoa(os.Getpid())
 	if isolated && childPID == parentPID {
 		panic("process mode executed quarantined race bodies in the parent")
+	}
+	if cleanupPanicScenario && (fallbackChildPID == "" || fallbackChildPID == childPID || fallbackChildPID == parentPID) {
+		panic("test after cleanup panic did not run in a fresh batch child")
 	}
 	if !isolated && childPID != parentPID {
 		panic("in-process mode unexpectedly executed quarantined race bodies in a child")
@@ -341,6 +369,22 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	requireQuarantinedInvocationState(t, "second")
 	t.Parallel()
 	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
+		pidDir := os.Getenv(quarantinedRacePIDDirEnv)
+		if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceParallelStartedFile), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		deadline := time.Now().Add(time.Second)
+		for {
+			if _, err := os.Stat(filepath.Join(pidDir, quarantinedRaceParentEnumeratedFile)); err == nil {
+				break
+			} else if !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			if !time.Now().Before(deadline) {
+				t.Fatal("parallel child started before the parent completed serial enumeration")
+			}
+			time.Sleep(time.Millisecond)
+		}
 		close(quarantinedRaceSecondReady)
 		<-quarantinedRaceFinished
 	}
@@ -402,9 +446,53 @@ func requireQuarantinedInvocationState(t *testing.T, state string) {
 }
 
 func TestQuarantinedSerialOrderConsumer(t *testing.T) {
-	if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), "serial-order")); err != nil {
+	pidDir := os.Getenv(quarantinedRacePIDDirEnv)
+	if _, err := os.Stat(filepath.Join(pidDir, "serial-order")); err != nil {
 		t.Fatalf("quarantined predecessor did not run at its native position: %v", err)
 	}
+	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
+		return
+	}
+	parallelPath := filepath.Join(pidDir, quarantinedRaceParallelStartedFile)
+	parallelErr := os.ErrNotExist
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_, parallelErr = os.Stat(parallelPath)
+		if parallelErr == nil || !os.IsNotExist(parallelErr) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceParentEnumeratedFile), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if parallelErr == nil {
+		t.Fatal("isolated parallel body started before the parent completed serial enumeration")
+	}
+	if !os.IsNotExist(parallelErr) {
+		t.Fatal(parallelErr)
+	}
+}
+
+func TestQuarantinedCleanupPanic(t *testing.T) {
+	if os.Getenv("TestQuarantinedCleanupPanic") != "true" {
+		t.Skip("cleanup panic regression only applies to process retries")
+	}
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping cleanup panic")
+	}
+	writeQuarantinedRacePID(t)
+	t.Cleanup(func() { panic("quarantined cleanup panic") })
+}
+
+func TestQuarantinedAfterCleanupPanic(t *testing.T) {
+	if os.Getenv("TestQuarantinedCleanupPanic") != "true" {
+		t.Skip("cleanup panic regression only applies to process retries")
+	}
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping post-panic fixture")
+	}
+	writeQuarantinedRacePID(t)
 }
 
 func TestQuarantinedRaceCustomTestMain(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -1,0 +1,251 @@
+//go:build race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+)
+
+func quarantinedRaceScenarioAvailable() bool { return true }
+
+const (
+	unquarantinedRaceFixtureEnv             = "DD_TEST_UNQUARANTINED_RACE_FIXTURE"
+	unquarantinedRaceFailureSentinel        = "unquarantined race preserved test failure"
+	quarantinedRaceInProcessFixtureEnv      = "DD_TEST_QUARANTINED_RACE_IN_PROCESS_FIXTURE"
+	quarantinedRaceInProcessFailureSentinel = "quarantined race remained in the parent"
+	quarantinedRacePIDDirEnv                = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+)
+
+func unquarantinedRaceFixtureSelected() bool {
+	return os.Getenv(unquarantinedRaceFixtureEnv) == "true"
+}
+
+func quarantinedRaceInProcessFixtureSelected() bool {
+	return os.Getenv(quarantinedRaceInProcessFixtureEnv) == "true"
+}
+
+func runQuarantinedRaceTests(m *testing.M, executionMode string) {
+	if err := os.Setenv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, executionMode); err != nil {
+		panic(err)
+	}
+	isolated := executionMode == "process"
+	server := setUpHTTPServer(false, false, false, nil, false, nil, true,
+		&net.TestManagementTestsResponseDataModules{
+			Modules: map[string]net.TestManagementTestsResponseDataSuites{
+				"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting": {
+					Suites: map[string]net.TestManagementTestsResponseDataTests{
+						"quarantine_race_test.go": {
+							Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+								"TestQuarantinedRace": {
+									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
+										Quarantined: true,
+									},
+								},
+								"TestQuarantinedRaceSecond": {
+									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
+										Quarantined: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		false, nil)
+	defer server.Close()
+
+	currentM = m
+	mTracer = integrations.InitializeCIVisibilityMock()
+	pidDir := os.Getenv(quarantinedRacePIDDirEnv)
+	if pidDir == "" {
+		panic("missing quarantined race PID directory")
+	}
+
+	exitCode := RunM(m)
+	if isolated && exitCode != 0 {
+		panic("expected a quarantined race not to affect the test run exit code; got " + strconv.Itoa(exitCode))
+	}
+	if !isolated && exitCode == 0 {
+		panic("expected in-process race accounting to preserve the native failing exit code")
+	}
+
+	var childPID string
+	failedSpans := 0
+	finishedSpans := mTracer.FinishedSpans()
+	spanTypeCounts := map[string]int{}
+	for _, span := range finishedSpans {
+		if spanType, ok := span.Tag(ext.SpanType).(string); ok {
+			spanTypeCounts[spanType]++
+		}
+	}
+	if spanTypeCounts[constants.SpanTypeTestSession] != 1 {
+		panic(fmt.Sprintf("expected one parent-owned test session, got %d", spanTypeCounts[constants.SpanTypeTestSession]))
+	}
+	if spanTypeCounts[constants.SpanTypeTestModule] != 1 {
+		panic(fmt.Sprintf("expected one parent-owned test module, got %d", spanTypeCounts[constants.SpanTypeTestModule]))
+	}
+	for _, testName := range []string{"TestQuarantinedRace", "TestQuarantinedRaceSecond"} {
+		spans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go."+testName, 1)
+		checkSpansByTagValue(spans, constants.TestIsQuarantined, "true", 1)
+		checkSpansByTagValue(spans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		if spans[0].Tag(constants.TestStatus) == constants.TestStatusFail {
+			failedSpans++
+		}
+		payload, readErr := os.ReadFile(filepath.Join(pidDir, testName))
+		if readErr != nil {
+			panic(readErr)
+		}
+		pid := strings.TrimSpace(string(payload))
+		if pid == "" {
+			panic("missing quarantined race child PID")
+		}
+		if childPID == "" {
+			childPID = pid
+		} else if childPID != pid {
+			panic("quarantined race tests did not share one batch child")
+		}
+	}
+	if failedSpans == 0 {
+		panic("expected the quarantined batch to report at least one race failure")
+	}
+	parentPID := strconv.Itoa(os.Getpid())
+	if isolated && childPID == parentPID {
+		panic("process mode executed quarantined race bodies in the parent")
+	}
+	if !isolated && childPID != parentPID {
+		panic("in-process mode unexpectedly executed quarantined race bodies in a child")
+	}
+	if !isolated {
+		fmt.Fprint(os.Stdout, quarantinedRaceInProcessFailureSentinel)
+	}
+	os.Exit(exitCode)
+}
+
+func runUnquarantinedRaceFixture(m *testing.M) {
+	server := setUpHTTPServer(true, false, false, nil, false, nil, true,
+		&net.TestManagementTestsResponseDataModules{}, false, nil)
+	defer server.Close()
+
+	currentM = m
+	mTracer = integrations.InitializeCIVisibilityMock()
+	exitCode := RunM(m)
+	if exitCode == 0 {
+		panic("expected an unquarantined race to fail the test run")
+	}
+	fmt.Fprint(os.Stdout, unquarantinedRaceFailureSentinel)
+	os.Exit(exitCode)
+}
+
+func TestUnquarantinedRaceRemainsFailure(t *testing.T) {
+	runFailingRaceFixture(t, "^TestUnquarantinedRace$", unquarantinedRaceFailureSentinel,
+		unquarantinedRaceFixtureEnv+"=true")
+}
+
+func TestProcessModeOptInLeavesQuarantinedRaceInProcess(t *testing.T) {
+	pidDir := t.TempDir()
+	runFailingRaceFixture(t, "^TestQuarantinedRace", quarantinedRaceInProcessFailureSentinel,
+		quarantinedRaceInProcessFixtureEnv+"=true",
+		quarantinedRacePIDDirEnv+"="+pidDir)
+}
+
+func runFailingRaceFixture(t *testing.T, runFilter, sentinel string, environment ...string) {
+	t.Helper()
+	overrides := make(map[string]struct{}, len(environment))
+	for _, entry := range environment {
+		key, _, _ := strings.Cut(entry, "=")
+		overrides[key] = struct{}{}
+	}
+	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(os.Args[1:], runFilter)...)
+	cmd.Env = make([]string, 0, len(os.Environ())+len(environment))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, overridden := overrides[key]; !overridden {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, environment...)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() == 0 {
+		t.Fatalf("expected race subprocess to fail; err=%v\n%s", err, output.String())
+	}
+	if !strings.Contains(output.String(), sentinel) {
+		t.Fatalf("race subprocess did not emit %q\n%s", sentinel, output.String())
+	}
+}
+
+func TestQuarantinedRace(t *testing.T) {
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
+	}
+	t.Parallel()
+
+	runRaceFixture()
+	writeQuarantinedRacePID(t)
+	fmt.Fprint(os.Stdout, "quarantined race fixture completed")
+}
+
+func TestQuarantinedRaceSecond(t *testing.T) {
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
+	}
+	runRaceFixture()
+	writeQuarantinedRacePID(t)
+}
+
+func writeQuarantinedRacePID(t *testing.T) {
+	t.Helper()
+	dir := os.Getenv(quarantinedRacePIDDirEnv)
+	if dir == "" {
+		t.Fatal("missing quarantined race PID directory")
+	}
+	if err := os.WriteFile(filepath.Join(dir, t.Name()), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnquarantinedRace(t *testing.T) {
+	if execMeta := getTestMetadata(t); execMeta == nil || !execMeta.hasAdditionalFeatureWrapper {
+		t.Skip("no CI Visibility wrapper active; skipping race injection")
+	}
+	runRaceFixture()
+}
+
+func runRaceFixture() {
+	var value int
+	start := make(chan struct{})
+	done := make(chan struct{}, 2)
+	write := func(next int) {
+		<-start
+		value = next
+		done <- struct{}{}
+	}
+	go write(1)
+	go write(2)
+	close(start)
+	<-done
+	<-done
+	runtime.KeepAlive(value)
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -34,6 +34,8 @@ const (
 	quarantinedRaceInProcessFixtureEnv      = "DD_TEST_QUARANTINED_RACE_IN_PROCESS_FIXTURE"
 	quarantinedRaceInProcessFailureSentinel = "quarantined race remained in the parent"
 	quarantinedRacePIDDirEnv                = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+	quarantinedRaceStateDirEnv              = "DD_TEST_QUARANTINED_RACE_STATE_DIR"
+	quarantinedRaceMutableEnv               = "DD_TEST_QUARANTINED_RACE_MUTABLE"
 	quarantinedRaceCustomTestMainEnv        = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
 	quarantinedRaceCustomTestMainPIDEnv     = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
 )
@@ -314,6 +316,7 @@ func TestQuarantinedRace(t *testing.T) {
 	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
 		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
 	}
+	requireQuarantinedInvocationState(t, "first")
 	t.Parallel()
 
 	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
@@ -335,6 +338,7 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
 		t.Skip("no CI Visibility quarantine wrapper active; skipping race injection")
 	}
+	requireQuarantinedInvocationState(t, "second")
 	t.Parallel()
 	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
 		close(quarantinedRaceSecondReady)
@@ -351,6 +355,50 @@ func TestQuarantinedSerialOrderProducer(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeQuarantinedRacePID(t)
+}
+
+func TestQuarantinedInvocationStateMutator(t *testing.T) {
+	if os.Getenv(quarantinedRaceStateDirEnv) == "" || isProcessRetryChild() {
+		return
+	}
+	setQuarantinedInvocationState(t, "first")
+}
+
+func TestQuarantinedInvocationStateSecondMutator(t *testing.T) {
+	if os.Getenv(quarantinedRaceStateDirEnv) == "" || isProcessRetryChild() {
+		return
+	}
+	setQuarantinedInvocationState(t, "second")
+}
+
+func setQuarantinedInvocationState(t *testing.T, state string) {
+	t.Helper()
+	if err := os.Setenv(quarantinedRaceMutableEnv, state); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(filepath.Join(os.Getenv(quarantinedRaceStateDirEnv), state)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireQuarantinedInvocationState(t *testing.T, state string) {
+	t.Helper()
+	stateDir := os.Getenv(quarantinedRaceStateDirEnv)
+	if stateDir == "" {
+		return
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantWorkingDirectory := filepath.Join(stateDir, state)
+	wantWorkingDirectory, err = filepath.EvalSymlinks(wantWorkingDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workingDirectory != wantWorkingDirectory || os.Getenv(quarantinedRaceMutableEnv) != state {
+		t.Fatalf("isolated invocation state = cwd %q env %q, want cwd %q env %q", workingDirectory, os.Getenv(quarantinedRaceMutableEnv), wantWorkingDirectory, state)
+	}
 }
 
 func TestQuarantinedSerialOrderConsumer(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -10,6 +10,7 @@ package gotesting
 import (
 	"bytes"
 	"fmt"
+	stdnet "net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
@@ -32,7 +34,11 @@ const (
 	quarantinedRaceInProcessFixtureEnv      = "DD_TEST_QUARANTINED_RACE_IN_PROCESS_FIXTURE"
 	quarantinedRaceInProcessFailureSentinel = "quarantined race remained in the parent"
 	quarantinedRacePIDDirEnv                = "DD_TEST_QUARANTINED_RACE_PID_DIR"
+	quarantinedRaceCustomTestMainEnv        = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
+	quarantinedRaceCustomTestMainPIDEnv     = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
 )
+
+var quarantinedRaceSecondFinished = make(chan struct{}, 1)
 
 func unquarantinedRaceFixtureSelected() bool {
 	return os.Getenv(unquarantinedRaceFixtureEnv) == "true"
@@ -91,7 +97,16 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		panic("missing quarantined race PID directory")
 	}
 
-	exitCode := RunM(m)
+	var exitCode int
+	if isolated {
+		// A generated test main has no user TestMain frame. RunM in a fresh
+		// goroutine so this fixture exercises that production call stack.
+		done := make(chan int, 1)
+		go func() { done <- RunM(m) }()
+		exitCode = <-done
+	} else {
+		exitCode = RunM(m)
+	}
 	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" && mockCoverageRequests.Load() == 0 {
 		panic("expected quarantined process retries to upload test coverage")
 	}
@@ -129,8 +144,16 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		if testName == "Test_Foo" {
 			checkSpansByTagValue(spans, constants.TestIsModified, "true", 1)
 		}
-		if spans[0].Tag(constants.TestStatus) == constants.TestStatusFail {
+		status := spans[0].Tag(constants.TestStatus)
+		if status == constants.TestStatusFail {
 			failedSpans++
+		}
+		wantStatus := any(constants.TestStatusPass)
+		if testName == "TestQuarantinedRace" {
+			wantStatus = constants.TestStatusFail
+		}
+		if status != wantStatus {
+			panic(fmt.Sprintf("%s status = %v, want %v", testName, status, wantStatus))
 		}
 		payload, readErr := os.ReadFile(filepath.Join(pidDir, testName))
 		if readErr != nil {
@@ -160,6 +183,60 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		fmt.Fprint(os.Stdout, quarantinedRaceInProcessFailureSentinel)
 	}
 	os.Exit(exitCode)
+}
+
+func acquireQuarantinedRaceCustomTestMainResource() func() {
+	address := os.Getenv(quarantinedRaceCustomTestMainEnv)
+	if address == "" {
+		return func() {}
+	}
+	listener, err := stdnet.Listen("tcp", address)
+	if err != nil {
+		panic("quarantined race child re-entered active TestMain setup: " + err.Error())
+	}
+	if err := os.Setenv(quarantinedRaceCustomTestMainEnv, listener.Addr().String()); err != nil {
+		_ = listener.Close()
+		panic(err)
+	}
+	return func() { _ = listener.Close() }
+}
+
+func runQuarantinedRaceCustomTestMainTests(m *testing.M) {
+	if err := os.Setenv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process"); err != nil {
+		panic(err)
+	}
+	server := setUpHTTPServer(false, false, false, nil, true, nil, true,
+		&net.TestManagementTestsResponseDataModules{
+			Modules: map[string]net.TestManagementTestsResponseDataSuites{
+				"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting": {
+					Suites: map[string]net.TestManagementTestsResponseDataTests{
+						"quarantine_race_test.go": {
+							Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+								"TestQuarantinedRaceCustomTestMain": {
+									Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, true, nil)
+	defer server.Close()
+	configureImpactedTestsGitDiff()
+
+	currentM = m
+	mTracer = integrations.InitializeCIVisibilityMock()
+	if exitCode := RunM(m); exitCode != 0 {
+		panic("custom TestMain quarantined fixture failed with exit code " + strconv.Itoa(exitCode))
+	}
+	payload, err := os.ReadFile(os.Getenv(quarantinedRaceCustomTestMainPIDEnv))
+	if err != nil {
+		panic(err)
+	}
+	if strings.TrimSpace(string(payload)) != strconv.Itoa(os.Getpid()) {
+		panic("custom TestMain quarantined fixture did not run in the parent")
+	}
+	os.Exit(0)
 }
 
 func runUnquarantinedRaceFixture(m *testing.M) {
@@ -225,6 +302,10 @@ func TestQuarantinedRace(t *testing.T) {
 	t.Parallel()
 
 	runRaceFixture()
+	select {
+	case <-quarantinedRaceSecondFinished:
+	case <-time.After(250 * time.Millisecond):
+	}
 	writeQuarantinedRacePID(t)
 	fmt.Fprint(os.Stdout, "quarantined race fixture completed")
 }
@@ -235,6 +316,19 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	}
 	t.Parallel()
 	writeQuarantinedRacePID(t)
+	select {
+	case quarantinedRaceSecondFinished <- struct{}{}:
+	default:
+	}
+}
+
+func TestQuarantinedRaceCustomTestMain(t *testing.T) {
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active")
+	}
+	if err := os.WriteFile(os.Getenv(quarantinedRaceCustomTestMainPIDEnv), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestUnquarantinedRace(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -38,13 +38,10 @@ const (
 	quarantinedRaceMutableEnv               = "DD_TEST_QUARANTINED_RACE_MUTABLE"
 	quarantinedRaceParallelStartedFile      = "parallel-started"
 	quarantinedRaceParentEnumeratedFile     = "parent-enumerated"
+	quarantinedRaceSecondReadyFile          = "second-ready"
+	quarantinedRaceFinishedFile             = "race-finished"
 	quarantinedRaceCustomTestMainEnv        = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN"
 	quarantinedRaceCustomTestMainPIDEnv     = "DD_TEST_QUARANTINED_RACE_CUSTOM_TESTMAIN_PID"
-)
-
-var (
-	quarantinedRaceSecondReady = make(chan struct{})
-	quarantinedRaceFinished    = make(chan struct{})
 )
 
 func unquarantinedRaceFixtureSelected() bool {
@@ -69,6 +66,9 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
 		},
 		"TestQuarantinedSerialOrderProducer": {
+			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+		},
+		"TestQuarantinedSerialStateProducer": {
 			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
 		},
 	}
@@ -134,9 +134,11 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 	if !isolated && exitCode == 0 {
 		panic("expected in-process race accounting to preserve the native failing exit code")
 	}
+	if isolated && !cleanupPanicScenario && os.Getenv(quarantinedRaceMutableEnv) != "post-enumeration" {
+		panic("parallel child state leaked into the parent")
+	}
 
-	var childPID, fallbackChildPID string
-	coverageEnabled := os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true"
+	childPIDs := make(map[string]string)
 	failedSpans := 0
 	finishedSpans := mTracer.FinishedSpans()
 	spanTypeCounts := map[string]int{}
@@ -155,6 +157,7 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		"TestQuarantinedRace":                "quarantine_race_test.go.TestQuarantinedRace",
 		"TestQuarantinedRaceSecond":          "quarantine_race_test.go.TestQuarantinedRaceSecond",
 		"TestQuarantinedSerialOrderProducer": "quarantine_race_test.go.TestQuarantinedSerialOrderProducer",
+		"TestQuarantinedSerialStateProducer": "quarantine_race_test.go.TestQuarantinedSerialStateProducer",
 		"Test_Foo":                           "testing_test.go.Test_Foo",
 	}
 	if cleanupPanicScenario {
@@ -175,8 +178,7 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 			failedSpans++
 		}
 		wantStatus := any(constants.TestStatusPass)
-		if testName == "TestQuarantinedRace" || testName == "TestQuarantinedCleanupPanic" ||
-			testName == "TestQuarantinedRaceSecond" && !coverageEnabled {
+		if testName == "TestQuarantinedRace" || testName == "TestQuarantinedCleanupPanic" {
 			wantStatus = constants.TestStatusFail
 		}
 		if status != wantStatus {
@@ -190,39 +192,24 @@ func runQuarantinedRaceTests(m *testing.M, executionMode string) {
 		if pid == "" {
 			panic("missing quarantined race child PID")
 		}
-		fallback := cleanupPanicScenario && testName == "TestQuarantinedAfterCleanupPanic"
-		if isolated && fallback {
-			if fallbackChildPID == "" {
-				fallbackChildPID = pid
-			} else if fallbackChildPID != pid {
-				panic("missing quarantined tests did not share one replacement batch child")
+		if isolated {
+			if pid == strconv.Itoa(os.Getpid()) {
+				panic("process mode executed quarantined race bodies in the parent")
 			}
-		} else if childPID == "" {
-			childPID = pid
-		} else if childPID != pid {
-			panic("quarantined race tests did not share one batch child")
+			if other, duplicate := childPIDs[pid]; duplicate {
+				panic(testName + " shared an isolated process with " + other)
+			}
+			childPIDs[pid] = testName
+		} else if pid != strconv.Itoa(os.Getpid()) {
+			panic("in-process mode unexpectedly executed quarantined race bodies in a child")
 		}
 	}
-	wantFailedSpans := 1
-	if !cleanupPanicScenario && !coverageEnabled {
-		wantFailedSpans = 2
-	}
-	if failedSpans != wantFailedSpans {
-		panic(fmt.Sprintf("expected %d quarantined batch race failures, got %d", wantFailedSpans, failedSpans))
+	if failedSpans != 1 {
+		panic(fmt.Sprintf("expected one quarantined race failure, got %d", failedSpans))
 	}
 	if !cleanupPanicScenario {
 		consumerSpans := checkSpansByResourceName(finishedSpans, "quarantine_race_test.go.TestQuarantinedSerialOrderConsumer", 1)
 		checkSpansByTagValue(consumerSpans, constants.TestStatus, constants.TestStatusPass, 1)
-	}
-	parentPID := strconv.Itoa(os.Getpid())
-	if isolated && childPID == parentPID {
-		panic("process mode executed quarantined race bodies in the parent")
-	}
-	if cleanupPanicScenario && (fallbackChildPID == "" || fallbackChildPID == childPID || fallbackChildPID == parentPID) {
-		panic("test after cleanup panic did not run in a fresh batch child")
-	}
-	if !isolated && childPID != parentPID {
-		panic("in-process mode unexpectedly executed quarantined race bodies in a child")
 	}
 	if !isolated {
 		fmt.Fprint(os.Stdout, quarantinedRaceInProcessFailureSentinel)
@@ -346,17 +333,10 @@ func TestQuarantinedRace(t *testing.T) {
 	}
 	requireQuarantinedInvocationState(t, "first")
 	t.Parallel()
-
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
-		select {
-		case <-quarantinedRaceSecondReady:
-		case <-time.After(time.Second):
-			t.Fatal("parallel peer was not admitted")
-		}
-	}
+	waitForQuarantinedRaceFile(t, quarantinedRaceSecondReadyFile)
 	runRaceFixture()
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
-		close(quarantinedRaceFinished)
+	if err := os.WriteFile(filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), quarantinedRaceFinishedFile), nil, 0o600); err != nil {
+		t.Fatal(err)
 	}
 	writeQuarantinedRacePID(t)
 	fmt.Fprint(os.Stdout, "quarantined race fixture completed")
@@ -368,28 +348,37 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 	}
 	requireQuarantinedInvocationState(t, "second")
 	t.Parallel()
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) != "true" {
-		pidDir := os.Getenv(quarantinedRacePIDDirEnv)
-		if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceParallelStartedFile), nil, 0o600); err != nil {
+	pidDir := os.Getenv(quarantinedRacePIDDirEnv)
+	if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceParallelStartedFile), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForQuarantinedRaceFile(t, quarantinedRaceParentEnumeratedFile)
+	requireQuarantinedInvocationState(t, "post-enumeration")
+	if err := os.Setenv(quarantinedRaceMutableEnv, "parallel-child"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceSecondReadyFile), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForQuarantinedRaceFile(t, quarantinedRaceFinishedFile)
+	writeQuarantinedRacePID(t)
+}
+
+func waitForQuarantinedRaceFile(t *testing.T, name string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv(quarantinedRacePIDDirEnv), name)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
 			t.Fatal(err)
 		}
-		deadline := time.Now().Add(time.Second)
-		for {
-			if _, err := os.Stat(filepath.Join(pidDir, quarantinedRaceParentEnumeratedFile)); err == nil {
-				break
-			} else if !os.IsNotExist(err) {
-				t.Fatal(err)
-			}
-			if !time.Now().Before(deadline) {
-				t.Fatal("parallel child started before the parent completed serial enumeration")
-			}
-			time.Sleep(time.Millisecond)
+		if !time.Now().Before(deadline) {
+			t.Fatalf("timed out waiting for %s", name)
 		}
-		requireQuarantinedInvocationState(t, "post-enumeration")
-		close(quarantinedRaceSecondReady)
-		<-quarantinedRaceFinished
+		time.Sleep(time.Millisecond)
 	}
-	writeQuarantinedRacePID(t)
 }
 
 func TestQuarantinedSerialOrderProducer(t *testing.T) {
@@ -400,6 +389,24 @@ func TestQuarantinedSerialOrderProducer(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeQuarantinedRacePID(t)
+}
+
+func TestQuarantinedSerialStateProducer(t *testing.T) {
+	if execMeta := getTestMetadata(t); !isProcessRetryChild() && (execMeta == nil || !execMeta.hasAdditionalFeatureWrapper) {
+		t.Skip("no CI Visibility quarantine wrapper active; skipping state fixture")
+	}
+	setQuarantinedInvocationState(t, "child-final")
+	writeQuarantinedRacePID(t)
+}
+
+func TestQuarantinedSerialStateConsumer(t *testing.T) {
+	if os.Getenv(quarantinedRaceStateDirEnv) == "" {
+		return
+	}
+	if isProcessRetryChild() {
+		t.Fatal("serial state consumer ran in a child")
+	}
+	requireQuarantinedInvocationState(t, "child-final")
 }
 
 func TestQuarantinedInvocationStateMutator(t *testing.T) {
@@ -450,9 +457,6 @@ func TestQuarantinedSerialOrderConsumer(t *testing.T) {
 	pidDir := os.Getenv(quarantinedRacePIDDirEnv)
 	if _, err := os.Stat(filepath.Join(pidDir, "serial-order")); err != nil {
 		t.Fatalf("quarantined predecessor did not run at its native position: %v", err)
-	}
-	if os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true" {
-		return
 	}
 	parallelPath := filepath.Join(pidDir, quarantinedRaceParallelStartedFile)
 	parallelErr := os.ErrNotExist

--- a/internal/civisibility/integrations/gotesting/quarantine_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race_test.go
@@ -385,6 +385,7 @@ func TestQuarantinedRaceSecond(t *testing.T) {
 			}
 			time.Sleep(time.Millisecond)
 		}
+		requireQuarantinedInvocationState(t, "post-enumeration")
 		close(quarantinedRaceSecondReady)
 		<-quarantinedRaceFinished
 	}
@@ -463,6 +464,7 @@ func TestQuarantinedSerialOrderConsumer(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
+	setQuarantinedInvocationState(t, "post-enumeration")
 	if err := os.WriteFile(filepath.Join(pidDir, quarantinedRaceParentEnumeratedFile), nil, 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -36,13 +36,13 @@ type retryAttemptGroup struct {
 	originalTransitioned               bool
 	originalParallelReady              chan struct{}
 	originalParallelLocked             func()
+	rootParallelAnnounce               func() error
 	rootParallelBridge                 func() error
 	matcher                            *retryAttemptMatcherTransaction
 	attempts                           []*retryAttemptRoot
 	observeOutput                      bool
 	observeNativeOutput                bool
 	outputLimit                        int64
-	raceCheckpoint                     *atomic.Int64
 	retired                            bool
 }
 
@@ -227,9 +227,6 @@ func newRetryAttemptRootInGroup(group *retryAttemptGroup) (*retryAttemptRoot, st
 	original := group.original
 
 	raceBaseline := retryAttemptRaceErrors()
-	if group.raceCheckpoint != nil {
-		raceBaseline = group.raceCheckpoint.Load()
-	}
 	originalBase := commonBaseForTest(original, layout)
 	if originalBase == nil {
 		return nil, "testing_t_layout_unsupported"

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -40,6 +40,7 @@ type retryAttemptGroup struct {
 	attempts               []*retryAttemptRoot
 	observeOutput          bool
 	observeNativeOutput    bool
+	outputLimit            int64
 	retired                bool
 }
 
@@ -73,8 +74,9 @@ type retryAttemptRoot struct {
 }
 
 type retryAttemptOutputCapture struct {
-	mu     locking.Mutex
-	output []byte
+	mu      locking.Mutex
+	output  []byte
+	bounded *processRetryBoundedOutput
 }
 
 type retryAttemptCaptureWriter struct {
@@ -83,18 +85,30 @@ type retryAttemptCaptureWriter struct {
 }
 
 func (w retryAttemptCaptureWriter) Write(p []byte) (int, error) {
-	w.capture.mu.Lock()
-	w.capture.output = append(w.capture.output, p...)
-	w.capture.mu.Unlock()
+	w.capture.write(p)
 	return w.writer.Write(p)
 }
 
-func (c *retryAttemptOutputCapture) take() []byte {
+func (c *retryAttemptOutputCapture) write(p []byte) {
+	if c.bounded != nil {
+		_, _ = c.bounded.Write(p)
+		return
+	}
+	c.mu.Lock()
+	c.output = append(c.output, p...)
+	c.mu.Unlock()
+}
+
+func (c *retryAttemptOutputCapture) take() ([]byte, bool) {
+	if c.bounded != nil {
+		tail, truncated := c.bounded.Tail()
+		return []byte(tail), truncated
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	output := c.output
 	c.output = nil
-	return output
+	return output, false
 }
 
 func newRetryAttemptGroup(original *testing.T) (*retryAttemptGroup, string) {
@@ -251,6 +265,9 @@ func newRetryAttemptRootInGroup(group *retryAttemptGroup) (*retryAttemptRoot, st
 		layout:       layout,
 		raceBaseline: raceBaseline,
 		stackCapture: debug.Stack,
+	}
+	if group.outputLimit > 0 {
+		attempt.outputCapture.bounded = newProcessRetryBoundedOutput(group.outputLimit)
 	}
 	group.mu.Lock()
 	if group.retired {

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -42,6 +42,7 @@ type retryAttemptGroup struct {
 	observeOutput                      bool
 	observeNativeOutput                bool
 	outputLimit                        int64
+	raceCheckpoint                     *atomic.Int64
 	retired                            bool
 }
 
@@ -226,6 +227,9 @@ func newRetryAttemptRootInGroup(group *retryAttemptGroup) (*retryAttemptRoot, st
 	original := group.original
 
 	raceBaseline := retryAttemptRaceErrors()
+	if group.raceCheckpoint != nil {
+		raceBaseline = group.raceCheckpoint.Load()
+	}
 	originalBase := commonBaseForTest(original, layout)
 	if originalBase == nil {
 		return nil, "testing_t_layout_unsupported"

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -25,23 +25,24 @@ import (
 )
 
 type retryAttemptGroup struct {
-	mu                     locking.Mutex
-	executionMu            locking.Mutex
-	original               *testing.T
-	layout                 *testingInternalsLayout
-	originalParentBase     unsafe.Pointer
-	originalParentBarrier  <-chan bool
-	rootParallelObserved   bool
-	originalTransitioned   bool
-	originalParallelReady  chan struct{}
-	originalParallelLocked func()
-	rootParallelBridge     func() error
-	matcher                *retryAttemptMatcherTransaction
-	attempts               []*retryAttemptRoot
-	observeOutput          bool
-	observeNativeOutput    bool
-	outputLimit            int64
-	retired                bool
+	mu                                 locking.Mutex
+	executionMu                        locking.Mutex
+	original                           *testing.T
+	layout                             *testingInternalsLayout
+	originalParentBase                 unsafe.Pointer
+	originalParentBarrier              <-chan bool
+	rootParallelObserved               bool
+	suppressOriginalParallelTransition bool
+	originalTransitioned               bool
+	originalParallelReady              chan struct{}
+	originalParallelLocked             func()
+	rootParallelBridge                 func() error
+	matcher                            *retryAttemptMatcherTransaction
+	attempts                           []*retryAttemptRoot
+	observeOutput                      bool
+	observeNativeOutput                bool
+	outputLimit                        int64
+	retired                            bool
 }
 
 type retryAttemptMatcherTransaction struct {
@@ -402,6 +403,10 @@ func (g *retryAttemptGroup) transitionOriginalToParallel() bool {
 
 	g.mu.Lock()
 	g.rootParallelObserved = true
+	if g.suppressOriginalParallelTransition {
+		g.mu.Unlock()
+		return true
+	}
 	if g.originalTransitioned {
 		ready := g.originalParallelReady
 		g.mu.Unlock()

--- a/internal/civisibility/integrations/gotesting/retry_attempt.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt.go
@@ -25,25 +25,24 @@ import (
 )
 
 type retryAttemptGroup struct {
-	mu                                 locking.Mutex
-	executionMu                        locking.Mutex
-	original                           *testing.T
-	layout                             *testingInternalsLayout
-	originalParentBase                 unsafe.Pointer
-	originalParentBarrier              <-chan bool
-	rootParallelObserved               bool
-	suppressOriginalParallelTransition bool
-	originalTransitioned               bool
-	originalParallelReady              chan struct{}
-	originalParallelLocked             func()
-	rootParallelAnnounce               func() error
-	rootParallelBridge                 func() error
-	matcher                            *retryAttemptMatcherTransaction
-	attempts                           []*retryAttemptRoot
-	observeOutput                      bool
-	observeNativeOutput                bool
-	outputLimit                        int64
-	retired                            bool
+	mu                     locking.Mutex
+	executionMu            locking.Mutex
+	original               *testing.T
+	layout                 *testingInternalsLayout
+	originalParentBase     unsafe.Pointer
+	originalParentBarrier  <-chan bool
+	rootParallelObserved   bool
+	originalTransitioned   bool
+	originalParallelReady  chan struct{}
+	originalParallelLocked func()
+	rootParallelAnnounce   func() error
+	rootParallelBridge     func() error
+	matcher                *retryAttemptMatcherTransaction
+	attempts               []*retryAttemptRoot
+	observeOutput          bool
+	observeNativeOutput    bool
+	outputLimit            int64
+	retired                bool
 }
 
 type retryAttemptMatcherTransaction struct {
@@ -404,10 +403,6 @@ func (g *retryAttemptGroup) transitionOriginalToParallel() bool {
 
 	g.mu.Lock()
 	g.rootParallelObserved = true
-	if g.suppressOriginalParallelTransition {
-		g.mu.Unlock()
-		return true
-	}
 	if g.originalTransitioned {
 		ready := g.originalParallelReady
 		g.mu.Unlock()

--- a/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
@@ -115,6 +115,7 @@ func executeFreshRetryAttemptIteration(execOpts *executionOptions) bool {
 
 		execMeta = createTestMetadata(attempt.test, nil)
 		attempt.metadata = execMeta
+		execMeta.freshRetryAttemptTest = attempt.test
 		execMeta.flakyRetryBudgetReservation = execOpts.flakyRetryBudgetReservation
 		execMeta.hasAdditionalFeatureWrapper = true
 		execMeta.usesFreshRetryAttemptRuntime = true

--- a/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
@@ -67,6 +67,9 @@ func stopRetryGroupAfterRace(execOpts *executionOptions, raceDetected bool) bool
 	if execOpts == nil || !raceDetected {
 		return false
 	}
+	if execOpts.options != nil && execOpts.options.allowRetryAfterRace {
+		return false
+	}
 	execOpts.rawAttemptFailureSeen = true
 	execOpts.retryCount = 0
 	return true

--- a/internal/civisibility/integrations/gotesting/retry_attempt_integration_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_integration_test.go
@@ -215,6 +215,17 @@ func TestProcessRetryParityDetectedRaceStopsFreshRetryGroup(t *testing.T) {
 	require.False(t, stopRetryGroupAfterRace(execOpts, false))
 }
 
+func TestProcessRetryParityAttemptToFixContinuesAfterDetectedRace(t *testing.T) {
+	execOpts := &executionOptions{
+		options:    &runTestWithRetryOptions{allowRetryAfterRace: true},
+		retryCount: 3,
+	}
+
+	require.False(t, stopRetryGroupAfterRace(execOpts, true))
+	require.Equal(t, int64(3), execOpts.retryCount)
+	require.False(t, execOpts.rawAttemptFailureSeen)
+}
+
 func TestProcessRetryParityFailfastStopsAfterFirstRawFailure(t *testing.T) {
 	createTestMetadata(t, nil)
 	defer deleteTestMetadata(t)

--- a/internal/civisibility/integrations/gotesting/retry_attempt_norace.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_norace.go
@@ -10,3 +10,5 @@ package gotesting
 func retryAttemptRaceErrors() int64 {
 	return 0
 }
+
+func retryAttemptRaceEnabled() bool { return false }

--- a/internal/civisibility/integrations/gotesting/retry_attempt_race.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_race.go
@@ -12,3 +12,5 @@ import "runtime"
 func retryAttemptRaceErrors() int64 {
 	return int64(runtime.RaceErrors())
 }
+
+func retryAttemptRaceEnabled() bool { return true }

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
@@ -90,6 +90,7 @@ type retryAttemptResult struct {
 	schedulerSlotReleased  bool
 	terminalTrace          []retryAttemptTerminal
 	output                 []byte
+	outputTruncated        bool
 	nativeOutput           []byte
 }
 
@@ -334,7 +335,7 @@ func finalizeFreshRetryAttempt(attempt *retryAttemptRoot, resultCh chan<- retryA
 
 	flushRetryAttemptPartial(base, layout)
 	if attempt.group.observeOutput {
-		result.output = freezeRetryAttemptOutput(attempt, base, layout)
+		result.output, result.outputTruncated = freezeRetryAttemptOutput(attempt, base, layout)
 	}
 	reportRetryAttempt(base, layout)
 	result.reportExecuted = true
@@ -654,19 +655,29 @@ func reportRetryAttempt(base unsafe.Pointer, layout *testingInternalsLayout) {
 	_, _ = fmt.Fprintf(*fieldPtr[io.Writer](parent, layout.common.w), format, args...)
 }
 
-func freezeRetryAttemptOutput(attempt *retryAttemptRoot, base unsafe.Pointer, layout *testingInternalsLayout) []byte {
+func freezeRetryAttemptOutput(attempt *retryAttemptRoot, base unsafe.Pointer, layout *testingInternalsLayout) ([]byte, bool) {
 	mu := fieldPtr[sync.RWMutex](base, layout.common.mu)
 	mu.RLock()
-	output := append([]byte(nil), (*fieldPtr[[]byte](base, layout.common.output))...)
+	output, truncated := collectRetryAttemptOutput(attempt, *fieldPtr[[]byte](base, layout.common.output))
 	mu.RUnlock()
+	return output, truncated
+}
+
+func collectRetryAttemptOutput(attempt *retryAttemptRoot, current []byte) ([]byte, bool) {
+	var captured []byte
+	var capturedTruncated bool
 	if attempt != nil {
-		captured := attempt.outputCapture.take()
-		if len(output) == 0 {
-			return captured
-		}
-		output = append(output, captured...)
+		captured, capturedTruncated = attempt.outputCapture.take()
 	}
-	return output
+	if attempt == nil || attempt.group.outputLimit <= 0 {
+		output := append([]byte(nil), current...)
+		return append(output, captured...), capturedTruncated
+	}
+	sink := newProcessRetryBoundedOutput(attempt.group.outputLimit)
+	_, _ = sink.Write(current)
+	_, _ = sink.Write(captured)
+	tail, truncated := sink.Tail()
+	return []byte(tail), capturedTruncated || truncated
 }
 
 func snapshotRetryAttemptResult(attempt *retryAttemptRoot, base unsafe.Pointer, layout *testingInternalsLayout, result *retryAttemptResult) {
@@ -684,13 +695,7 @@ func snapshotRetryAttemptResult(attempt *retryAttemptRoot, base unsafe.Pointer, 
 			result.nativeOutput = append([]byte(nil), currentOutput...)
 		}
 		if result.output == nil {
-			result.output = append([]byte(nil), currentOutput...)
-			captured := attempt.outputCapture.take()
-			if len(result.output) == 0 {
-				result.output = captured
-			} else {
-				result.output = append(result.output, captured...)
-			}
+			result.output, result.outputTruncated = collectRetryAttemptOutput(attempt, currentOutput)
 		}
 	}
 	*fieldPtr[[]byte](base, layout.common.output) = nil

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
@@ -230,7 +230,7 @@ func finalizeFreshRetryAttempt(attempt *retryAttemptRoot, resultCh chan<- retryA
 		resultCh <- result
 	}()
 
-	result.raceCheckpointCount, result.raceDetected = checkRetryAttemptRaces(base, layout)
+	result.raceCheckpointCount, result.raceDetected = checkRetryAttemptRaces(attempt, base, layout)
 	if t.Failed() {
 		result.failureCheckpointPhase = retryAttemptFailurePreCheckpoint
 	}
@@ -320,8 +320,10 @@ func finalizeFreshRetryAttempt(attempt *retryAttemptRoot, resultCh chan<- retryA
 			return
 		}
 		addRetryAttemptElapsed(base, layout)
-		result.raceCheckpointCount, result.raceDetected = checkRetryAttemptRaces(base, layout)
-		if result.raceDetected && result.failureCheckpointPhase == retryAttemptNotFailed {
+		raceCheckpointCount, raceDetected := checkRetryAttemptRaces(attempt, base, layout)
+		result.raceCheckpointCount = max(result.raceCheckpointCount, raceCheckpointCount)
+		result.raceDetected = result.raceDetected || raceDetected
+		if raceDetected && result.failureCheckpointPhase == retryAttemptNotFailed {
 			result.failureCheckpointPhase = retryAttemptFailurePostCheckpoint
 		}
 		if !*fieldPtr[bool](base, layout.common.isParallel) {
@@ -566,8 +568,15 @@ func setRetryAttemptRunner(base unsafe.Pointer, layout *testingInternalsLayout) 
 	}
 }
 
-func checkRetryAttemptRaces(base unsafe.Pointer, layout *testingInternalsLayout) (int64, bool) {
+func checkRetryAttemptRaces(attempt *retryAttemptRoot, base unsafe.Pointer, layout *testingInternalsLayout) (int64, bool) {
 	raceErrors := retryAttemptRaceErrors()
+	if attempt != nil && attempt.group != nil && attempt.group.raceCheckpoint != nil {
+		checkpoint := attempt.group.raceCheckpoint
+		if !claimRetryAttemptRaceCheckpoint(checkpoint, raceErrors) {
+			advanceRetryAttemptRaceBaseline(fieldPtr[atomic.Int64](base, layout.common.lastRaceErrors), raceErrors)
+			return raceErrors, false
+		}
+	}
 	lastRaceErrors := fieldPtr[atomic.Int64](base, layout.common.lastRaceErrors)
 	for {
 		last := lastRaceErrors.Load()
@@ -596,6 +605,21 @@ func checkRetryAttemptRaces(base unsafe.Pointer, layout *testingInternalsLayout)
 		}
 	}
 	return raceErrors, true
+}
+
+func claimRetryAttemptRaceCheckpoint(checkpoint *atomic.Int64, raceErrors int64) bool {
+	if checkpoint == nil {
+		return true
+	}
+	for {
+		last := checkpoint.Load()
+		if raceErrors <= last {
+			return false
+		}
+		if checkpoint.CompareAndSwap(last, raceErrors) {
+			return true
+		}
+	}
 }
 
 func setRetryAttemptRan(base unsafe.Pointer, layout *testingInternalsLayout) {

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
@@ -230,7 +230,7 @@ func finalizeFreshRetryAttempt(attempt *retryAttemptRoot, resultCh chan<- retryA
 		resultCh <- result
 	}()
 
-	result.raceCheckpointCount, result.raceDetected = checkRetryAttemptRaces(attempt, base, layout)
+	result.raceCheckpointCount, result.raceDetected = checkRetryAttemptRaces(base, layout)
 	if t.Failed() {
 		result.failureCheckpointPhase = retryAttemptFailurePreCheckpoint
 	}
@@ -320,7 +320,7 @@ func finalizeFreshRetryAttempt(attempt *retryAttemptRoot, resultCh chan<- retryA
 			return
 		}
 		addRetryAttemptElapsed(base, layout)
-		raceCheckpointCount, raceDetected := checkRetryAttemptRaces(attempt, base, layout)
+		raceCheckpointCount, raceDetected := checkRetryAttemptRaces(base, layout)
 		result.raceCheckpointCount = max(result.raceCheckpointCount, raceCheckpointCount)
 		result.raceDetected = result.raceDetected || raceDetected
 		if raceDetected && result.failureCheckpointPhase == retryAttemptNotFailed {
@@ -535,6 +535,11 @@ func (r *retryAttemptRoot) beginRootParallelSchedulerTransfer() {
 	r.parallelPauseDuration = *fieldPtr[time.Duration](localBase, layout.common.duration)
 	r.parallelLeaseTransfer.Store(true)
 
+	if announce := r.group.rootParallelAnnounce; announce != nil {
+		if err := announce(); err != nil {
+			panic(err)
+		}
+	}
 	transitioned := r.group.transitionOriginalToParallel()
 	if bridge := r.group.rootParallelBridge; bridge != nil {
 		if err := bridge(); err != nil {
@@ -568,15 +573,8 @@ func setRetryAttemptRunner(base unsafe.Pointer, layout *testingInternalsLayout) 
 	}
 }
 
-func checkRetryAttemptRaces(attempt *retryAttemptRoot, base unsafe.Pointer, layout *testingInternalsLayout) (int64, bool) {
+func checkRetryAttemptRaces(base unsafe.Pointer, layout *testingInternalsLayout) (int64, bool) {
 	raceErrors := retryAttemptRaceErrors()
-	if attempt != nil && attempt.group != nil && attempt.group.raceCheckpoint != nil {
-		checkpoint := attempt.group.raceCheckpoint
-		if !claimRetryAttemptRaceCheckpoint(checkpoint, raceErrors) {
-			advanceRetryAttemptRaceBaseline(fieldPtr[atomic.Int64](base, layout.common.lastRaceErrors), raceErrors)
-			return raceErrors, false
-		}
-	}
 	lastRaceErrors := fieldPtr[atomic.Int64](base, layout.common.lastRaceErrors)
 	for {
 		last := lastRaceErrors.Load()
@@ -605,21 +603,6 @@ func checkRetryAttemptRaces(attempt *retryAttemptRoot, base unsafe.Pointer, layo
 		}
 	}
 	return raceErrors, true
-}
-
-func claimRetryAttemptRaceCheckpoint(checkpoint *atomic.Int64, raceErrors int64) bool {
-	if checkpoint == nil {
-		return true
-	}
-	for {
-		last := checkpoint.Load()
-		if raceErrors <= last {
-			return false
-		}
-		if checkpoint.CompareAndSwap(last, raceErrors) {
-			return true
-		}
-	}
 }
 
 func setRetryAttemptRan(base unsafe.Pointer, layout *testingInternalsLayout) {

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -1185,14 +1185,3 @@ func TestProcessRetryParityRaceBaselineReconciliationIsMonotonic(t *testing.T) {
 	require.Equal(t, target, originalBaseline.Load())
 	require.Equal(t, target, parentBaseline.Load())
 }
-
-func TestProcessRetryBatchRaceCheckpointClaimsEachIncrementOnce(t *testing.T) {
-	checkpoint := &atomic.Int64{}
-	checkpoint.Store(10)
-
-	require.True(t, claimRetryAttemptRaceCheckpoint(checkpoint, 11))
-	require.False(t, claimRetryAttemptRaceCheckpoint(checkpoint, 11))
-	require.False(t, claimRetryAttemptRaceCheckpoint(checkpoint, 10))
-	require.True(t, claimRetryAttemptRaceCheckpoint(checkpoint, 13))
-	require.Equal(t, int64(13), checkpoint.Load())
-}

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -1185,3 +1185,14 @@ func TestProcessRetryParityRaceBaselineReconciliationIsMonotonic(t *testing.T) {
 	require.Equal(t, target, originalBaseline.Load())
 	require.Equal(t, target, parentBaseline.Load())
 }
+
+func TestProcessRetryBatchRaceCheckpointClaimsEachIncrementOnce(t *testing.T) {
+	checkpoint := &atomic.Int64{}
+	checkpoint.Store(10)
+
+	require.True(t, claimRetryAttemptRaceCheckpoint(checkpoint, 11))
+	require.False(t, claimRetryAttemptRaceCheckpoint(checkpoint, 11))
+	require.False(t, claimRetryAttemptRaceCheckpoint(checkpoint, 10))
+	require.True(t, claimRetryAttemptRaceCheckpoint(checkpoint, 13))
+	require.Equal(t, int64(13), checkpoint.Load())
+}

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -831,6 +831,35 @@ func TestProcessRetryParityFreshRunnerSharesRootParallelLeaseAcrossSequentialAtt
 	})
 }
 
+func TestProcessRetryCoverageSuppressesOriginalRootParallelTransition(t *testing.T) {
+	t.Run("container", func(container *testing.T) {
+		container.Run("attempt", func(original *testing.T) {
+			before := snapshotRetryAttemptTestState(original)
+			group, reason := newRetryAttemptGroup(original)
+			require.Empty(original, reason)
+			group.suppressOriginalParallelTransition = true
+
+			attempt, result, reason := runFreshRetryAttemptInGroup(group, func(local *testing.T) {
+				local.Parallel()
+			})
+			require.Empty(original, reason)
+			require.NotNil(original, attempt)
+			attempt.cancelContexts()
+			group.retire()
+
+			require.False(original, result.failed)
+			require.True(original, group.rootParallelWasObserved())
+			fields := getTestPrivateFields(original)
+			require.NotNil(original, fields)
+			fields.mu.RLock()
+			originalParallel := *fields.isParallel
+			fields.mu.RUnlock()
+			require.False(original, originalParallel)
+			require.Equal(original, before, snapshotRetryAttemptTestState(original))
+		})
+	})
+}
+
 func TestProcessRetryParityFreshRunnerSerializesAttemptsInOneGroup(t *testing.T) {
 	group, reason := newRetryAttemptGroup(t)
 	require.Empty(t, reason)

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -831,35 +831,6 @@ func TestProcessRetryParityFreshRunnerSharesRootParallelLeaseAcrossSequentialAtt
 	})
 }
 
-func TestProcessRetryCoverageSuppressesOriginalRootParallelTransition(t *testing.T) {
-	t.Run("container", func(container *testing.T) {
-		container.Run("attempt", func(original *testing.T) {
-			before := snapshotRetryAttemptTestState(original)
-			group, reason := newRetryAttemptGroup(original)
-			require.Empty(original, reason)
-			group.suppressOriginalParallelTransition = true
-
-			attempt, result, reason := runFreshRetryAttemptInGroup(group, func(local *testing.T) {
-				local.Parallel()
-			})
-			require.Empty(original, reason)
-			require.NotNil(original, attempt)
-			attempt.cancelContexts()
-			group.retire()
-
-			require.False(original, result.failed)
-			require.True(original, group.rootParallelWasObserved())
-			fields := getTestPrivateFields(original)
-			require.NotNil(original, fields)
-			fields.mu.RLock()
-			originalParallel := *fields.isParallel
-			fields.mu.RUnlock()
-			require.False(original, originalParallel)
-			require.Equal(original, before, snapshotRetryAttemptTestState(original))
-		})
-	})
-}
-
 func TestProcessRetryParityFreshRunnerSerializesAttemptsInOneGroup(t *testing.T) {
 	group, reason := newRetryAttemptGroup(t)
 	require.Empty(t, reason)

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -959,6 +959,33 @@ func TestProcessRetryParityObservesOutputWhenLogsAreEnabled(t *testing.T) {
 	require.Nil(t, *fieldPtr[[]byte](commonBaseForTest(attempt.test, attempt.layout), attempt.layout.common.output))
 }
 
+func TestProcessRetryParityBoundsObservedOutput(t *testing.T) {
+	group, reason := newRetryAttemptGroupWithOutputObservation(t, true)
+	require.Empty(t, reason)
+	group.outputLimit = 64
+	defer group.retire()
+
+	attempt, result, reason := runFreshRetryAttemptInGroup(group, func(local *testing.T) {
+		base := commonBaseForTest(local, group.layout)
+		mu := fieldPtr[sync.RWMutex](base, group.layout.common.mu)
+		mu.Lock()
+		setPrivatePointerField(
+			group.layout.common.chatty.typ,
+			fieldRawPtr(base, group.layout.common.chatty.unsafeField),
+			nil,
+		)
+		mu.Unlock()
+		_, _ = local.Output().Write(bytes.Repeat([]byte("x"), 128))
+		_, _ = local.Output().Write([]byte("per-test-output-sentinel"))
+	})
+
+	require.Empty(t, reason)
+	require.NotNil(t, attempt)
+	require.True(t, result.outputTruncated)
+	require.LessOrEqual(t, len(result.output), 64)
+	require.Contains(t, string(result.output), "per-test-output-sentinel")
+}
+
 func TestProcessRetryParityNativeOutputObservationIsExplicit(t *testing.T) {
 	group, reason := newRetryAttemptGroupWithOutputObservation(t, true)
 	require.Empty(t, reason)
@@ -1047,8 +1074,9 @@ func TestProcessRetryParityCapturesEachTerminalStackOnce(t *testing.T) {
 func TestProcessRetryParityOutputCaptureTransfersOwnership(t *testing.T) {
 	capture := &retryAttemptOutputCapture{output: []byte("attempt output")}
 
-	output := capture.take()
+	output, truncated := capture.take()
 	require.Equal(t, []byte("attempt output"), output)
+	require.False(t, truncated)
 	require.Empty(t, capture.snapshot())
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -122,6 +122,7 @@ type processRetryChildConfig struct {
 	batchCoverageFinalizer *processRetryBatchCoverageFinalizer
 	nativeGatePath         string
 	nativeParallelPath     string
+	nativeEnumerationPath  string
 	tempDir                string
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
@@ -3507,6 +3508,15 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			// the other process to enumerate the next test.
 			group.rootParallelAnnounce = func() error {
 				return os.WriteFile(cfg.nativeParallelPath, nil, processRetryBatchManifestMode)
+			}
+			if !cfg.CollectPerTestCoverage {
+				group.rootParallelBridge = func() error {
+					deadline, deadlineOK := time.Time{}, false
+					if cfg.ParentDeadlineOK {
+						deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
+					}
+					return waitForProcessRetryBatchSignal(cfg.nativeEnumerationPath, deadline, deadlineOK)
+				}
 			}
 		} else if control != nil {
 			group.rootParallelBridge = control.childRootParallelBridge

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -123,6 +123,7 @@ type processRetryChildConfig struct {
 	nativeGatePath         string
 	nativeParallelPath     string
 	nativeEnumerationPath  string
+	processSlotRelease     chan<- processRetryLimiterRelease
 	tempDir                string
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
@@ -1859,6 +1860,9 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		return finishSetupFailure(limiterResult.Err, limiterResult.Cause == processRetryLimiterParentDeadline)
 	}
 	defer limiterResult.Release()
+	if cfg.processSlotRelease != nil {
+		cfg.processSlotRelease <- limiterResult.Release
+	}
 	if processRetryShutdownRequested(shutdown) || processRetryShuttingDown() {
 		return finishSetupFailure(errProcessRetryShutdown, false)
 	}
@@ -3496,10 +3500,6 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		}
 		if cfg.BatchChild {
 			group.outputLimit = processRetryResultOutputMaxBytes
-			// Runtime coverage counters are process-global. Keep the native
-			// t.Parallel admission, but serialize covered bodies while each
-			// test owns the counter delta that becomes its coverage payload.
-			group.suppressOriginalParallelTransition = cfg.CollectPerTestCoverage
 		}
 		observation.group = group
 		if cfg.nativeParallelPath != "" {
@@ -3509,21 +3509,19 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			group.rootParallelAnnounce = func() error {
 				return os.WriteFile(cfg.nativeParallelPath, nil, processRetryBatchManifestMode)
 			}
-			if !cfg.CollectPerTestCoverage {
-				group.rootParallelBridge = func() error {
-					deadline, deadlineOK := time.Time{}, false
-					if cfg.ParentDeadlineOK {
-						deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
-					}
-					state, run, err := waitForProcessRetryBatchGate(cfg.nativeEnumerationPath, deadline, deadlineOK)
-					if err != nil {
-						return err
-					}
-					if !run {
-						return errors.New("missing native process retry parent state")
-					}
-					return applyProcessRetryBatchInvocationState(state)
+			group.rootParallelBridge = func() error {
+				deadline, deadlineOK := time.Time{}, false
+				if cfg.ParentDeadlineOK {
+					deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
 				}
+				state, run, err := waitForProcessRetryBatchGate(cfg.nativeEnumerationPath, deadline, deadlineOK)
+				if err != nil {
+					return err
+				}
+				if !run {
+					return errors.New("missing native process retry parent state")
+				}
+				return applyProcessRetryBatchInvocationState(state)
 			}
 		} else if control != nil {
 			group.rootParallelBridge = control.childRootParallelBridge
@@ -3625,31 +3623,38 @@ func asError(value any) error {
 }
 
 func (o *processRetryChildObservation) writeFinalResult() {
-	if o == nil {
-		return
-	}
-	o.finalize.Do(func() {
-		if o.test == nil || o.execMeta == nil {
-			return
-		}
-		o.writer.Write(o.buildResult(""))
-	})
+	o.writeResult("")
 }
 
 func (o *processRetryChildObservation) writeControlledTerminalResult(control *processRetryControl, status processRetryStatus) {
 	if o == nil || !isProcessRetryControlledTerminalStatus(status) {
 		return
 	}
+	if o.writeResult(status) && control != nil {
+		_ = control.childControlledTerminal(status)
+	}
+}
+
+func (o *processRetryChildObservation) writeResult(status processRetryStatus) bool {
+	if o == nil {
+		return false
+	}
 	written := false
 	o.finalize.Do(func() {
 		if o.test == nil || o.execMeta == nil {
 			return
 		}
-		written = o.writer.Write(o.buildResult(status))
+		result := o.buildResult(status)
+		// Serial tests own process-global state in parent order. Parallel state
+		// cannot be propagated without racing its peers.
+		if o.cfg.nativeGatePath != "" && !result.RootParallel {
+			if err := writeCurrentProcessRetryBatchInvocationState(processRetryBatchFinalStatePath(o.cfg.ResultPath)); err != nil {
+				result = processRetryNotRunResult(o.cfg, "final_invocation_state_write_failed")
+			}
+		}
+		written = o.writer.Write(result)
 	})
-	if written && control != nil {
-		_ = control.childControlledTerminal(status)
-	}
+	return written
 }
 
 func (o *processRetryChildObservation) buildResult(status processRetryStatus) processRetryResult {
@@ -4258,7 +4263,7 @@ func validateProcessRetryCoverageFiles(files []coverage.ProcessTestCoverageFile)
 
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "native_parent_not_run", "invalid_invocation_state", "invocation_state_apply_failed":
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "native_parent_not_run", "invalid_invocation_state", "invocation_state_apply_failed", "final_invocation_state_write_failed":
 		return true
 	default:
 		return false

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -116,6 +116,7 @@ type processRetryChildConfig struct {
 	BatchChild             bool
 	CollectPerTestCoverage bool
 	batchTest              *processRetryBatchTestConfig
+	batchRaceCheckpoint    *atomic.Int64
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -182,20 +183,29 @@ type processRetryResult struct {
 	Coverage          []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
 }
 
+type processRetryTestSource struct {
+	RuntimePath      string `json:"runtime_path,omitempty"`
+	RuntimeStartLine int    `json:"runtime_start_line,omitempty"`
+	FunctionName     string `json:"function_name,omitempty"`
+}
+
 type processRetrySubtestResult struct {
-	TestName       string             `json:"test_name"`
-	Status         processRetryStatus `json:"status"`
-	StartUnixNano  int64              `json:"start_unix_nano"`
-	FinishUnixNano int64              `json:"finish_unix_nano"`
-	DurationNanos  int64              `json:"duration_nanos"`
-	Failed         bool               `json:"failed"`
-	Skipped        bool               `json:"skipped"`
-	Panic          bool               `json:"panic"`
-	ErrorType      string             `json:"error_type,omitempty"`
-	ErrorMessage   string             `json:"error_message,omitempty"`
-	ErrorStack     string             `json:"error_stack,omitempty"`
-	SkipReason     string             `json:"skip_reason,omitempty"`
-	order          uint64
+	TestName        string                  `json:"test_name"`
+	Status          processRetryStatus      `json:"status"`
+	StartUnixNano   int64                   `json:"start_unix_nano"`
+	FinishUnixNano  int64                   `json:"finish_unix_nano"`
+	DurationNanos   int64                   `json:"duration_nanos"`
+	Failed          bool                    `json:"failed"`
+	Skipped         bool                    `json:"skipped"`
+	Panic           bool                    `json:"panic"`
+	ErrorType       string                  `json:"error_type,omitempty"`
+	ErrorMessage    string                  `json:"error_message,omitempty"`
+	ErrorStack      string                  `json:"error_stack,omitempty"`
+	SkipReason      string                  `json:"skip_reason,omitempty"`
+	OutputTail      string                  `json:"output_tail,omitempty"`
+	OutputTruncated bool                    `json:"output_truncated,omitempty"`
+	Source          *processRetryTestSource `json:"source,omitempty"`
+	order           uint64
 }
 
 type processRetryErrorInfo struct {
@@ -2514,10 +2524,15 @@ func finishProcessRetryTestEvent(
 	test := suite.CreateTest(testInfo.testName, integrations.WithTestStartTime(attempt.StartTime))
 	if testInfo.sourceFunc != nil {
 		test.SetTestFunc(testInfo.sourceFunc)
+	} else if testInfo.source != nil {
+		integrations.SetTestSource(test, testInfo.source.RuntimePath, testInfo.source.RuntimeStartLine, testInfo.source.FunctionName)
 	}
 	execMeta.test = test
 	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
+	if cancelExecution && attempt.Result.Status == processRetryStatusSkip && attempt.Result.Skipped && attempt.Result.SkipReason == constants.TestDisabledSkipReason {
+		cancelExecution = false
+	}
 	test.SetTag(constants.TestRetryExecutionMode, "process")
 	if execMeta.isItrForcedRun {
 		test.SetTag(constants.TestForcedToRun, "true")
@@ -2645,25 +2660,28 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 		execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
 		execMeta.allRetriesFailed = execMeta.isARetry && parentMeta.allRetriesFailed && result.Failed
 		childAttempt := completedProcessRetryAttempt(processRetryResult{
-			Version:        1,
-			TestName:       result.TestName,
-			Status:         result.Status,
-			StartUnixNano:  result.StartUnixNano,
-			FinishUnixNano: result.FinishUnixNano,
-			DurationNanos:  result.DurationNanos,
-			Failed:         result.Failed,
-			Skipped:        result.Skipped,
-			Panic:          result.Panic,
-			ErrorType:      result.ErrorType,
-			ErrorMessage:   result.ErrorMessage,
-			ErrorStack:     result.ErrorStack,
-			SkipReason:     result.SkipReason,
+			Version:         1,
+			TestName:        result.TestName,
+			Status:          result.Status,
+			StartUnixNano:   result.StartUnixNano,
+			FinishUnixNano:  result.FinishUnixNano,
+			DurationNanos:   result.DurationNanos,
+			Failed:          result.Failed,
+			Skipped:         result.Skipped,
+			Panic:           result.Panic,
+			ErrorType:       result.ErrorType,
+			ErrorMessage:    result.ErrorMessage,
+			ErrorStack:      result.ErrorStack,
+			SkipReason:      result.SkipReason,
+			OutputTail:      result.OutputTail,
+			OutputTruncated: result.OutputTruncated,
 		})
 		finishProcessRetryTestEvent(&commonInfo{
 			moduleName: testInfo.moduleName,
 			suiteName:  testInfo.suiteName,
 			testName:   result.TestName,
 			identity:   identity,
+			source:     result.Source,
 		}, execMeta, childAttempt, nil, nil)
 	}
 }
@@ -3162,6 +3180,8 @@ func configureProcessRetryBatchChildWorkloads(
 	fuzzTargets *[]testing.InternalFuzzTarget,
 	examples *[]testing.InternalExample,
 ) testingMFinalizer {
+	batchRaceCheckpoint := &atomic.Int64{}
+	batchRaceCheckpoint.Store(retryAttemptRaceErrors())
 	available := make(map[string]testing.InternalTest, len(*tests))
 	for _, test := range *tests {
 		available[test.Name] = test
@@ -3170,6 +3190,7 @@ func configureProcessRetryBatchChildWorkloads(
 	finalizers := make([]func(), 0, len(cfg.Batch.Tests))
 	for index, spec := range cfg.Batch.Tests {
 		childCfg := processRetryBatchChildConfig(cfg, index, spec)
+		childCfg.batchRaceCheckpoint = batchRaceCheckpoint
 		test, ok := available[spec.TestName]
 		if !ok {
 			newProcessRetryResultWriter(childCfg.ResultPath).Write(processRetryNotRunResult(childCfg, ""))
@@ -3321,6 +3342,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		if cfg.BatchChild {
 			group.outputLimit = processRetryResultOutputMaxBytes
 			group.suppressOriginalParallelTransition = cfg.CollectPerTestCoverage
+			group.raceCheckpoint = cfg.batchRaceCheckpoint
 		}
 		observation.group = group
 		if control != nil {
@@ -3558,6 +3580,11 @@ func markProcessRetryChildFailed(tb testing.TB) {
 }
 
 func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing.T) {
+	var source *processRetryTestSource
+	if fn := runtime.FuncForPC(reflect.ValueOf(original).Pointer()); fn != nil {
+		runtimePath, runtimeStartLine := fn.FileLine(fn.Entry())
+		source = &processRetryTestSource{RuntimePath: runtimePath, RuntimeStartLine: runtimeStartLine, FunctionName: fn.Name()}
+	}
 	return func(t *testing.T) {
 		fields := getTestPrivateFields(t)
 		if fields == nil || fields.parent == nil {
@@ -3569,6 +3596,7 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			original(t)
 			return
 		}
+		restoreChatty := bufferProcessRetrySubtestOutput(t)
 
 		execMeta := createTestMetadata(t, nil)
 		execMeta.test = owner.test
@@ -3583,7 +3611,8 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		var finishOnce sync.Once
 		finish := func() {
 			finishOnce.Do(func() {
-				collector.finish(order, start, t, execMeta)
+				collector.finish(order, start, t, execMeta, source)
+				restoreChatty()
 				deleteTestMetadata(t)
 			})
 		}
@@ -3628,6 +3657,33 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 
 		original(t)
 		bodyReturned = true
+	}
+}
+
+func bufferProcessRetrySubtestOutput(t *testing.T) func() {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || layout.disabled || !layout.chattyOK {
+		return func() {}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return func() {}
+	}
+	mu := fieldPtr[sync.RWMutex](base, layout.common.mu)
+	mu.Lock()
+	chatty := pointerWord(base, layout.common.chatty)
+	if chatty != nil {
+		setPrivatePointerField(layout.common.chatty.typ, fieldRawPtr(base, layout.common.chatty.unsafeField), nil)
+	}
+	mu.Unlock()
+	return func() {
+		if chatty == nil {
+			return
+		}
+		mu.Lock()
+		setPrivatePointerField(layout.common.chatty.typ, fieldRawPtr(base, layout.common.chatty.unsafeField), chatty)
+		mu.Unlock()
+		runtime.KeepAlive(t)
 	}
 }
 
@@ -3913,8 +3969,17 @@ func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
 	if !processRetryJSONStringFits(result.ErrorType, processRetryErrorTypeMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
-		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) {
+		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) ||
+		!processRetryJSONStringFits(result.OutputTail, processRetryResultOutputMaxBytes) {
 		return fmt.Errorf("%w: subtest metadata field too large", errProcessRetryResultInvalid)
+	}
+	if result.Source != nil && (!processRetryJSONStringFits(result.Source.RuntimePath, processRetryErrorMessageMaxBytes) ||
+		!processRetryJSONStringFits(result.Source.FunctionName, processRetryErrorMessageMaxBytes) ||
+		result.Source.RuntimePath == "" || result.Source.RuntimeStartLine <= 0 || result.Source.FunctionName == "") {
+		return fmt.Errorf("%w: invalid subtest source", errProcessRetryResultInvalid)
+	}
+	if result.OutputTruncated && result.OutputTail == "" {
+		return fmt.Errorf("%w: invalid subtest output mirrors", errProcessRetryResultInvalid)
 	}
 	switch result.Status {
 	case processRetryStatusPass:
@@ -3956,7 +4021,7 @@ func (c *processRetrySubtestCollector) begin() (uint64, time.Time) {
 	return c.next.Add(1), time.Now()
 }
 
-func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata) {
+func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource) {
 	if c == nil || t == nil || execMeta == nil {
 		return
 	}
@@ -3968,7 +4033,12 @@ func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *
 		DurationNanos:  finish.UnixNano() - start.UnixNano(),
 		Failed:         t.Failed(),
 		Skipped:        t.Skipped(),
+		Source:         source,
 		order:          order,
+	}
+	flushOutputWriterPartial(t)
+	if fields := getTestPrivateFields(t); fields != nil {
+		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(fields.GetOutput())
 	}
 	if panicInfo := execMeta.processRetryPanic.Load(); panicInfo != nil {
 		result.Panic = true

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -973,6 +973,7 @@ type processRetryLaunchBaseline struct {
 	maxConcurrencySet bool
 	timeout           time.Duration
 	timeoutSet        bool
+	preserveStartup   bool
 	err               error
 }
 
@@ -1268,12 +1269,14 @@ func captureProcessRetryLaunchBaselineFromTemplate(template *processRetryLaunchB
 	if baseline.err != nil {
 		return &baseline
 	}
-	// Keep retry configuration stable while matching mutable native process state at invocation.
-	baseline.workingDirectory, baseline.err = baseline.hooks.workingDirectory()
-	if baseline.err != nil {
-		return &baseline
+	if !baseline.preserveStartup {
+		// Keep retry configuration stable while matching mutable native process state at invocation.
+		baseline.workingDirectory, baseline.err = baseline.hooks.workingDirectory()
+		if baseline.err != nil {
+			return &baseline
+		}
+		baseline.environment = sanitizeProcessRetryBaseEnv(baseline.hooks.environ())
 	}
-	baseline.environment = sanitizeProcessRetryBaseEnv(baseline.hooks.environ())
 	baseline.currentCPU = processRetryCurrentCPU()
 	return &baseline
 }

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -469,7 +469,7 @@ func sanitizeProcessRetryBaseEnv(base []string) []string {
 			result = append(result, entry)
 			continue
 		}
-		if isProcessRetryInternalEnvKey(key) || strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable) {
+		if isProcessRetryExcludedEnvKey(key) {
 			continue
 		}
 		if strings.EqualFold(key, constants.CIVisibilityEnabledEnvironmentVariable) {
@@ -481,6 +481,10 @@ func sanitizeProcessRetryBaseEnv(base []string) []string {
 		result = append(result, entry)
 	}
 	return result
+}
+
+func isProcessRetryExcludedEnvKey(key string) bool {
+	return isProcessRetryInternalEnvKey(key) || strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable)
 }
 
 func buildProcessRetryEnv(base []string, cfg processRetryChildConfig) []string {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -2642,7 +2642,7 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 		execMeta.anyExecutionPassed = result.Status == processRetryStatusPass
 		execMeta.anyExecutionFailed = result.Failed
 		execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
-		execMeta.allRetriesFailed = result.Failed
+		execMeta.allRetriesFailed = execMeta.isARetry && parentMeta.allRetriesFailed && result.Failed
 		childAttempt := completedProcessRetryAttempt(processRetryResult{
 			Version:        1,
 			TestName:       result.TestName,
@@ -3466,7 +3466,7 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		Panic:             panicData != nil,
 		RaceDetected:      o.result.raceDetected,
 		RootParallel:      rootParallel,
-		Coverage:          append([]coverage.ProcessTestCoverageFile(nil), o.coverage...),
+		Coverage:          o.coverage,
 	}
 	if o.cfg.BatchChild {
 		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(o.result.output)

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -1268,6 +1268,12 @@ func captureProcessRetryLaunchBaselineFromTemplate(template *processRetryLaunchB
 	if baseline.err != nil {
 		return &baseline
 	}
+	// Keep retry configuration stable while matching mutable native process state at invocation.
+	baseline.workingDirectory, baseline.err = baseline.hooks.workingDirectory()
+	if baseline.err != nil {
+		return &baseline
+	}
+	baseline.environment = sanitizeProcessRetryBaseEnv(baseline.hooks.environ())
 	baseline.currentCPU = processRetryCurrentCPU()
 	return &baseline
 }
@@ -3411,9 +3417,14 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			if cfg.ParentDeadlineOK {
 				deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
 			}
-			if err := waitForProcessRetryBatchGate(cfg.nativeGatePath, deadline, deadlineOK); err != nil {
+			run, err := waitForProcessRetryBatchGate(cfg.nativeGatePath, deadline, deadlineOK)
+			if err != nil {
 				writer.Write(processRetryNotRunResult(cfg, err.Error()))
 				t.Fail()
+				return
+			}
+			if !run {
+				writer.Write(processRetryNotRunResult(cfg, "native_parent_not_run"))
 				return
 			}
 		}
@@ -4110,7 +4121,7 @@ func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
 
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure":
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "native_parent_not_run":
 		return true
 	default:
 		return false

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3515,7 +3515,14 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 					if cfg.ParentDeadlineOK {
 						deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
 					}
-					return waitForProcessRetryBatchSignal(cfg.nativeEnumerationPath, deadline, deadlineOK)
+					state, run, err := waitForProcessRetryBatchGate(cfg.nativeEnumerationPath, deadline, deadlineOK)
+					if err != nil {
+						return err
+					}
+					if !run {
+						return errors.New("missing native process retry parent state")
+					}
+					return applyProcessRetryBatchInvocationState(state)
 				}
 			}
 		} else if control != nil {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"slices"
@@ -32,6 +33,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/envconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
@@ -112,6 +114,7 @@ type processRetryChildConfig struct {
 	ObservedGOMAXPROCS     int
 	Batch                  *processRetryBatchConfig
 	BatchChild             bool
+	CollectPerTestCoverage bool
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -152,29 +155,30 @@ const (
 )
 
 type processRetryResult struct {
-	Version           int                         `json:"version"`
-	TestName          string                      `json:"test_name"`
-	Attempt           int                         `json:"attempt"`
-	RetryReason       string                      `json:"retry_reason"`
-	MRunEpoch         uint64                      `json:"m_run_epoch,omitempty"`
-	InvocationOrdinal uint64                      `json:"invocation_ordinal,omitempty"`
-	Status            processRetryStatus          `json:"status"`
-	StartUnixNano     int64                       `json:"start_unix_nano"`
-	FinishUnixNano    int64                       `json:"finish_unix_nano"`
-	DurationNanos     int64                       `json:"duration_nanos"`
-	Failed            bool                        `json:"failed"`
-	Skipped           bool                        `json:"skipped"`
-	Panic             bool                        `json:"panic"`
-	RaceDetected      bool                        `json:"race_detected,omitempty"`
-	RootParallel      bool                        `json:"root_parallel,omitempty"`
-	ErrorType         string                      `json:"error_type,omitempty"`
-	ErrorMessage      string                      `json:"error_message,omitempty"`
-	ErrorStack        string                      `json:"error_stack,omitempty"`
-	SkipReason        string                      `json:"skip_reason,omitempty"`
-	ResultError       string                      `json:"result_error,omitempty"`
-	OutputTail        string                      `json:"output_tail,omitempty"`
-	OutputTruncated   bool                        `json:"output_truncated,omitempty"`
-	Subtests          []processRetrySubtestResult `json:"subtests,omitempty"`
+	Version           int                                `json:"version"`
+	TestName          string                             `json:"test_name"`
+	Attempt           int                                `json:"attempt"`
+	RetryReason       string                             `json:"retry_reason"`
+	MRunEpoch         uint64                             `json:"m_run_epoch,omitempty"`
+	InvocationOrdinal uint64                             `json:"invocation_ordinal,omitempty"`
+	Status            processRetryStatus                 `json:"status"`
+	StartUnixNano     int64                              `json:"start_unix_nano"`
+	FinishUnixNano    int64                              `json:"finish_unix_nano"`
+	DurationNanos     int64                              `json:"duration_nanos"`
+	Failed            bool                               `json:"failed"`
+	Skipped           bool                               `json:"skipped"`
+	Panic             bool                               `json:"panic"`
+	RaceDetected      bool                               `json:"race_detected,omitempty"`
+	RootParallel      bool                               `json:"root_parallel,omitempty"`
+	ErrorType         string                             `json:"error_type,omitempty"`
+	ErrorMessage      string                             `json:"error_message,omitempty"`
+	ErrorStack        string                             `json:"error_stack,omitempty"`
+	SkipReason        string                             `json:"skip_reason,omitempty"`
+	ResultError       string                             `json:"result_error,omitempty"`
+	OutputTail        string                             `json:"output_tail,omitempty"`
+	OutputTruncated   bool                               `json:"output_truncated,omitempty"`
+	Subtests          []processRetrySubtestResult        `json:"subtests,omitempty"`
+	Coverage          []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
 }
 
 type processRetrySubtestResult struct {
@@ -1926,9 +1930,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	selector := cfg.TestName
 	if childCfg.Batch != nil {
 		selector = "."
-		argsSnapshot.runSelector = ""
-		argsSnapshot.skipSelector = ""
-		argsSnapshot.preserved = append(append([]string(nil), argsSnapshot.preserved...), "-test.failfast=false")
+		argsSnapshot = processRetryBatchArgsSnapshot(argsSnapshot)
 	}
 	filteredArgs, ok, reason := buildProcessRetryArgsFromSnapshot(argsSnapshot, selector, currentCPU, childTestingTimeout)
 	if !ok {
@@ -2089,6 +2091,11 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		unregisterActiveProcessRetryChild(cmd)
 	}
 	return attempt
+}
+
+func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot) processRetryArgsSnapshot {
+	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false")
+	return snapshot
 }
 
 func applyProcessRetryControlledTerminalState(
@@ -2508,6 +2515,7 @@ func finishProcessRetryTestEvent(
 		test.SetTestFunc(testInfo.sourceFunc)
 	}
 	execMeta.test = test
+	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
 	test.SetTag(constants.TestRetryExecutionMode, "process")
 	if execMeta.isItrForcedRun {
@@ -3049,6 +3057,9 @@ func instrumentProcessRetryChild(m *testing.M, cfg processRetryChildConfig) (boo
 		return false, failureTestingMFinalizer
 	}
 	cfg = control.cfg
+	if cfg.Batch != nil && testing.CoverMode() != "" {
+		coverage.InitializeCoverage(m, false)
+	}
 	if err := control.childAdmission(); err != nil {
 		_ = control.Close()
 		writer.Write(processRetryNotRunResult(cfg, "control_protocol_failure"))
@@ -3176,6 +3187,9 @@ func configureProcessRetryBatchChildWorkloads(
 		for _, finalizeTest := range finalizers {
 			finalizeTest()
 		}
+		if err := coverage.WriteProcessCoverageProfile(processRetryBatchCoveragePath(cfg.ResultPath)); err != nil {
+			log.Debug("civisibility: failed to write isolated first-attempt coverage: %s", err.Error())
+		}
 		writer.Write(processRetryNotRunResult(cfg, ""))
 		return finalize(exitCode)
 	}
@@ -3286,6 +3300,7 @@ type processRetryChildObservation struct {
 	group     *retryAttemptGroup
 	execMeta  *testExecutionMetadata
 	result    retryAttemptResult
+	coverage  []coverage.ProcessTestCoverageFile
 	startTime time.Time
 }
 
@@ -3304,6 +3319,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		}
 		if cfg.BatchChild {
 			group.outputLimit = processRetryResultOutputMaxBytes
+			group.suppressOriginalParallelTransition = cfg.CollectPerTestCoverage
 		}
 		observation.group = group
 		if control != nil {
@@ -3329,7 +3345,22 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			observation.execMeta = execMeta
 			return ""
 		}
-		attempt, result, reason := runFreshRetryAttemptInGroupWithCallbacks(group, prepare, original, nil)
+		childBody := original
+		if cfg.BatchChild && cfg.CollectPerTestCoverage && coverage.CanCollect() {
+			if fn := runtime.FuncForPC(reflect.ValueOf(original).Pointer()); fn != nil {
+				testFile, _ := fn.FileLine(fn.Entry())
+				childBody = func(t *testing.T) {
+					collector := coverage.BeginProcessTestCoverage(testFile)
+					if collector == nil {
+						original(t)
+						return
+					}
+					defer func() { observation.coverage = collector.Finish() }()
+					original(t)
+				}
+			}
+		}
+		attempt, result, reason := runFreshRetryAttemptInGroupWithCallbacks(group, prepare, childBody, nil)
 		if reason != "" || attempt == nil {
 			writer.Write(processRetryNotRunResult(cfg, "testing_t_reflection_drift"))
 			t.Fail()
@@ -3435,6 +3466,7 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		Panic:             panicData != nil,
 		RaceDetected:      o.result.raceDetected,
 		RootParallel:      rootParallel,
+		Coverage:          append([]coverage.ProcessTestCoverageFile(nil), o.coverage...),
 	}
 	if o.cfg.BatchChild {
 		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(o.result.output)
@@ -3554,7 +3586,15 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				deleteTestMetadata(t)
 			})
 		}
-		t.Cleanup(finish)
+		directChild := getTestMetadataFromPointer(*fields.parent) == owner
+		t.Cleanup(func() {
+			finish()
+			if directChild {
+				if root, ok := owner.test.(*processRetryNoopTest); ok {
+					root.writePanicResult(owner.processRetryPanic.Load())
+				}
+			}
+		})
 
 		bodyReturned := false
 		defer func() {
@@ -3574,10 +3614,6 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			}
 			execMeta.processRetryPanic.CompareAndSwap(nil, info)
 			owner.processRetryPanic.CompareAndSwap(nil, info)
-			if root, ok := owner.test.(*processRetryNoopTest); ok {
-				finish()
-				root.writePanicResult(owner.processRetryPanic.Load())
-			}
 			if unexpectedTermination {
 				return
 			}
@@ -3708,7 +3744,7 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 		return err
 	}
 	maxBytes := processRetryResultMaxBytes
-	if len(result.Subtests) > 0 {
+	if len(result.Subtests) > 0 || len(result.Coverage) > 0 {
 		maxBytes = processRetryResultWithSubtestsMaxBytes
 	}
 	if len(payload) > maxBytes {
@@ -3767,7 +3803,7 @@ func readProcessRetryResult(resultPath string, expected processRetryChildConfig)
 	if err := validateProcessRetryResult(result, expected); err != nil {
 		return processRetryResult{}, false, err
 	}
-	if len(result.Subtests) == 0 && len(payload) > processRetryResultMaxBytes {
+	if len(result.Subtests) == 0 && len(result.Coverage) == 0 && len(payload) > processRetryResultMaxBytes {
 		return processRetryResult{}, false, fmt.Errorf("%w: result file too large", errProcessRetryResultInvalid)
 	}
 	timingOK := result.StartUnixNano != 0 && result.FinishUnixNano != 0 && result.FinishUnixNano >= result.StartUnixNano
@@ -3825,6 +3861,17 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 			return err
 		}
 	}
+	if len(result.Coverage) > 0 && !expected.BatchChild {
+		return fmt.Errorf("%w: unexpected process coverage", errProcessRetryResultInvalid)
+	}
+	if len(result.Coverage) > processRetryBatchMaxTests {
+		return fmt.Errorf("%w: too many process coverage files", errProcessRetryResultInvalid)
+	}
+	for _, file := range result.Coverage {
+		if strings.TrimSpace(file.Name) == "" || !processRetryJSONStringFits(file.Name, processRetryErrorMessageMaxBytes) {
+			return fmt.Errorf("%w: invalid process coverage file", errProcessRetryResultInvalid)
+		}
+	}
 	switch result.Status {
 	case processRetryStatusPass:
 		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.ResultError != "" {
@@ -3843,7 +3890,7 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 			return fmt.Errorf("%w: invalid controlled terminal mirrors", errProcessRetryResultInvalid)
 		}
 	case processRetryStatusNotRun:
-		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || !validProcessRetryResultError(result.ResultError) {
+		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || len(result.Coverage) > 0 || !validProcessRetryResultError(result.ResultError) {
 			return fmt.Errorf("%w: invalid not_run mirrors", errProcessRetryResultInvalid)
 		}
 	default:

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -2231,6 +2231,12 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 
 func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot, testLogFile string, preserveNativeSchedule bool) processRetryArgsSnapshot {
 	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false")
+	for index, arg := range snapshot.preserved {
+		name, value, hasValue := processRetrySplitFlag(arg)
+		if name == "-test.v" && (!hasValue || value == "true") {
+			snapshot.preserved[index] = "-test.v=test2json"
+		}
+	}
 	if testLogFile != "" {
 		snapshot.preserved = append(snapshot.preserved, "-test.testlogfile="+testLogFile)
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -117,6 +117,7 @@ type processRetryChildConfig struct {
 	BatchChild             bool
 	CollectPerTestCoverage bool
 	batchTest              *processRetryBatchTestConfig
+	attemptToFixRetries    int
 	itrCoverageActive      bool
 	impactedTestsAnalyzer  *impactedtests.ImpactedTestAnalyzer
 	batchCoverageFinalizer *processRetryBatchCoverageFinalizer
@@ -215,25 +216,28 @@ type processRetryTestSource struct {
 }
 
 type processRetrySubtestResult struct {
-	TestName        string                             `json:"test_name"`
-	Status          processRetryStatus                 `json:"status"`
-	StartUnixNano   int64                              `json:"start_unix_nano"`
-	FinishUnixNano  int64                              `json:"finish_unix_nano"`
-	DurationNanos   int64                              `json:"duration_nanos"`
-	Failed          bool                               `json:"failed"`
-	Skipped         bool                               `json:"skipped"`
-	SkippedByITR    bool                               `json:"skipped_by_itr,omitempty"`
-	ITRForcedRun    bool                               `json:"itr_forced_run,omitempty"`
-	Panic           bool                               `json:"panic"`
-	ErrorType       string                             `json:"error_type,omitempty"`
-	ErrorMessage    string                             `json:"error_message,omitempty"`
-	ErrorStack      string                             `json:"error_stack,omitempty"`
-	SkipReason      string                             `json:"skip_reason,omitempty"`
-	OutputTail      string                             `json:"output_tail,omitempty"`
-	OutputTruncated bool                               `json:"output_truncated,omitempty"`
-	Source          *processRetryTestSource            `json:"source,omitempty"`
-	Coverage        []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
-	order           uint64
+	TestName         string                             `json:"test_name"`
+	AttemptToFix     bool                               `json:"attempt_to_fix,omitempty"`
+	Attempt          int                                `json:"attempt,omitempty"`
+	AttemptToFixLast bool                               `json:"attempt_to_fix_last,omitempty"`
+	Status           processRetryStatus                 `json:"status"`
+	StartUnixNano    int64                              `json:"start_unix_nano"`
+	FinishUnixNano   int64                              `json:"finish_unix_nano"`
+	DurationNanos    int64                              `json:"duration_nanos"`
+	Failed           bool                               `json:"failed"`
+	Skipped          bool                               `json:"skipped"`
+	SkippedByITR     bool                               `json:"skipped_by_itr,omitempty"`
+	ITRForcedRun     bool                               `json:"itr_forced_run,omitempty"`
+	Panic            bool                               `json:"panic"`
+	ErrorType        string                             `json:"error_type,omitempty"`
+	ErrorMessage     string                             `json:"error_message,omitempty"`
+	ErrorStack       string                             `json:"error_stack,omitempty"`
+	SkipReason       string                             `json:"skip_reason,omitempty"`
+	OutputTail       string                             `json:"output_tail,omitempty"`
+	OutputTruncated  bool                               `json:"output_truncated,omitempty"`
+	Source           *processRetryTestSource            `json:"source,omitempty"`
+	Coverage         []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
+	order            uint64
 }
 
 type processRetryErrorInfo struct {
@@ -472,15 +476,21 @@ func sanitizeProcessRetryBaseEnv(base []string) []string {
 		if isProcessRetryExcludedEnvKey(key) {
 			continue
 		}
-		if strings.EqualFold(key, constants.CIVisibilityEnabledEnvironmentVariable) {
-			if mode, valid := envconfig.ParseEnabledMode(value); valid && mode == envconfig.EnabledModeParent {
-				result = append(result, key+"=false")
-				continue
-			}
+		if isProcessRetryParentOnlyEnv(key, value) {
+			result = append(result, key+"=false")
+			continue
 		}
 		result = append(result, entry)
 	}
 	return result
+}
+
+func isProcessRetryParentOnlyEnv(key, value string) bool {
+	if !strings.EqualFold(key, constants.CIVisibilityEnabledEnvironmentVariable) {
+		return false
+	}
+	mode, valid := envconfig.ParseEnabledMode(value)
+	return valid && mode == envconfig.EnabledModeParent
 }
 
 func isProcessRetryExcludedEnvKey(key string) bool {
@@ -1012,6 +1022,7 @@ type processRetryArgsSnapshot struct {
 	artifactOutput   string
 	artifactsEnabled bool
 	testLogFile      string
+	profilingEnabled bool
 	timeout          time.Duration
 	timeoutSet       bool
 	ok               bool
@@ -2607,6 +2618,20 @@ func processRetryParallelBaselineReady(baseline *processRetryLaunchBaseline) (bo
 	return true, ""
 }
 
+func processRetryFirstAttemptIsolationReady(baseline *processRetryLaunchBaseline) (bool, string) {
+	if ok, reason := processRetryParallelBaselineReady(baseline); !ok {
+		return false, reason
+	}
+	argsSnapshot := baseline.argsSnapshot
+	if !argsSnapshot.captured {
+		argsSnapshot = captureProcessRetryArgsSnapshot(baseline.args)
+	}
+	if argsSnapshot.profilingEnabled {
+		return false, "test_profiling_enabled"
+	}
+	return true, ""
+}
+
 func deferProcessRetryTestEventWithAdmission(
 	testInfo *commonInfo,
 	execMeta *testExecutionMetadata,
@@ -2752,6 +2777,7 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 	if parentSnapshot == nil {
 		return
 	}
+	outcomes := make(map[string]retryOutcomeAccumulator)
 	for _, result := range attempt.Result.Subtests {
 		identity := newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName)
 		execMeta := &testExecutionMetadata{}
@@ -2782,10 +2808,27 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 			execMeta.hasExplicitDisabled = true
 			execMeta.hasExplicitAttemptToFix = true
 		}
-		execMeta.anyExecutionPassed = result.Status == processRetryStatusPass
-		execMeta.anyExecutionFailed = result.Failed
-		execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
-		execMeta.allRetriesFailed = execMeta.isARetry && parentMeta.allRetriesFailed && result.Failed
+		if result.AttemptToFix {
+			prior := outcomes[result.TestName]
+			execMeta.suppressParentRetryMetadata = true
+			execMeta.hasAdditionalFeatureWrapper = true
+			execMeta.isARetry = result.Attempt > 0
+			execMeta.isLastRetry = result.AttemptToFixLast
+			execMeta.isAttemptToFix = true
+			execMeta.hasExplicitAttemptToFix = true
+			execMeta.shouldOrchestrateAttemptToFix = true
+			execMeta.retryContinuationDecided = true
+			execMeta.retryContinuationAdmitted = !result.AttemptToFixLast
+			execMeta.anyExecutionPassed = prior.anyPassed()
+			execMeta.anyExecutionFailed = prior.anyFailed()
+			execMeta.allAttemptsPassed = prior.allAttemptsPassed()
+			execMeta.allRetriesFailed = execMeta.isARetry && prior.allRetriesFailed()
+		} else {
+			execMeta.anyExecutionPassed = result.Status == processRetryStatusPass
+			execMeta.anyExecutionFailed = result.Failed
+			execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
+			execMeta.allRetriesFailed = execMeta.isARetry && parentMeta.allRetriesFailed && result.Failed
+		}
 		childAttempt := completedProcessRetryAttempt(processRetryResult{
 			Version:         1,
 			TestName:        result.TestName,
@@ -2811,13 +2854,18 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 			identity:   identity,
 			source:     result.Source,
 		}, execMeta, childAttempt, nil, nil)
+		if result.AttemptToFix {
+			prior := outcomes[result.TestName]
+			prior.observe(result.Failed, result.Skipped)
+			outcomes[result.TestName] = prior
+		}
 	}
 }
 
 func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnapshot {
 	preserved, boundary, runSelector, skipSelector, ok, reason := processRetryFilterArgs(originalArgs, true)
 	timeout, timeoutSet := processRetryTimeoutFromArgs(originalArgs)
-	artifactOutput, artifactsEnabled, testLogFile := processRetryOutputPolicyFromArgs(originalArgs)
+	artifactOutput, artifactsEnabled, testLogFile, profilingEnabled := processRetryOutputPolicyFromArgs(originalArgs)
 	return processRetryArgsSnapshot{
 		captured:         true,
 		preserved:        append([]string(nil), preserved...),
@@ -2827,6 +2875,7 @@ func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnap
 		artifactOutput:   artifactOutput,
 		artifactsEnabled: artifactsEnabled,
 		testLogFile:      testLogFile,
+		profilingEnabled: profilingEnabled,
 		timeout:          timeout,
 		timeoutSet:       timeoutSet,
 		ok:               ok,
@@ -2873,7 +2922,7 @@ func buildProcessRetryArgsFromSnapshot(snapshot processRetryArgsSnapshot, testNa
 	return args, true, ""
 }
 
-func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, artifactsEnabled bool, testLogFile string) {
+func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, artifactsEnabled bool, testLogFile string, profilingEnabled bool) {
 	for i := 0; i < len(originalArgs); i++ {
 		arg := originalArgs[i]
 		if arg == "--" || !processRetryIsFlagToken(arg) {
@@ -2895,9 +2944,11 @@ func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, 
 			}
 		case "-test.testlogfile":
 			testLogFile = value
+		case "-test.cpuprofile", "-test.memprofile", "-test.blockprofile", "-test.mutexprofile", "-test.trace":
+			profilingEnabled = profilingEnabled || value != ""
 		}
 	}
-	return outputDir, artifactsEnabled, testLogFile
+	return outputDir, artifactsEnabled, testLogFile, profilingEnabled
 }
 
 func processRetryTimeoutFromArgs(originalArgs []string) (time.Duration, bool) {
@@ -3815,6 +3866,12 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			collector = &root.subtests
 			order, start = collector.begin()
 		}
+		attemptToFix := root != nil && root.cfg.batchTest != nil && slices.Contains(root.cfg.batchTest.AttemptToFixSubtests, t.Name())
+		if attemptToFix {
+			execMeta.isAttemptToFix = true
+			execMeta.hasExplicitAttemptToFix = true
+			execMeta.shouldOrchestrateAttemptToFix = true
+		}
 		var finishOnce sync.Once
 		finish := func() {
 			finishOnce.Do(func() {
@@ -3825,7 +3882,14 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				if parentBarrier != nil {
 					*parentBarrier = oldParentBarrier
 				}
-				collector.finish(order, start, t, execMeta, source, files)
+				if attemptToFix {
+					if !collector.completeAttemptToFix(t.Name(), files) {
+						collector.finishNativeAttemptToFix(order, start, t, execMeta, source, files)
+						collector.completeAttemptToFix(t.Name(), files)
+					}
+				} else {
+					collector.finish(order, start, t, execMeta, source, files)
+				}
 				restoreChatty()
 				deleteTestMetadata(t)
 			})
@@ -3846,7 +3910,6 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		}
 		if root != nil && root.cfg.batchTest != nil {
 			if itr, ok := processRetrySubtestITR(root.cfg.batchTest.ITRSubtests, t.Name()); ok {
-				execMeta.isAttemptToFix = itr.AttemptToFix
 				execMeta.isAModifiedTest = root.isModifiedSubtest(t.Name(), sourceFunc)
 				decision := decideITRSkip(true, itr.MissingLineCodeCoverage, root.cfg.itrCoverageActive, execMeta, integrations.IsTestFuncUnskippable(sourceFunc))
 				execMeta.isItrForcedRun = decision.forcedRun
@@ -3869,6 +3932,10 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 					*parentBarrier = nil
 				}
 			}
+		}
+		if attemptToFix {
+			runProcessRetryChildAttemptToFixSubtest(t, original, owner, collector, source, root.cfg.attemptToFixRetries, execMeta.isItrForcedRun)
+			return
 		}
 
 		bodyReturned := false
@@ -3898,6 +3965,60 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		original(t)
 		bodyReturned = true
 	}
+}
+
+func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testing.T), owner *testExecutionMetadata, collector *processRetrySubtestCollector, source *processRetryTestSource, retries int, itrForcedRun bool) {
+	group, reason := newRetryAttemptGroupWithOutputObservation(t, true)
+	if reason != "" {
+		original(t)
+		return
+	}
+	identity := newTestIdentity("", "", t.Name())
+	var outcomes retryOutcomeAccumulator
+	preparedIndex := -1
+	runTestWithRetry(&runTestWithRetryOptions{
+		targetFunc:                    original,
+		t:                             t,
+		retryAttemptGroupFactory:      func(*testing.T) (*retryAttemptGroup, string) { return group, "" },
+		allowProcessRetryChildRetries: true,
+		preExecMetaAdjust: func(execMeta *testExecutionMetadata, executionIndex int) {
+			execMeta.identity = identity
+			execMeta.test = owner.test
+			execMeta.processRetryOwner = owner
+			execMeta.isAttemptToFix = true
+			execMeta.isItrForcedRun = itrForcedRun
+			execMeta.hasExplicitAttemptToFix = true
+			execMeta.shouldOrchestrateAttemptToFix = true
+			execMeta.suppressParentRetryMetadata = true
+			if preparedIndex == executionIndex {
+				return
+			}
+			preparedIndex = executionIndex
+			order, start := collector.begin()
+			execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
+				collector.finishAttemptToFix(order, start, execMeta.freshRetryAttemptTest, execMeta, source, executionIndex, result)
+			}
+		},
+		preIsLastRetry: func(_ *testExecutionMetadata, _ int, remainingRetries int64) bool {
+			return remainingRetries == 1
+		},
+		postAdjustRetryCount: func(*testExecutionMetadata, time.Duration) int64 {
+			return int64(retries)
+		},
+		postPerExecution: func(attempt *testing.T, _ *testExecutionMetadata, _ int, _ time.Duration) {
+			outcomes.observe(attempt.Failed(), attempt.Skipped())
+		},
+		postShouldRetry: func(_ *testing.T, _ *testExecutionMetadata, _ int, remainingRetries int64) bool {
+			return remainingRetries > 0
+		},
+		postOnRetryEnd: func(t *testing.T, _ int, last *testing.T, result retryGroupPolicyResult) {
+			if result.failfastRawFailure || result.lateFailure || outcomes.anyFailed() {
+				t.Fail()
+			} else if last.Skipped() {
+				t.SkipNow()
+			}
+		},
+	})
 }
 
 func processRetrySubtestITR(configs []processRetrySubtestITRConfig, name string) (processRetrySubtestITRConfig, bool) {
@@ -4163,17 +4284,35 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 		return fmt.Errorf("%w: too many subtest results", errProcessRetryResultInvalid)
 	}
 	seenSubtests := make(map[string]struct{}, len(result.Subtests))
+	nextAttemptToFix := make(map[string]int)
+	completedAttemptToFix := make(map[string]struct{})
 	for _, subtest := range result.Subtests {
 		if !strings.HasPrefix(subtest.TestName, result.TestName+"/") {
 			return fmt.Errorf("%w: invalid subtest identity", errProcessRetryResultInvalid)
 		}
-		if _, duplicate := seenSubtests[subtest.TestName]; duplicate {
-			return fmt.Errorf("%w: duplicate subtest result", errProcessRetryResultInvalid)
+		if subtest.AttemptToFix {
+			if _, duplicate := seenSubtests[subtest.TestName]; duplicate || subtest.Attempt != nextAttemptToFix[subtest.TestName] {
+				return fmt.Errorf("%w: invalid attempt-to-fix subtest sequence", errProcessRetryResultInvalid)
+			}
+			if _, completed := completedAttemptToFix[subtest.TestName]; completed {
+				return fmt.Errorf("%w: completed attempt-to-fix subtest continued", errProcessRetryResultInvalid)
+			}
+			nextAttemptToFix[subtest.TestName]++
+			if subtest.AttemptToFixLast {
+				completedAttemptToFix[subtest.TestName] = struct{}{}
+			}
+		} else {
+			if _, duplicate := seenSubtests[subtest.TestName]; duplicate || nextAttemptToFix[subtest.TestName] != 0 {
+				return fmt.Errorf("%w: duplicate subtest result", errProcessRetryResultInvalid)
+			}
+			seenSubtests[subtest.TestName] = struct{}{}
 		}
-		seenSubtests[subtest.TestName] = struct{}{}
 		if err := validateProcessRetrySubtestResult(subtest); err != nil {
 			return err
 		}
+	}
+	if len(completedAttemptToFix) != len(nextAttemptToFix) {
+		return fmt.Errorf("%w: incomplete attempt-to-fix subtest sequence", errProcessRetryResultInvalid)
 	}
 	if len(result.Coverage) > 0 && !expected.BatchChild {
 		return fmt.Errorf("%w: unexpected process coverage", errProcessRetryResultInvalid)
@@ -4209,6 +4348,9 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 }
 
 func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
+	if result.Attempt < 0 || !result.AttemptToFix && (result.Attempt != 0 || result.AttemptToFixLast) {
+		return fmt.Errorf("%w: invalid subtest attempt metadata", errProcessRetryResultInvalid)
+	}
 	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
 		(result.DurationNanos != 0 && result.DurationNanos != result.FinishUnixNano-result.StartUnixNano) {
 		return fmt.Errorf("%w: invalid subtest timing", errProcessRetryResultInvalid)
@@ -4287,32 +4429,69 @@ func (c *processRetrySubtestCollector) begin() (uint64, time.Time) {
 }
 
 func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile) {
+	c.finishWithAttempt(order, start, t, execMeta, source, files, -1, nil)
+}
+
+func (c *processRetrySubtestCollector) finishAttemptToFix(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, attempt int, retryResult retryAttemptResult) {
+	c.finishWithAttempt(order, start, t, execMeta, source, nil, attempt, &retryResult)
+}
+
+func (c *processRetrySubtestCollector) finishNativeAttemptToFix(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile) {
+	c.finishWithAttempt(order, start, t, execMeta, source, files, 0, nil)
+}
+
+func (c *processRetrySubtestCollector) finishWithAttempt(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile, attempt int, retryResult *retryAttemptResult) {
 	if c == nil || t == nil || execMeta == nil {
 		return
 	}
 	finish := time.Now()
+	failed := t.Failed()
+	skipped := t.Skipped()
+	if retryResult != nil {
+		finish = start.Add(max(retryResult.duration, 0))
+		failed = retryResult.failed || retryResult.raceDetected || retryResult.panicData != nil || retryResult.cleanupPanicData != nil
+		skipped = retryResult.skipped
+	}
 	result := processRetrySubtestResult{
 		TestName:       t.Name(),
+		AttemptToFix:   attempt >= 0,
+		Attempt:        max(attempt, 0),
 		StartUnixNano:  start.UnixNano(),
 		FinishUnixNano: finish.UnixNano(),
 		DurationNanos:  finish.UnixNano() - start.UnixNano(),
-		Failed:         t.Failed(),
-		Skipped:        t.Skipped(),
+		Failed:         failed,
+		Skipped:        skipped,
 		SkippedByITR:   execMeta.isItrSkipped,
 		ITRForcedRun:   execMeta.isItrForcedRun,
 		Source:         source,
 		Coverage:       files,
 		order:          order,
 	}
-	flushOutputWriterPartial(t)
-	if fields := getTestPrivateFields(t); fields != nil {
-		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(fields.GetOutput())
+	if retryResult != nil {
+		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(retryResult.output)
+		result.OutputTruncated = result.OutputTruncated || retryResult.outputTruncated
+	} else {
+		flushOutputWriterPartial(t)
+		if fields := getTestPrivateFields(t); fields != nil {
+			result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(fields.GetOutput())
+		}
 	}
 	if panicInfo := execMeta.processRetryPanic.Load(); panicInfo != nil {
 		result.Panic = true
 		result.ErrorType = panicInfo.Type
 		result.ErrorMessage = panicInfo.Message
 		result.ErrorStack = panicInfo.Stack
+	} else if retryResult != nil && (retryResult.panicData != nil || retryResult.cleanupPanicData != nil) {
+		panicData := retryResult.panicData
+		panicStack := retryResult.panicStack
+		if panicData == nil {
+			panicData = retryResult.cleanupPanicData
+			panicStack = retryResult.cleanupPanicStack
+		}
+		result.Panic = true
+		result.ErrorType = "panic"
+		result.ErrorMessage = truncateProcessRetryErrorMessage(toString(panicData))
+		result.ErrorStack = truncateProcessRetryErrorStack(string(panicStack))
 	} else if errorInfo := execMeta.processRetryError.Load(); errorInfo != nil {
 		result.ErrorType = errorInfo.Type
 		result.ErrorMessage = errorInfo.Message
@@ -4335,6 +4514,22 @@ func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *
 	c.mu.Lock()
 	c.results = append(c.results, result)
 	c.mu.Unlock()
+}
+
+func (c *processRetrySubtestCollector) completeAttemptToFix(name string, files []coverage.ProcessTestCoverageFile) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for index := len(c.results) - 1; index >= 0; index-- {
+		if result := &c.results[index]; result.TestName == name && result.AttemptToFix {
+			result.AttemptToFixLast = true
+			result.Coverage = files
+			return true
+		}
+	}
+	return false
 }
 
 func (c *processRetrySubtestCollector) snapshot() []processRetrySubtestResult {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -115,6 +115,7 @@ type processRetryChildConfig struct {
 	Batch                  *processRetryBatchConfig
 	BatchChild             bool
 	CollectPerTestCoverage bool
+	batchTest              *processRetryBatchTestConfig
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -3595,6 +3596,11 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				}
 			}
 		})
+		if root, ok := owner.test.(*processRetryNoopTest); ok && root.cfg.batchTest != nil && slices.Contains(root.cfg.batchTest.DisabledSubtests, t.Name()) {
+			reason := constants.TestDisabledSkipReason
+			execMeta.processRetrySkipReason.Store(&reason)
+			t.SkipNow()
+		}
 
 		bodyReturned := false
 		defer func() {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -117,8 +117,25 @@ type processRetryChildConfig struct {
 	CollectPerTestCoverage bool
 	batchTest              *processRetryBatchTestConfig
 	batchRaceCheckpoint    *atomic.Int64
+	batchCoverageFinalizer *processRetryBatchCoverageFinalizer
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
+}
+
+type processRetryBatchCoverageFinalizer struct {
+	once    sync.Once
+	profile *coverage.ProcessCoverageProfile
+	path    string
+}
+
+func (f *processRetryBatchCoverageFinalizer) run() {
+	if f != nil {
+		f.once.Do(func() {
+			if err := f.profile.WriteDelta(f.path); err != nil {
+				log.Debug("civisibility: failed to write isolated first-attempt coverage: %s", err.Error())
+			}
+		})
+	}
 }
 
 type processRetryStatus string
@@ -142,6 +159,7 @@ const (
 	processRetryTruncationMarker           = "[dd-trace-go: process retry panic data truncated]"
 	processRetryMetadataTruncationMarker   = "[dd-trace-go: process retry metadata truncated]"
 	processRetryOutputTruncationMarker     = "\n[dd-trace-go: process retry output truncated]\n"
+	processRetryTestLogMagic               = "# test log\n"
 	processRetryOutputMaxBytes             = 32 * 1024
 	processRetryStreamMaxBytes             = 32 * 1024
 	processRetryExitCodeUnset              = -1
@@ -251,6 +269,7 @@ var (
 	errProcessRetryOutputDrainTimedOut = errors.New("process retry output drain timed out")
 	errProcessRetryContainmentLost     = errors.New("process retry process-tree containment lost")
 	errProcessRetryMultipleMRun        = errors.New("process retry child invoked testing.M.Run more than once")
+	errProcessRetryTestLogMerge        = errors.New("process retry test log merge failed")
 )
 
 var lookupProcessRetryChildTransport = integrations.LookupProcessRetryChildTransport
@@ -970,6 +989,7 @@ type processRetryArgsSnapshot struct {
 	skipSelector     string
 	artifactOutput   string
 	artifactsEnabled bool
+	testLogFile      string
 	timeout          time.Duration
 	timeoutSet       bool
 	ok               bool
@@ -1786,7 +1806,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	if currentCPU < 1 {
 		currentCPU = processRetryCurrentCPU()
 	}
-	selectedTimeout := selectedProcessRetryTimeout(argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
+	selectedTimeout := selectedProcessRetryTimeout(cfg.Batch != nil, argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
 	if selectedTimeout <= 0 {
 		return finishSetupFailure(context.DeadlineExceeded, true)
 	}
@@ -1823,7 +1843,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	if err := ctx.Err(); err != nil {
 		return finishSetupFailure(err, false)
 	}
-	selectedTimeout = selectedProcessRetryTimeout(argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
+	selectedTimeout = selectedProcessRetryTimeout(cfg.Batch != nil, argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
 	if selectedTimeout <= 0 {
 		return finishSetupFailure(context.DeadlineExceeded, true)
 	}
@@ -1865,6 +1885,14 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	}
 
 	resultPath := filepath.Join(tempDir, "result.json")
+	parentTestLogPath := argsSnapshot.testLogFile
+	childTestLogPath := ""
+	if cfg.Batch != nil && parentTestLogPath != "" {
+		if !filepath.IsAbs(parentTestLogPath) {
+			parentTestLogPath = filepath.Join(workingDir, parentTestLogPath)
+		}
+		childTestLogPath = filepath.Join(tempDir, "testlog.txt")
+	}
 	childCfg := cfg
 	childCfg.ResultPath = resultPath
 	childCfg.ObservedGOMAXPROCS = currentCPU
@@ -1941,7 +1969,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	selector := cfg.TestName
 	if childCfg.Batch != nil {
 		selector = "."
-		argsSnapshot = processRetryBatchArgsSnapshot(argsSnapshot)
+		argsSnapshot = processRetryBatchArgsSnapshot(argsSnapshot, childTestLogPath)
 	}
 	filteredArgs, ok, reason := buildProcessRetryArgsFromSnapshot(argsSnapshot, selector, currentCPU, childTestingTimeout)
 	if !ok {
@@ -2074,6 +2102,12 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	if releaseErr := releaseTree(); releaseErr != nil {
 		markContainmentLost(releaseErr)
 	}
+	if childTestLogPath != "" && !attempt.Unreaped {
+		if err := mergeProcessRetryTestLog(parentTestLogPath, childTestLogPath, workingDir); err != nil {
+			attempt.SetupFailure = true
+			attempt.Err = errors.Join(attempt.Err, errProcessRetryTestLogMerge, err)
+		}
+	}
 	result, timingOK, resultErr := readProcessRetryResult(resultPath, childCfg)
 	if resultErr != nil {
 		attempt.Err = errors.Join(attempt.Err, resultErr)
@@ -2104,9 +2138,38 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	return attempt
 }
 
-func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot) processRetryArgsSnapshot {
-	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false")
+func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot, testLogFile string) processRetryArgsSnapshot {
+	// Race and coverage counters are process-global, so parallel batch tests
+	// cannot reliably attribute their increments to the test that caused them.
+	// Preserve t.Parallel's scheduling while serializing the admitted bodies.
+	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false", "-test.parallel=1")
+	if testLogFile != "" {
+		snapshot.preserved = append(snapshot.preserved, "-test.testlogfile="+testLogFile)
+	}
 	return snapshot
+}
+
+func mergeProcessRetryTestLog(parentPath, childPath, childWorkingDirectory string) error {
+	childLog, err := os.ReadFile(childPath)
+	if err != nil {
+		return err
+	}
+	if !bytes.HasPrefix(childLog, []byte(processRetryTestLogMagic)) || childLog[len(childLog)-1] != '\n' {
+		return errors.New("invalid child test log")
+	}
+	records := childLog[len(processRetryTestLogMagic):]
+	if len(records) == 0 {
+		return nil
+	}
+	parentLog, err := os.OpenFile(parentPath, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return err
+	}
+	_, writeErr := io.WriteString(parentLog, "chdir "+childWorkingDirectory+"\n")
+	if writeErr == nil {
+		_, writeErr = parentLog.Write(records)
+	}
+	return errors.Join(writeErr, parentLog.Close())
 }
 
 func applyProcessRetryControlledTerminalState(
@@ -2158,6 +2221,7 @@ func finalizeProcessRetryOutputCaptures(
 }
 
 func selectedProcessRetryTimeout(
+	batch bool,
 	argTimeout time.Duration,
 	argTimeoutSet bool,
 	envTimeout time.Duration,
@@ -2167,6 +2231,9 @@ func selectedProcessRetryTimeout(
 	now time.Time,
 ) time.Duration {
 	selected := processRetryDefaultTimeout
+	if batch && argTimeoutSet {
+		selected = argTimeout
+	}
 	if envTimeoutSet {
 		selected = envTimeout
 	}
@@ -2689,7 +2756,7 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnapshot {
 	preserved, boundary, runSelector, skipSelector, ok, reason := processRetryFilterArgs(originalArgs, true)
 	timeout, timeoutSet := processRetryTimeoutFromArgs(originalArgs)
-	artifactOutput, artifactsEnabled := processRetryArtifactPolicyFromArgs(originalArgs)
+	artifactOutput, artifactsEnabled, testLogFile := processRetryOutputPolicyFromArgs(originalArgs)
 	return processRetryArgsSnapshot{
 		captured:         true,
 		preserved:        append([]string(nil), preserved...),
@@ -2698,6 +2765,7 @@ func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnap
 		skipSelector:     skipSelector,
 		artifactOutput:   artifactOutput,
 		artifactsEnabled: artifactsEnabled,
+		testLogFile:      testLogFile,
 		timeout:          timeout,
 		timeoutSet:       timeoutSet,
 		ok:               ok,
@@ -2744,7 +2812,7 @@ func buildProcessRetryArgsFromSnapshot(snapshot processRetryArgsSnapshot, testNa
 	return args, true, ""
 }
 
-func processRetryArtifactPolicyFromArgs(originalArgs []string) (outputDir string, enabled bool) {
+func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, artifactsEnabled bool, testLogFile string) {
 	for i := 0; i < len(originalArgs); i++ {
 		arg := originalArgs[i]
 		if arg == "--" || !processRetryIsFlagToken(arg) {
@@ -2759,14 +2827,16 @@ func processRetryArtifactPolicyFromArgs(originalArgs []string) (outputDir string
 		case "-test.outputdir":
 			outputDir = value
 		case "-test.artifacts":
-			enabled = true
+			artifactsEnabled = true
 			if hasValue {
 				parsed, err := strconv.ParseBool(value)
-				enabled = err == nil && parsed
+				artifactsEnabled = err == nil && parsed
 			}
+		case "-test.testlogfile":
+			testLogFile = value
 		}
 	}
-	return outputDir, enabled
+	return outputDir, artifactsEnabled, testLogFile
 }
 
 func processRetryTimeoutFromArgs(originalArgs []string) (time.Duration, bool) {
@@ -3182,6 +3252,14 @@ func configureProcessRetryBatchChildWorkloads(
 ) testingMFinalizer {
 	batchRaceCheckpoint := &atomic.Int64{}
 	batchRaceCheckpoint.Store(retryAttemptRaceErrors())
+	processCoverageProfile, err := coverage.BeginProcessCoverageProfile()
+	if err != nil {
+		log.Debug("civisibility: failed to capture isolated first-attempt coverage baseline: %s", err.Error())
+	}
+	finalizeCoverage := &processRetryBatchCoverageFinalizer{
+		profile: processCoverageProfile,
+		path:    processRetryBatchCoveragePath(cfg.ResultPath),
+	}
 	available := make(map[string]testing.InternalTest, len(*tests))
 	for _, test := range *tests {
 		available[test.Name] = test
@@ -3191,6 +3269,7 @@ func configureProcessRetryBatchChildWorkloads(
 	for index, spec := range cfg.Batch.Tests {
 		childCfg := processRetryBatchChildConfig(cfg, index, spec)
 		childCfg.batchRaceCheckpoint = batchRaceCheckpoint
+		childCfg.batchCoverageFinalizer = finalizeCoverage
 		test, ok := available[spec.TestName]
 		if !ok {
 			newProcessRetryResultWriter(childCfg.ResultPath).Write(processRetryNotRunResult(childCfg, ""))
@@ -3209,9 +3288,7 @@ func configureProcessRetryBatchChildWorkloads(
 		for _, finalizeTest := range finalizers {
 			finalizeTest()
 		}
-		if err := coverage.WriteProcessCoverageProfile(processRetryBatchCoveragePath(cfg.ResultPath)); err != nil {
-			log.Debug("civisibility: failed to write isolated first-attempt coverage: %s", err.Error())
-		}
+		finalizeCoverage.run()
 		writer.Write(processRetryNotRunResult(cfg, ""))
 		return finalize(exitCode)
 	}
@@ -3395,6 +3472,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		} else {
 			observation.writeFinalResult()
 		}
+		finalizeProcessRetryBatchCoverageBeforeTerminalReplay(cfg, result)
 
 		if result.failed || result.raceDetected || result.panicData != nil || result.cleanupPanicData != nil {
 			t.Fail()
@@ -3414,6 +3492,16 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		}
 	}
 	return wrapped, observation.writeFinalResult
+}
+
+func finalizeProcessRetryBatchCoverageBeforeTerminalReplay(cfg processRetryChildConfig, result retryAttemptResult) {
+	if requiresProcessRetryBatchCoverageFlush(result) {
+		cfg.batchCoverageFinalizer.run()
+	}
+}
+
+func requiresProcessRetryBatchCoverageFlush(result retryAttemptResult) bool {
+	return result.nativeFatalTraceReplay || result.panicData != nil || result.cleanupPanicData != nil
 }
 
 func processRetryControlledTerminalStatus(result retryAttemptResult) processRetryStatus {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -700,7 +700,7 @@ func (c *processRetryOutputCapture) ChildWriter() *os.File {
 	return c.writePipe
 }
 
-func (c *processRetryOutputCapture) StartCopy() {
+func (c *processRetryOutputCapture) StartCopy(stream io.Writer) {
 	if c == nil {
 		return
 	}
@@ -714,12 +714,25 @@ func (c *processRetryOutputCapture) StartCopy() {
 	readPipe := c.readPipe
 	c.mu.Unlock()
 	go func() {
-		_, copyErr := io.Copy(sink, readPipe)
+		_, copyErr := io.Copy(processRetryCaptureWriter{capture: sink, stream: stream}, readPipe)
 		c.complete(errors.Join(
 			ignoreProcessRetryClosedError(copyErr),
 			ignoreProcessRetryClosedError(readPipe.Close()),
 		))
 	}()
+}
+
+type processRetryCaptureWriter struct {
+	capture io.Writer
+	stream  io.Writer
+}
+
+func (w processRetryCaptureWriter) Write(p []byte) (int, error) {
+	n, err := w.capture.Write(p)
+	if w.stream != nil {
+		_, _ = w.stream.Write(p[:n])
+	}
+	return n, err
 }
 
 func ignoreProcessRetryClosedError(err error) error {
@@ -942,13 +955,64 @@ func combineProcessRetryOutputTails(stdout, stderr *processRetryOutputCapture, m
 
 func filterProcessRetryBatchOutput(output string) string {
 	var filtered strings.Builder
-	for line := range strings.SplitAfterSeq(output, "\n") {
-		if strings.HasPrefix(line, "\x16") {
-			continue
-		}
-		filtered.WriteString(line)
-	}
+	_, _ = io.WriteString(newProcessRetryBatchOutputWriter(&filtered), output)
 	return filtered.String()
+}
+
+type processRetryBatchOutputWriter struct {
+	destination io.Writer
+	lineStart   bool
+	dropLine    bool
+}
+
+func newProcessRetryBatchOutputWriter(destination io.Writer) *processRetryBatchOutputWriter {
+	return &processRetryBatchOutputWriter{destination: destination, lineStart: true}
+}
+
+func (w *processRetryBatchOutputWriter) Write(p []byte) (int, error) {
+	written, offset, kept := 0, 0, 0
+	flush := func(end int) error {
+		if end == kept {
+			return nil
+		}
+		n, err := w.destination.Write(p[kept:end])
+		written = kept + n
+		if err != nil {
+			return err
+		}
+		if written != end {
+			return io.ErrShortWrite
+		}
+		kept = end
+		return nil
+	}
+	for offset < len(p) {
+		if w.lineStart {
+			w.dropLine = p[offset] == retryAttemptOutputMarker
+			w.lineStart = false
+		}
+		newline := bytes.IndexByte(p[offset:], '\n')
+		end := len(p)
+		if newline >= 0 {
+			end = offset + newline + 1
+		}
+		if w.dropLine {
+			if err := flush(offset); err != nil {
+				return written, err
+			}
+			written = end
+			kept = end
+		}
+		if newline >= 0 {
+			w.lineStart = true
+			w.dropLine = false
+		}
+		offset = end
+	}
+	if err := flush(len(p)); err != nil {
+		return written, err
+	}
+	return len(p), nil
 }
 
 type processRetryAttemptResult struct {
@@ -969,6 +1033,7 @@ type processRetryAttemptResult struct {
 	BodyAdmitted                bool
 	ControlledTerminalCommitted bool
 	testLogMerge                *processRetryTestLogMerge
+	outputStreamed              bool
 	Cleanup                     func()
 }
 
@@ -2061,8 +2126,14 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	}
 	cmd.Args = append([]string{executable}, filteredArgs...)
 
-	stdoutCapture.StartCopy()
-	stderrCapture.StartCopy()
+	var stdoutStream, stderrStream io.Writer
+	if childCfg.Batch != nil && childCfg.Batch.PreserveNativeSchedule {
+		stdoutStream = newProcessRetryBatchOutputWriter(os.Stdout)
+		stderrStream = os.Stderr
+		attempt.outputStreamed = true
+	}
+	stdoutCapture.StartCopy(stdoutStream)
+	stderrCapture.StartCopy(stderrStream)
 	waitCh, startErr := startProcessRetryChild(ctx, attemptTimer.C(), hooks, cmd)
 	if control != nil {
 		attempt.Err = errors.Join(attempt.Err, control.CloseChildEndpoints())
@@ -3925,6 +3996,13 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			execMeta.hasExplicitAttemptToFix = true
 			execMeta.shouldOrchestrateAttemptToFix = true
 		}
+		quarantined := root != nil && root.cfg.batchTest != nil && slices.Contains(root.cfg.batchTest.QuarantinedSubtests, t.Name())
+		if quarantined {
+			execMeta.isQuarantined = true
+			execMeta.hasExplicitQuarantined = true
+		}
+		managed := attemptToFix || quarantined
+		managedResultCollected := false
 		var finishOnce sync.Once
 		finish := func() {
 			finishOnce.Do(func() {
@@ -3940,7 +4018,7 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 						collector.finishNativeAttemptToFix(order, start, t, execMeta, source, files)
 						collector.completeAttemptToFix(t.Name())
 					}
-				} else {
+				} else if !managedResultCollected {
 					collector.finish(order, start, t, execMeta, source, files)
 				}
 				restoreChatty()
@@ -3984,14 +4062,14 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				*parentBarrier = nil
 			}
 		}
-		if collectCoverage && attemptToFix {
+		if collectCoverage && managed {
 			suppressParallelCoverage()
 		}
-		var attemptToFixGroup *retryAttemptGroup
-		if attemptToFix {
-			attemptToFixGroup, _ = newRetryAttemptGroupWithOutputObservation(t, true)
+		var managedGroup *retryAttemptGroup
+		if managed {
+			managedGroup, _ = newRetryAttemptGroupWithOutputObservation(t, true)
 		}
-		if collectCoverage && (!attemptToFix || attemptToFixGroup == nil) {
+		if collectCoverage && (!managed || managedGroup == nil) {
 			subtestCoverage = coverage.BeginProcessTestCoverage(source.RuntimePath)
 			if subtestCoverage != nil && parentBarrier == nil {
 				suppressParallelCoverage()
@@ -4000,8 +4078,11 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				parentBarrier = nil
 			}
 		}
-		if attemptToFix {
-			runProcessRetryChildAttemptToFixSubtest(t, original, owner, collector, source, attemptToFixGroup, root.cfg.attemptToFixRetries, execMeta.isItrForcedRun, collectCoverage)
+		if managed {
+			runProcessRetryChildManagedSubtest(t, original, owner, collector, source, managedGroup, root.cfg.attemptToFixRetries, attemptToFix, quarantined, execMeta.isItrForcedRun, collectCoverage, &managedResultCollected)
+			if quarantined {
+				t.SkipNow()
+			}
 			return
 		}
 
@@ -4034,8 +4115,11 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 	}
 }
 
-func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testing.T), owner *testExecutionMetadata, collector *processRetrySubtestCollector, source *processRetryTestSource, group *retryAttemptGroup, retries int, itrForcedRun, collectCoverage bool) {
+func runProcessRetryChildManagedSubtest(t *testing.T, original func(*testing.T), owner *testExecutionMetadata, collector *processRetrySubtestCollector, source *processRetryTestSource, group *retryAttemptGroup, retries int, attemptToFix, quarantined, itrForcedRun, collectCoverage bool, resultCollected *bool) {
 	if group == nil {
+		if quarantined {
+			t.SkipNow()
+		}
 		original(t)
 		return
 	}
@@ -4052,10 +4136,12 @@ func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testin
 			execMeta.identity = identity
 			execMeta.test = owner.test
 			execMeta.processRetryOwner = owner
-			execMeta.isAttemptToFix = true
+			execMeta.isAttemptToFix = attemptToFix
+			execMeta.isQuarantined = quarantined
 			execMeta.isItrForcedRun = itrForcedRun
-			execMeta.hasExplicitAttemptToFix = true
-			execMeta.shouldOrchestrateAttemptToFix = true
+			execMeta.hasExplicitAttemptToFix = attemptToFix
+			execMeta.hasExplicitQuarantined = quarantined
+			execMeta.shouldOrchestrateAttemptToFix = attemptToFix
 			execMeta.suppressParentRetryMetadata = true
 			if preparedIndex == executionIndex {
 				return
@@ -4067,22 +4153,34 @@ func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testin
 				attemptCoverage = coverage.BeginProcessTestCoverage(source.RuntimePath)
 			}
 			execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
-				collector.finishAttemptToFix(order, start, execMeta.freshRetryAttemptTest, execMeta, source, attemptCoverage.Finish(), executionIndex, result)
+				files := attemptCoverage.Finish()
+				if attemptToFix {
+					collector.finishAttemptToFix(order, start, execMeta.freshRetryAttemptTest, execMeta, source, files, executionIndex, result)
+				} else {
+					collector.finishWithAttempt(order, start, execMeta.freshRetryAttemptTest, execMeta, source, files, -1, &result)
+				}
+				*resultCollected = true
 			}
 		},
 		preIsLastRetry: func(_ *testExecutionMetadata, _ int, remainingRetries int64) bool {
 			return remainingRetries == 1
 		},
 		postAdjustRetryCount: func(*testExecutionMetadata, time.Duration) int64 {
+			if !attemptToFix {
+				return 0
+			}
 			return int64(retries)
 		},
 		postPerExecution: func(attempt *testing.T, _ *testExecutionMetadata, _ int, _ time.Duration) {
 			outcomes.observe(attempt.Failed(), attempt.Skipped())
 		},
 		postShouldRetry: func(_ *testing.T, _ *testExecutionMetadata, _ int, remainingRetries int64) bool {
-			return remainingRetries > 0
+			return attemptToFix && remainingRetries > 0
 		},
 		postOnRetryEnd: func(t *testing.T, _ int, last *testing.T, result retryGroupPolicyResult) {
+			if quarantined {
+				return
+			}
 			if result.failfastRawFailure || result.lateFailure || outcomes.anyFailed() {
 				t.Fail()
 			} else if last.Skipped() {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -116,8 +116,10 @@ type processRetryChildConfig struct {
 	BatchChild             bool
 	CollectPerTestCoverage bool
 	batchTest              *processRetryBatchTestConfig
-	batchRaceCheckpoint    *atomic.Int64
 	batchCoverageFinalizer *processRetryBatchCoverageFinalizer
+	nativeGatePath         string
+	nativeParallelPath     string
+	tempDir                string
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -1870,9 +1872,13 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 			return remainingAttemptTime() <= 0
 		}
 	}
-	tempDir, err := os.MkdirTemp("", "dd-process-retry-*")
-	if err != nil {
-		return finishSetupFailure(err, false)
+	tempDir := cfg.tempDir
+	if tempDir == "" {
+		var err error
+		tempDir, err = os.MkdirTemp("", "dd-process-retry-*")
+		if err != nil {
+			return finishSetupFailure(err, false)
+		}
 	}
 	attempt.TempDir = tempDir
 	var cleanupOnce sync.Once
@@ -2139,10 +2145,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 }
 
 func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot, testLogFile string) processRetryArgsSnapshot {
-	// Race and coverage counters are process-global, so parallel batch tests
-	// cannot reliably attribute their increments to the test that caused them.
-	// Preserve t.Parallel's scheduling while serializing the admitted bodies.
-	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false", "-test.parallel=1")
+	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false")
 	if testLogFile != "" {
 		snapshot.preserved = append(snapshot.preserved, "-test.testlogfile="+testLogFile)
 	}
@@ -3250,8 +3253,6 @@ func configureProcessRetryBatchChildWorkloads(
 	fuzzTargets *[]testing.InternalFuzzTarget,
 	examples *[]testing.InternalExample,
 ) testingMFinalizer {
-	batchRaceCheckpoint := &atomic.Int64{}
-	batchRaceCheckpoint.Store(retryAttemptRaceErrors())
 	processCoverageProfile, err := coverage.BeginProcessCoverageProfile()
 	if err != nil {
 		log.Debug("civisibility: failed to capture isolated first-attempt coverage baseline: %s", err.Error())
@@ -3268,7 +3269,6 @@ func configureProcessRetryBatchChildWorkloads(
 	finalizers := make([]func(), 0, len(cfg.Batch.Tests))
 	for index, spec := range cfg.Batch.Tests {
 		childCfg := processRetryBatchChildConfig(cfg, index, spec)
-		childCfg.batchRaceCheckpoint = batchRaceCheckpoint
 		childCfg.batchCoverageFinalizer = finalizeCoverage
 		test, ok := available[spec.TestName]
 		if !ok {
@@ -3406,6 +3406,17 @@ type processRetryChildObservation struct {
 func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildConfig, writer *processRetryResultWriter, control *processRetryControl) (func(*testing.T), func()) {
 	observation := &processRetryChildObservation{cfg: cfg, writer: writer}
 	wrapped := func(t *testing.T) {
+		if cfg.nativeGatePath != "" {
+			deadline, deadlineOK := time.Time{}, false
+			if cfg.ParentDeadlineOK {
+				deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
+			}
+			if err := waitForProcessRetryBatchGate(cfg.nativeGatePath, deadline, deadlineOK); err != nil {
+				writer.Write(processRetryNotRunResult(cfg, err.Error()))
+				t.Fail()
+				return
+			}
+		}
 		start := time.Now()
 		observation.test = t
 		observation.startTime = start
@@ -3418,11 +3429,20 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		}
 		if cfg.BatchChild {
 			group.outputLimit = processRetryResultOutputMaxBytes
+			// Runtime coverage counters are process-global. Keep the native
+			// t.Parallel admission, but serialize covered bodies while each
+			// test owns the counter delta that becomes its coverage payload.
 			group.suppressOriginalParallelTransition = cfg.CollectPerTestCoverage
-			group.raceCheckpoint = cfg.batchRaceCheckpoint
 		}
 		observation.group = group
-		if control != nil {
+		if cfg.nativeParallelPath != "" {
+			// The parent must learn about t.Parallel before this child waits on
+			// its own package barrier, otherwise both native schedulers wait for
+			// the other process to enumerate the next test.
+			group.rootParallelAnnounce = func() error {
+				return os.WriteFile(cfg.nativeParallelPath, nil, processRetryBatchManifestMode)
+			}
+		} else if control != nil {
 			group.rootParallelBridge = control.childRootParallelBridge
 		}
 		defer group.retire()

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -4522,7 +4522,7 @@ func (c *processRetrySubtestCollector) completeAttemptToFix(name string, files [
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for index := len(c.results) - 1; index >= 0; index-- {
+	for index := range slices.Backward(c.results) {
 		if result := &c.results[index]; result.TestName == name && result.AttemptToFix {
 			result.AttemptToFixLast = true
 			result.Coverage = files

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -7,6 +7,7 @@ package gotesting
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -109,6 +110,8 @@ type processRetryChildConfig struct {
 	ParentDeadlineUnixNano int64
 	ParentDeadlineOK       bool
 	ObservedGOMAXPROCS     int
+	Batch                  *processRetryBatchConfig
+	BatchChild             bool
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -128,7 +131,9 @@ const (
 	processRetryErrorStackMaxBytes         = 32 * 1024
 	processRetrySkipReasonMaxBytes         = 8 * 1024
 	processRetryResultErrorMaxBytes        = 256
+	processRetryResultOutputMaxBytes       = 8 * 1024
 	processRetryResultMaxBytes             = 64 * 1024
+	processRetryResultWithSubtestsMaxBytes = 16 * 1024 * 1024
 	processRetryTruncationMarker           = "[dd-trace-go: process retry panic data truncated]"
 	processRetryMetadataTruncationMarker   = "[dd-trace-go: process retry metadata truncated]"
 	processRetryOutputTruncationMarker     = "\n[dd-trace-go: process retry output truncated]\n"
@@ -147,32 +152,70 @@ const (
 )
 
 type processRetryResult struct {
-	Version           int                `json:"version"`
-	TestName          string             `json:"test_name"`
-	Attempt           int                `json:"attempt"`
-	RetryReason       string             `json:"retry_reason"`
-	MRunEpoch         uint64             `json:"m_run_epoch,omitempty"`
-	InvocationOrdinal uint64             `json:"invocation_ordinal,omitempty"`
-	Status            processRetryStatus `json:"status"`
-	StartUnixNano     int64              `json:"start_unix_nano"`
-	FinishUnixNano    int64              `json:"finish_unix_nano"`
-	DurationNanos     int64              `json:"duration_nanos"`
-	Failed            bool               `json:"failed"`
-	Skipped           bool               `json:"skipped"`
-	Panic             bool               `json:"panic"`
-	RaceDetected      bool               `json:"race_detected,omitempty"`
-	RootParallel      bool               `json:"root_parallel,omitempty"`
-	ErrorType         string             `json:"error_type,omitempty"`
-	ErrorMessage      string             `json:"error_message,omitempty"`
-	ErrorStack        string             `json:"error_stack,omitempty"`
-	SkipReason        string             `json:"skip_reason,omitempty"`
-	ResultError       string             `json:"result_error,omitempty"`
+	Version           int                         `json:"version"`
+	TestName          string                      `json:"test_name"`
+	Attempt           int                         `json:"attempt"`
+	RetryReason       string                      `json:"retry_reason"`
+	MRunEpoch         uint64                      `json:"m_run_epoch,omitempty"`
+	InvocationOrdinal uint64                      `json:"invocation_ordinal,omitempty"`
+	Status            processRetryStatus          `json:"status"`
+	StartUnixNano     int64                       `json:"start_unix_nano"`
+	FinishUnixNano    int64                       `json:"finish_unix_nano"`
+	DurationNanos     int64                       `json:"duration_nanos"`
+	Failed            bool                        `json:"failed"`
+	Skipped           bool                        `json:"skipped"`
+	Panic             bool                        `json:"panic"`
+	RaceDetected      bool                        `json:"race_detected,omitempty"`
+	RootParallel      bool                        `json:"root_parallel,omitempty"`
+	ErrorType         string                      `json:"error_type,omitempty"`
+	ErrorMessage      string                      `json:"error_message,omitempty"`
+	ErrorStack        string                      `json:"error_stack,omitempty"`
+	SkipReason        string                      `json:"skip_reason,omitempty"`
+	ResultError       string                      `json:"result_error,omitempty"`
+	OutputTail        string                      `json:"output_tail,omitempty"`
+	OutputTruncated   bool                        `json:"output_truncated,omitempty"`
+	Subtests          []processRetrySubtestResult `json:"subtests,omitempty"`
+}
+
+type processRetrySubtestResult struct {
+	TestName       string             `json:"test_name"`
+	Status         processRetryStatus `json:"status"`
+	StartUnixNano  int64              `json:"start_unix_nano"`
+	FinishUnixNano int64              `json:"finish_unix_nano"`
+	DurationNanos  int64              `json:"duration_nanos"`
+	Failed         bool               `json:"failed"`
+	Skipped        bool               `json:"skipped"`
+	Panic          bool               `json:"panic"`
+	ErrorType      string             `json:"error_type,omitempty"`
+	ErrorMessage   string             `json:"error_message,omitempty"`
+	ErrorStack     string             `json:"error_stack,omitempty"`
+	SkipReason     string             `json:"skip_reason,omitempty"`
+	order          uint64
 }
 
 type processRetryErrorInfo struct {
 	Type    string
 	Message string
 	Stack   string
+}
+
+func completedProcessRetryAttempt(result processRetryResult) processRetryAttemptResult {
+	attempt := processRetryAttemptResult{
+		Result:             result,
+		OutputTail:         result.OutputTail,
+		OutputTruncated:    result.OutputTruncated,
+		ExitStatusObserved: true,
+		StartTime:          time.Unix(0, result.StartUnixNano),
+		FinishTime:         time.Unix(0, result.FinishUnixNano),
+	}
+	if result.OutputTruncated {
+		attempt.OutputTail = processRetryOutputTruncationMarker + attempt.OutputTail
+	}
+	if result.Panic {
+		attempt.ExitCode = processRetryControlledPanicExitCode
+		attempt.ControlledTerminalCommitted = true
+	}
+	return attempt
 }
 
 var (
@@ -245,6 +288,13 @@ func bootstrapProcessRetryChild() (processRetryChildConfig, error) {
 		cfg = enrichProcessRetryChildConfig(cfg, wire)
 		cfg.controlConfig = wire
 		cfg.controlConfigLoaded = true
+	}
+	if cfg.TestName == processRetryBatchTestName {
+		batch, batchErr := readProcessRetryBatchConfig(processRetryBatchManifestPath(cfg.ResultPath))
+		if batchErr != nil {
+			return cfg, batchErr
+		}
+		cfg.Batch = batch
 	}
 	if integrations.ProcessRetryChildTransportError() != nil {
 		return cfg, errors.New("retry child transport cleanup failed")
@@ -1807,6 +1857,11 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	if parentDeadlineOK {
 		childCfg.ParentDeadlineUnixNano = parentDeadline.UnixNano()
 	}
+	if childCfg.Batch != nil {
+		if err := writeProcessRetryBatchConfig(processRetryBatchManifestPath(resultPath), childCfg.Batch); err != nil {
+			return finishSetupFailure(err, false)
+		}
+	}
 	stdoutCapture, err := newProcessRetryOutputCapture(processRetryStreamMaxBytes)
 	if err != nil {
 		return finishSetupFailure(err, false)
@@ -1868,7 +1923,14 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	}
 	selectedTimeout = latestTimeout
 	childTestingTimeout := selectedTimeout + processRetryParentDeadlineReserve()
-	filteredArgs, ok, reason := buildProcessRetryArgsFromSnapshot(argsSnapshot, cfg.TestName, currentCPU, childTestingTimeout)
+	selector := cfg.TestName
+	if childCfg.Batch != nil {
+		selector = "."
+		argsSnapshot.runSelector = ""
+		argsSnapshot.skipSelector = ""
+		argsSnapshot.preserved = append(append([]string(nil), argsSnapshot.preserved...), "-test.failfast=false")
+	}
+	filteredArgs, ok, reason := buildProcessRetryArgsFromSnapshot(argsSnapshot, selector, currentCPU, childTestingTimeout)
 	if !ok {
 		closeCapturesForSetupFailure()
 		return finishSetupFailure(errors.Join(errors.New(reason), releaseTree()), false)
@@ -2438,6 +2500,7 @@ func finishProcessRetryTestEvent(
 		}
 		return effective
 	}
+	finishProcessRetrySubtestEvents(testInfo, execMeta, attempt)
 	module := session.GetOrCreateModule(testInfo.moduleName)
 	suite := module.GetOrCreateSuite(testInfo.suiteName)
 	test := suite.CreateTest(testInfo.testName, integrations.WithTestStartTime(attempt.StartTime))
@@ -2530,6 +2593,70 @@ func finishProcessRetryTestEvent(
 		test.Close(integrations.ResultStatusPass, closeOpts...)
 	}
 	return effective
+}
+
+func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecutionMetadata, attempt processRetryAttemptResult) {
+	if testInfo == nil || parentMeta == nil || len(attempt.Result.Subtests) == 0 {
+		return
+	}
+	parentSnapshot := snapshotProcessRetryExecutionMetadata(parentMeta)
+	if parentSnapshot == nil {
+		return
+	}
+	for _, result := range attempt.Result.Subtests {
+		identity := newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName)
+		execMeta := &testExecutionMetadata{}
+		if !applyProcessRetryMetadataSnapshot(execMeta, parentSnapshot) {
+			continue
+		}
+		execMeta.identity = identity
+		execMeta.isARetry = parentMeta.isARetry
+		execMeta.isLastRetry = parentMeta.isLastRetry
+		execMeta.remainingRetries = parentMeta.remainingRetries
+		execMeta.initialRetryCount = parentMeta.initialRetryCount
+		execMeta.initialRetryCountSet = parentMeta.initialRetryCountSet
+		execMeta.retryContinuationDecided = parentMeta.retryContinuationDecided
+		execMeta.retryContinuationAdmitted = parentMeta.retryContinuationAdmitted
+		execMeta.shouldOrchestrateAttemptToFix = false
+		execMeta.isEarlyFlakeDetectionEnabled = false
+		execMeta.isFlakyTestRetriesEnabled = false
+		if data, matchKind, ok := getTestManagementData(identity); ok && matchKind == testManagementMatchExact && data != nil {
+			execMeta.suppressParentRetryMetadata = true
+			execMeta.isARetry = false
+			execMeta.isEfdInParallel = false
+			execMeta.isQuarantined = execMeta.isQuarantined || data.Quarantined
+			execMeta.isDisabled = execMeta.isDisabled || data.Disabled
+			execMeta.isAttemptToFix = data.AttemptToFix
+			execMeta.hasExplicitQuarantined = true
+			execMeta.hasExplicitDisabled = true
+			execMeta.hasExplicitAttemptToFix = true
+		}
+		execMeta.anyExecutionPassed = result.Status == processRetryStatusPass
+		execMeta.anyExecutionFailed = result.Failed
+		execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
+		execMeta.allRetriesFailed = result.Failed
+		childAttempt := completedProcessRetryAttempt(processRetryResult{
+			Version:        1,
+			TestName:       result.TestName,
+			Status:         result.Status,
+			StartUnixNano:  result.StartUnixNano,
+			FinishUnixNano: result.FinishUnixNano,
+			DurationNanos:  result.DurationNanos,
+			Failed:         result.Failed,
+			Skipped:        result.Skipped,
+			Panic:          result.Panic,
+			ErrorType:      result.ErrorType,
+			ErrorMessage:   result.ErrorMessage,
+			ErrorStack:     result.ErrorStack,
+			SkipReason:     result.SkipReason,
+		})
+		finishProcessRetryTestEvent(&commonInfo{
+			moduleName: testInfo.moduleName,
+			suiteName:  testInfo.suiteName,
+			testName:   result.TestName,
+			identity:   identity,
+		}, execMeta, childAttempt, nil, nil)
+	}
 }
 
 func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnapshot {
@@ -2767,6 +2894,9 @@ func processRetryChildRunPattern(originalRun, testName string) string {
 	if originalRun != "" {
 		return originalRun
 	}
+	if testName == "." {
+		return "."
+	}
 	return "^" + regexp.QuoteMeta(testName) + "$"
 }
 
@@ -2979,6 +3109,9 @@ func configureProcessRetryChildWorkloads(
 		hardStop("testing_m_reflection_drift")
 		return finalize
 	}
+	if cfg.Batch != nil {
+		return configureProcessRetryBatchChildWorkloads(cfg, writer, finalize, tests, benchmarks, fuzzTargets, examples)
+	}
 
 	var selected testing.InternalTest
 	found := false
@@ -3004,6 +3137,46 @@ func configureProcessRetryChildWorkloads(
 	*tests = []testing.InternalTest{selected}
 	return func(exitCode int) int {
 		finalizeSelected()
+		return finalize(exitCode)
+	}
+}
+
+func configureProcessRetryBatchChildWorkloads(
+	cfg processRetryChildConfig,
+	writer *processRetryResultWriter,
+	finalize testingMFinalizer,
+	tests *[]testing.InternalTest,
+	benchmarks *[]testing.InternalBenchmark,
+	fuzzTargets *[]testing.InternalFuzzTarget,
+	examples *[]testing.InternalExample,
+) testingMFinalizer {
+	available := make(map[string]testing.InternalTest, len(*tests))
+	for _, test := range *tests {
+		available[test.Name] = test
+	}
+	selected := make([]testing.InternalTest, 0, len(cfg.Batch.Tests))
+	finalizers := make([]func(), 0, len(cfg.Batch.Tests))
+	for index, spec := range cfg.Batch.Tests {
+		childCfg := processRetryBatchChildConfig(cfg, index, spec)
+		test, ok := available[spec.TestName]
+		if !ok {
+			newProcessRetryResultWriter(childCfg.ResultPath).Write(processRetryNotRunResult(childCfg, ""))
+			continue
+		}
+		wrapped, finalizeTest := wrapProcessRetryChildTest(test.F, childCfg, newProcessRetryResultWriter(childCfg.ResultPath), nil)
+		test.F = wrapped
+		selected = append(selected, test)
+		finalizers = append(finalizers, finalizeTest)
+	}
+	*tests = selected
+	*benchmarks = nil
+	*fuzzTargets = nil
+	*examples = nil
+	return func(exitCode int) int {
+		for _, finalizeTest := range finalizers {
+			finalizeTest()
+		}
+		writer.Write(processRetryNotRunResult(cfg, ""))
 		return finalize(exitCode)
 	}
 }
@@ -3123,23 +3296,34 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		observation.test = t
 		observation.startTime = start
 
-		group, reason := newRetryAttemptGroupWithOutputObservation(t, false)
+		group, reason := newRetryAttemptGroupWithOutputObservation(t, cfg.BatchChild)
 		if reason != "" {
 			writer.Write(processRetryNotRunResult(cfg, "testing_t_reflection_drift"))
 			t.Fail()
 			return
 		}
+		if cfg.BatchChild {
+			group.outputLimit = processRetryResultOutputMaxBytes
+		}
 		observation.group = group
-		group.rootParallelBridge = control.childRootParallelBridge
+		if control != nil {
+			group.rootParallelBridge = control.childRootParallelBridge
+		}
 		defer group.retire()
 
 		prepare := func(attempt *retryAttemptRoot) string {
-			deadline, deadlineOK := control.logicalDeadline()
+			deadline, deadlineOK := time.Time{}, false
+			if control != nil {
+				deadline, deadlineOK = control.logicalDeadline()
+			} else if cfg.ParentDeadlineOK {
+				deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
+			}
 			if !setRetryAttemptLogicalDeadline(attempt, deadline, deadlineOK) {
 				return "testing_t_reflection_drift"
 			}
 			execMeta := createTestMetadata(attempt.test, nil)
 			attempt.metadata = execMeta
+			execMeta.hasAdditionalFeatureWrapper = true
 			execMeta.identity = newTestIdentity("", "", cfg.TestName)
 			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
 			observation.execMeta = execMeta
@@ -3152,7 +3336,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			return
 		}
 		observation.result = result
-		if status := processRetryControlledTerminalStatus(result); status != "" {
+		if status := processRetryControlledTerminalStatus(result); status != "" && control != nil {
 			observation.writeControlledTerminalResult(control, status)
 		} else {
 			observation.writeFinalResult()
@@ -3252,6 +3436,13 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		RaceDetected:      o.result.raceDetected,
 		RootParallel:      rootParallel,
 	}
+	if o.cfg.BatchChild {
+		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(o.result.output)
+		result.OutputTruncated = result.OutputTruncated || o.result.outputTruncated
+	}
+	if root, ok := o.execMeta.test.(*processRetryNoopTest); ok {
+		result.Subtests = root.snapshotSubtests()
+	}
 	if result.Failed {
 		if panicInfo := o.execMeta.processRetryPanic.Load(); result.Panic && panicInfo != nil {
 			result.ErrorType = panicInfo.Type
@@ -3300,12 +3491,18 @@ func processRetryChildOwnerMetadata(execMeta *testExecutionMetadata) *testExecut
 }
 
 func recordProcessRetryChildErrorInfo(tb testing.TB, errType, errMessage string, stackSkip int) {
-	if execMeta := processRetryChildOwnerMetadata(getTestMetadata(tb)); execMeta != nil {
-		execMeta.processRetryError.CompareAndSwap(nil, &processRetryErrorInfo{
-			Type:    truncateProcessRetryErrorType(errType),
-			Message: truncateProcessRetryStructuredErrorMessage(errMessage),
-			Stack:   truncateProcessRetryStructuredErrorStack(utils.GetStacktrace(stackSkip)),
-		})
+	execMeta := getTestMetadata(tb)
+	if execMeta == nil {
+		return
+	}
+	info := &processRetryErrorInfo{
+		Type:    truncateProcessRetryErrorType(errType),
+		Message: truncateProcessRetryStructuredErrorMessage(errMessage),
+		Stack:   truncateProcessRetryStructuredErrorStack(utils.GetStacktrace(stackSkip)),
+	}
+	execMeta.processRetryError.CompareAndSwap(nil, info)
+	if owner := processRetryChildOwnerMetadata(execMeta); owner != nil && owner != execMeta {
+		owner.processRetryError.CompareAndSwap(nil, info)
 	}
 }
 
@@ -3343,7 +3540,21 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		execMeta := createTestMetadata(t, nil)
 		execMeta.test = owner.test
 		execMeta.processRetryOwner = owner
-		t.Cleanup(func() { deleteTestMetadata(t) })
+		var collector *processRetrySubtestCollector
+		var order uint64
+		var start time.Time
+		if root, ok := owner.test.(*processRetryNoopTest); ok {
+			collector = &root.subtests
+			order, start = collector.begin()
+		}
+		var finishOnce sync.Once
+		finish := func() {
+			finishOnce.Do(func() {
+				collector.finish(order, start, t, execMeta)
+				deleteTestMetadata(t)
+			})
+		}
+		t.Cleanup(finish)
 
 		bodyReturned := false
 		defer func() {
@@ -3356,12 +3567,15 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			if panicData == nil {
 				return
 			}
-			owner.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
+			info := &processRetryErrorInfo{
 				Type:    "panic",
 				Message: truncateProcessRetryErrorMessage(toString(panicData)),
 				Stack:   truncateProcessRetryErrorStack(utils.GetStacktrace(1)),
-			})
+			}
+			execMeta.processRetryPanic.CompareAndSwap(nil, info)
+			owner.processRetryPanic.CompareAndSwap(nil, info)
 			if root, ok := owner.test.(*processRetryNoopTest); ok {
+				finish()
 				root.writePanicResult(owner.processRetryPanic.Load())
 			}
 			if unexpectedTermination {
@@ -3460,6 +3674,26 @@ func truncateProcessRetryString(value string, maxBytes int, marker string) strin
 	return string(runes[:low]) + marker
 }
 
+func truncateProcessRetryOutputTail(output []byte) (string, bool) {
+	raw := string(output)
+	normalized := strings.ToValidUTF8(raw, "\uFFFD")
+	truncated := normalized != raw
+	if processRetryJSONStringFits(normalized, processRetryResultOutputMaxBytes) {
+		return normalized, truncated
+	}
+	runes := []rune(normalized)
+	low, high := 0, len(runes)
+	for low < high {
+		mid := low + (high-low+1)/2
+		if processRetryJSONStringFits(string(runes[len(runes)-mid:]), processRetryResultOutputMaxBytes) {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	return string(runes[len(runes)-low:]), true
+}
+
 func processRetryJSONStringFits(value string, maxBytes int) bool {
 	if len(value) > maxBytes {
 		return false
@@ -3473,7 +3707,11 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 	if err != nil {
 		return err
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	maxBytes := processRetryResultMaxBytes
+	if len(result.Subtests) > 0 {
+		maxBytes = processRetryResultWithSubtestsMaxBytes
+	}
+	if len(payload) > maxBytes {
 		return errors.New("process_retry_result_too_large")
 	}
 	dir := filepath.Dir(resultPath)
@@ -3510,11 +3748,11 @@ func readProcessRetryResult(resultPath string, expected processRetryChildConfig)
 	}
 	defer file.Close()
 
-	payload, err := io.ReadAll(io.LimitReader(file, processRetryResultMaxBytes+1))
+	payload, err := io.ReadAll(io.LimitReader(file, processRetryResultWithSubtestsMaxBytes+1))
 	if err != nil {
 		return processRetryResult{}, false, fmt.Errorf("%w: result file unreadable", errProcessRetryResultInvalid)
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	if len(payload) > processRetryResultWithSubtestsMaxBytes {
 		return processRetryResult{}, false, fmt.Errorf("%w: result file too large", errProcessRetryResultInvalid)
 	}
 	var result processRetryResult
@@ -3528,6 +3766,9 @@ func readProcessRetryResult(resultPath string, expected processRetryChildConfig)
 	}
 	if err := validateProcessRetryResult(result, expected); err != nil {
 		return processRetryResult{}, false, err
+	}
+	if len(result.Subtests) == 0 && len(payload) > processRetryResultMaxBytes {
+		return processRetryResult{}, false, fmt.Errorf("%w: result file too large", errProcessRetryResultInvalid)
 	}
 	timingOK := result.StartUnixNano != 0 && result.FinishUnixNano != 0 && result.FinishUnixNano >= result.StartUnixNano
 	if timingOK && result.DurationNanos != 0 && result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
@@ -3555,14 +3796,34 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
 		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) ||
-		!processRetryJSONStringFits(result.ResultError, processRetryResultErrorMaxBytes) {
+		!processRetryJSONStringFits(result.ResultError, processRetryResultErrorMaxBytes) ||
+		!processRetryJSONStringFits(result.OutputTail, processRetryResultOutputMaxBytes) {
 		return fmt.Errorf("%w: metadata field too large", errProcessRetryResultInvalid)
+	}
+	if result.OutputTruncated && result.OutputTail == "" {
+		return fmt.Errorf("%w: invalid output mirrors", errProcessRetryResultInvalid)
 	}
 	if result.Panic && (result.Status != processRetryStatusFail && !isProcessRetryControlledTerminalStatus(result.Status) || !result.Failed || result.ErrorType == "") {
 		return fmt.Errorf("%w: invalid panic mirrors", errProcessRetryResultInvalid)
 	}
 	if result.RaceDetected && (result.Status != processRetryStatusFail || !result.Failed) {
 		return fmt.Errorf("%w: invalid race mirrors", errProcessRetryResultInvalid)
+	}
+	if len(result.Subtests) > processRetryBatchMaxTests {
+		return fmt.Errorf("%w: too many subtest results", errProcessRetryResultInvalid)
+	}
+	seenSubtests := make(map[string]struct{}, len(result.Subtests))
+	for _, subtest := range result.Subtests {
+		if !strings.HasPrefix(subtest.TestName, result.TestName+"/") {
+			return fmt.Errorf("%w: invalid subtest identity", errProcessRetryResultInvalid)
+		}
+		if _, duplicate := seenSubtests[subtest.TestName]; duplicate {
+			return fmt.Errorf("%w: duplicate subtest result", errProcessRetryResultInvalid)
+		}
+		seenSubtests[subtest.TestName] = struct{}{}
+		if err := validateProcessRetrySubtestResult(subtest); err != nil {
+			return err
+		}
 	}
 	switch result.Status {
 	case processRetryStatusPass:
@@ -3582,11 +3843,41 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 			return fmt.Errorf("%w: invalid controlled terminal mirrors", errProcessRetryResultInvalid)
 		}
 	case processRetryStatusNotRun:
-		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || !validProcessRetryResultError(result.ResultError) {
+		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || !validProcessRetryResultError(result.ResultError) {
 			return fmt.Errorf("%w: invalid not_run mirrors", errProcessRetryResultInvalid)
 		}
 	default:
 		return fmt.Errorf("%w: unknown status", errProcessRetryResultInvalid)
+	}
+	return nil
+}
+
+func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
+	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
+		(result.DurationNanos != 0 && result.DurationNanos != result.FinishUnixNano-result.StartUnixNano) {
+		return fmt.Errorf("%w: invalid subtest timing", errProcessRetryResultInvalid)
+	}
+	if !processRetryJSONStringFits(result.ErrorType, processRetryErrorTypeMaxBytes) ||
+		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
+		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
+		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) {
+		return fmt.Errorf("%w: subtest metadata field too large", errProcessRetryResultInvalid)
+	}
+	switch result.Status {
+	case processRetryStatusPass:
+		if result.Failed || result.Skipped || result.Panic || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" {
+			return fmt.Errorf("%w: invalid subtest pass mirrors", errProcessRetryResultInvalid)
+		}
+	case processRetryStatusSkip:
+		if result.Failed || !result.Skipped || result.Panic || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" {
+			return fmt.Errorf("%w: invalid subtest skip mirrors", errProcessRetryResultInvalid)
+		}
+	case processRetryStatusFail:
+		if !result.Failed || result.SkipReason != "" || result.Panic && result.ErrorType == "" || result.ErrorType == "" && (result.ErrorMessage != "" || result.ErrorStack != "") {
+			return fmt.Errorf("%w: invalid subtest fail mirrors", errProcessRetryResultInvalid)
+		}
+	default:
+		return fmt.Errorf("%w: invalid subtest status", errProcessRetryResultInvalid)
 	}
 	return nil
 }
@@ -3602,6 +3893,75 @@ func validProcessRetryResultError(reason string) bool {
 
 var _ integrations.Test = (*processRetryNoopTest)(nil)
 
+type processRetrySubtestCollector struct {
+	mu      locking.Mutex
+	next    atomic.Uint64
+	results []processRetrySubtestResult
+}
+
+func (c *processRetrySubtestCollector) begin() (uint64, time.Time) {
+	return c.next.Add(1), time.Now()
+}
+
+func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata) {
+	if c == nil || t == nil || execMeta == nil {
+		return
+	}
+	finish := time.Now()
+	result := processRetrySubtestResult{
+		TestName:       t.Name(),
+		StartUnixNano:  start.UnixNano(),
+		FinishUnixNano: finish.UnixNano(),
+		DurationNanos:  finish.UnixNano() - start.UnixNano(),
+		Failed:         t.Failed(),
+		Skipped:        t.Skipped(),
+		order:          order,
+	}
+	if panicInfo := execMeta.processRetryPanic.Load(); panicInfo != nil {
+		result.Panic = true
+		result.ErrorType = panicInfo.Type
+		result.ErrorMessage = panicInfo.Message
+		result.ErrorStack = panicInfo.Stack
+	} else if errorInfo := execMeta.processRetryError.Load(); errorInfo != nil {
+		result.ErrorType = errorInfo.Type
+		result.ErrorMessage = errorInfo.Message
+		result.ErrorStack = errorInfo.Stack
+	}
+	if skipReason := execMeta.processRetrySkipReason.Load(); skipReason != nil && result.Skipped && !result.Failed {
+		result.SkipReason = *skipReason
+	}
+	switch {
+	case result.Failed || result.Panic:
+		result.Status = processRetryStatusFail
+		result.Failed = true
+		result.Skipped = false
+		result.SkipReason = ""
+	case result.Skipped:
+		result.Status = processRetryStatusSkip
+	default:
+		result.Status = processRetryStatusPass
+	}
+	c.mu.Lock()
+	c.results = append(c.results, result)
+	c.mu.Unlock()
+}
+
+func (c *processRetrySubtestCollector) snapshot() []processRetrySubtestResult {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	results := append([]processRetrySubtestResult(nil), c.results...)
+	c.mu.Unlock()
+	slices.SortFunc(results, func(a, b processRetrySubtestResult) int {
+		return cmp.Compare(a.order, b.order)
+	})
+	for index := range results {
+		results[index].order = 0
+	}
+	return results
+}
+
 type processRetryNoopTest struct {
 	integrations.Test
 	root      *testing.T
@@ -3610,6 +3970,14 @@ type processRetryNoopTest struct {
 	writer    *processRetryResultWriter
 	control   *processRetryControl
 	raceBase  int64
+	subtests  processRetrySubtestCollector
+}
+
+func (t *processRetryNoopTest) snapshotSubtests() []processRetrySubtestResult {
+	if t == nil {
+		return nil
+	}
+	return t.subtests.snapshot()
 }
 
 func newProcessRetryNoopTest(root *testing.T, cfg processRetryChildConfig, startTime time.Time, writer *processRetryResultWriter, control *processRetryControl, raceBase int64) integrations.Test {
@@ -3644,6 +4012,7 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 		ErrorType:         info.Type,
 		ErrorMessage:      info.Message,
 		ErrorStack:        info.Stack,
+		Subtests:          t.snapshotSubtests(),
 		StartUnixNano:     t.startTime.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
 		DurationNanos:     finish.Sub(t.startTime).Nanoseconds(),

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -880,9 +880,12 @@ func (c *processRetryOutputCapture) Tail() (string, bool, error) {
 	return tail, truncated || aborted, nil
 }
 
-func combineProcessRetryOutputTails(stdout, stderr *processRetryOutputCapture, maxBytes int64) (string, bool, error) {
+func combineProcessRetryOutputTails(stdout, stderr *processRetryOutputCapture, maxBytes int64, filterStdout func(string) string) (string, bool, error) {
 	stdoutTail, stdoutTruncated, stdoutErr := stdout.Tail()
 	stderrTail, stderrTruncated, stderrErr := stderr.Tail()
+	if filterStdout != nil {
+		stdoutTail = filterStdout(stdoutTail)
+	}
 	separator := stdoutTail != "" && stderrTail != ""
 	truncated := stdoutTruncated || stderrTruncated
 	combinedBytes := len(stdoutTail) + len(stderrTail)
@@ -940,10 +943,7 @@ func combineProcessRetryOutputTails(stdout, stderr *processRetryOutputCapture, m
 func filterProcessRetryBatchOutput(output string) string {
 	var filtered strings.Builder
 	for line := range strings.SplitAfterSeq(output, "\n") {
-		protocol := strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(line, "\n"), "\x16"))
-		if protocol == "PASS" || protocol == "FAIL" || strings.HasPrefix(protocol, "=== ") ||
-			strings.HasPrefix(protocol, "--- PASS:") || strings.HasPrefix(protocol, "--- FAIL:") ||
-			strings.HasPrefix(protocol, "--- SKIP:") || strings.HasPrefix(protocol, "coverage:") {
+		if strings.HasPrefix(line, "\x16") {
 			continue
 		}
 		filtered.WriteString(line)
@@ -1078,6 +1078,11 @@ type processRetryRealTimer struct {
 
 func (t *processRetryRealTimer) C() <-chan time.Time { return t.timer.C }
 func (t *processRetryRealTimer) Stop() bool          { return t.timer.Stop() }
+
+type processRetryDisabledTimer struct{}
+
+func (processRetryDisabledTimer) C() <-chan time.Time { return nil }
+func (processRetryDisabledTimer) Stop() bool          { return true }
 
 type processRetryLimiter struct {
 	mu         locking.Mutex
@@ -1863,7 +1868,8 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		currentCPU = processRetryCurrentCPU()
 	}
 	selectedTimeout := selectedProcessRetryTimeout(cfg.Batch != nil, argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
-	if selectedTimeout <= 0 {
+	timeoutDisabled := cfg.Batch != nil && selectedTimeout == 0
+	if selectedTimeout <= 0 && !timeoutDisabled {
 		return finishSetupFailure(context.DeadlineExceeded, true)
 	}
 	if err := ctx.Err(); err != nil {
@@ -1903,7 +1909,8 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		return finishSetupFailure(err, false)
 	}
 	selectedTimeout = selectedProcessRetryTimeout(cfg.Batch != nil, argsSnapshot.timeout, argsSnapshot.timeoutSet, baseline.timeout, baseline.timeoutSet, parentDeadline, parentDeadlineOK, hooks.now())
-	if selectedTimeout <= 0 {
+	timeoutDisabled = cfg.Batch != nil && selectedTimeout == 0
+	if selectedTimeout <= 0 && !timeoutDisabled {
 		return finishSetupFailure(context.DeadlineExceeded, true)
 	}
 	if parentDeadlineOK {
@@ -1915,13 +1922,23 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 			return finishSetupFailure(context.DeadlineExceeded, true)
 		}
 	}
-	attemptDeadline := hooks.now().Add(selectedTimeout)
-	attemptTimer := hooks.newTimer(selectedTimeout)
+	attemptDeadline := time.Time{}
+	var attemptTimer processRetryTimer = processRetryDisabledTimer{}
+	if !timeoutDisabled {
+		attemptDeadline = hooks.now().Add(selectedTimeout)
+		attemptTimer = hooks.newTimer(selectedTimeout)
+	}
 	defer attemptTimer.Stop()
 	remainingAttemptTime := func() time.Duration {
+		if timeoutDisabled {
+			return 0
+		}
 		return attemptDeadline.Sub(hooks.now())
 	}
 	attemptDeadlineReached := func() bool {
+		if timeoutDisabled {
+			return false
+		}
 		select {
 		case <-attemptTimer.C():
 			return true
@@ -1986,7 +2003,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		return finishSetupFailure(err, false)
 	}
 	selectedTimeout = remainingAttemptTime()
-	if selectedTimeout <= 0 || attemptDeadlineReached() {
+	if (!timeoutDisabled && selectedTimeout <= 0) || attemptDeadlineReached() {
 		closeCapturesForSetupFailure()
 		return finishSetupFailure(context.DeadlineExceeded, true)
 	}
@@ -2023,12 +2040,15 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		return finishSetupFailure(errors.Join(err, releaseTree()), false)
 	}
 	latestTimeout := remainingAttemptTime()
-	if latestTimeout <= 0 || attemptDeadlineReached() {
+	if (!timeoutDisabled && latestTimeout <= 0) || attemptDeadlineReached() {
 		closeCapturesForSetupFailure()
 		return finishSetupFailure(errors.Join(context.DeadlineExceeded, releaseTree()), true)
 	}
 	selectedTimeout = latestTimeout
-	childTestingTimeout := selectedTimeout + processRetryParentDeadlineReserve()
+	childTestingTimeout := time.Duration(0)
+	if !timeoutDisabled {
+		childTestingTimeout = selectedTimeout + processRetryParentDeadlineReserve()
+	}
 	selector := cfg.TestName
 	if childCfg.Batch != nil {
 		selector = "."
@@ -2158,10 +2178,11 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 			markContainmentLost(killErr)
 		}
 	}
-	finalizeProcessRetryOutputCaptures(hooks, cmd, &attempt, stdoutCapture, stderrCapture)
+	var filterStdout func(string) string
 	if cfg.Batch != nil {
-		attempt.OutputTail = filterProcessRetryBatchOutput(attempt.OutputTail)
+		filterStdout = filterProcessRetryBatchOutput
 	}
+	finalizeProcessRetryOutputCaptures(hooks, cmd, &attempt, stdoutCapture, stderrCapture, filterStdout)
 	if attempt.ContainmentLost {
 		containmentLost = true
 	}
@@ -2276,6 +2297,7 @@ func finalizeProcessRetryOutputCaptures(
 	cmd *exec.Cmd,
 	attempt *processRetryAttemptResult,
 	stdoutCapture, stderrCapture *processRetryOutputCapture,
+	filterStdout func(string) string,
 ) {
 	if attempt == nil {
 		return
@@ -2297,7 +2319,7 @@ func finalizeProcessRetryOutputCaptures(
 			abort(stderrCapture, 0),
 		)
 	}
-	outputTail, truncated, tailErr := combineProcessRetryOutputTails(stdoutCapture, stderrCapture, processRetryOutputMaxBytes)
+	outputTail, truncated, tailErr := combineProcessRetryOutputTails(stdoutCapture, stderrCapture, processRetryOutputMaxBytes, filterStdout)
 	attempt.OutputTail = outputTail
 	attempt.OutputTruncated = truncated || attempt.CaptureErr != nil
 	attempt.CaptureErr = errors.Join(attempt.CaptureErr, tailErr)
@@ -2320,11 +2342,11 @@ func selectedProcessRetryTimeout(
 	if envTimeoutSet {
 		selected = envTimeout
 	}
-	if argTimeoutSet && (selected <= 0 || argTimeout < selected) {
+	if argTimeoutSet && argTimeout > 0 && (selected <= 0 || argTimeout < selected) {
 		selected = argTimeout
 	}
 	if parentDeadlineOK {
-		if remaining := parentDeadline.Sub(now) - processRetryParentDeadlineReserve(); remaining < selected {
+		if remaining := parentDeadline.Sub(now) - processRetryParentDeadlineReserve(); selected <= 0 || remaining < selected {
 			selected = remaining
 		}
 	}
@@ -2910,7 +2932,7 @@ func buildProcessRetryArgsFromSnapshot(snapshot processRetryArgsSnapshot, testNa
 	if currentCPU < 1 {
 		currentCPU = 1
 	}
-	if childTestingTimeout <= 0 {
+	if childTestingTimeout < 0 {
 		return nil, false, "invalid_child_timeout"
 	}
 	if !snapshot.captured || !snapshot.ok {
@@ -3017,7 +3039,7 @@ func processRetryTimeoutFromArgs(originalArgs []string) (time.Duration, bool) {
 		}
 		parsed, err := time.ParseDuration(value)
 		if err == nil {
-			if parsed > 0 {
+			if parsed >= 0 {
 				timeout = parsed
 				found = true
 			} else {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/impactedtests"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
@@ -116,6 +117,8 @@ type processRetryChildConfig struct {
 	BatchChild             bool
 	CollectPerTestCoverage bool
 	batchTest              *processRetryBatchTestConfig
+	itrCoverageActive      bool
+	impactedTestsAnalyzer  *impactedtests.ImpactedTestAnalyzer
 	batchCoverageFinalizer *processRetryBatchCoverageFinalizer
 	nativeGatePath         string
 	nativeParallelPath     string
@@ -210,21 +213,24 @@ type processRetryTestSource struct {
 }
 
 type processRetrySubtestResult struct {
-	TestName        string                  `json:"test_name"`
-	Status          processRetryStatus      `json:"status"`
-	StartUnixNano   int64                   `json:"start_unix_nano"`
-	FinishUnixNano  int64                   `json:"finish_unix_nano"`
-	DurationNanos   int64                   `json:"duration_nanos"`
-	Failed          bool                    `json:"failed"`
-	Skipped         bool                    `json:"skipped"`
-	Panic           bool                    `json:"panic"`
-	ErrorType       string                  `json:"error_type,omitempty"`
-	ErrorMessage    string                  `json:"error_message,omitempty"`
-	ErrorStack      string                  `json:"error_stack,omitempty"`
-	SkipReason      string                  `json:"skip_reason,omitempty"`
-	OutputTail      string                  `json:"output_tail,omitempty"`
-	OutputTruncated bool                    `json:"output_truncated,omitempty"`
-	Source          *processRetryTestSource `json:"source,omitempty"`
+	TestName        string                             `json:"test_name"`
+	Status          processRetryStatus                 `json:"status"`
+	StartUnixNano   int64                              `json:"start_unix_nano"`
+	FinishUnixNano  int64                              `json:"finish_unix_nano"`
+	DurationNanos   int64                              `json:"duration_nanos"`
+	Failed          bool                               `json:"failed"`
+	Skipped         bool                               `json:"skipped"`
+	SkippedByITR    bool                               `json:"skipped_by_itr,omitempty"`
+	ITRForcedRun    bool                               `json:"itr_forced_run,omitempty"`
+	Panic           bool                               `json:"panic"`
+	ErrorType       string                             `json:"error_type,omitempty"`
+	ErrorMessage    string                             `json:"error_message,omitempty"`
+	ErrorStack      string                             `json:"error_stack,omitempty"`
+	SkipReason      string                             `json:"skip_reason,omitempty"`
+	OutputTail      string                             `json:"output_tail,omitempty"`
+	OutputTruncated bool                               `json:"output_truncated,omitempty"`
+	Source          *processRetryTestSource            `json:"source,omitempty"`
+	Coverage        []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
 	order           uint64
 }
 
@@ -932,7 +938,14 @@ type processRetryAttemptResult struct {
 	SetupFailure                bool
 	BodyAdmitted                bool
 	ControlledTerminalCommitted bool
+	testLogMerge                *processRetryTestLogMerge
 	Cleanup                     func()
+}
+
+type processRetryTestLogMerge struct {
+	parentPath            string
+	childPath             string
+	childWorkingDirectory string
 }
 
 type processRetryEffectiveStatus struct {
@@ -2118,9 +2131,13 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		markContainmentLost(releaseErr)
 	}
 	if childTestLogPath != "" && !attempt.Unreaped {
-		if err := mergeProcessRetryTestLog(parentTestLogPath, childTestLogPath, workingDir); err != nil {
-			attempt.SetupFailure = true
-			attempt.Err = errors.Join(attempt.Err, errProcessRetryTestLogMerge, err)
+		attempt.testLogMerge = &processRetryTestLogMerge{
+			parentPath:            parentTestLogPath,
+			childPath:             childTestLogPath,
+			childWorkingDirectory: workingDir,
+		}
+		if cfg.Batch == nil || !cfg.Batch.PreserveNativeSchedule {
+			mergePendingProcessRetryTestLog(&attempt)
 		}
 	}
 	result, timingOK, resultErr := readProcessRetryResult(resultPath, childCfg)
@@ -2182,6 +2199,18 @@ func mergeProcessRetryTestLog(parentPath, childPath, childWorkingDirectory strin
 		_, writeErr = parentLog.Write(records)
 	}
 	return errors.Join(writeErr, parentLog.Close())
+}
+
+func mergePendingProcessRetryTestLog(attempt *processRetryAttemptResult) {
+	if attempt == nil || attempt.testLogMerge == nil {
+		return
+	}
+	pending := attempt.testLogMerge
+	attempt.testLogMerge = nil
+	if err := mergeProcessRetryTestLog(pending.parentPath, pending.childPath, pending.childWorkingDirectory); err != nil {
+		attempt.SetupFailure = true
+		attempt.Err = errors.Join(attempt.Err, errProcessRetryTestLogMerge, err)
+	}
 }
 
 func applyProcessRetryControlledTerminalState(
@@ -2613,6 +2642,14 @@ func finishProcessRetryTestEvent(
 		cancelExecution = false
 	}
 	test.SetTag(constants.TestRetryExecutionMode, "process")
+	if execMeta.isItrSkipped {
+		test.SetTag(constants.TestSkippedByITR, "true")
+		test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
+		telemetry.ITRSkipped(telemetry.TestEventType)
+		currentITRState().markActualSkip()
+		session.SetTag(constants.ITRTestsSkipped, "true")
+		session.SetTag(constants.ITRTestsSkippingCount, numOfTestsSkipped.Add(1))
+	}
 	if execMeta.isItrForcedRun {
 		test.SetTag(constants.TestForcedToRun, "true")
 		telemetry.ITRForcedRun(telemetry.TestEventType)
@@ -2723,6 +2760,8 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 		execMeta.shouldOrchestrateAttemptToFix = false
 		execMeta.isEarlyFlakeDetectionEnabled = false
 		execMeta.isFlakyTestRetriesEnabled = false
+		execMeta.isItrForcedRun = result.ITRForcedRun
+		execMeta.isItrSkipped = result.SkippedByITR
 		if data, matchKind, ok := getTestManagementData(identity); ok && matchKind == testManagementMatchExact && data != nil {
 			execMeta.suppressParentRetryMetadata = true
 			execMeta.isARetry = false
@@ -2754,6 +2793,7 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 			SkipReason:      result.SkipReason,
 			OutputTail:      result.OutputTail,
 			OutputTruncated: result.OutputTruncated,
+			Coverage:        result.Coverage,
 		})
 		finishProcessRetryTestEvent(&commonInfo{
 			moduleName: testInfo.moduleName,
@@ -3262,6 +3302,14 @@ func configureProcessRetryBatchChildWorkloads(
 	fuzzTargets *[]testing.InternalFuzzTarget,
 	examples *[]testing.InternalExample,
 ) testingMFinalizer {
+	if cfg.Batch.ImpactedTestsEnabled {
+		for _, test := range cfg.Batch.Tests {
+			if len(test.ITRSubtests) > 0 {
+				cfg.impactedTestsAnalyzer, _ = impactedtests.NewImpactedTestAnalyzer()
+				break
+			}
+		}
+	}
 	processCoverageProfile, err := coverage.BeginProcessCoverageProfile()
 	if err != nil {
 		log.Debug("civisibility: failed to capture isolated first-attempt coverage baseline: %s", err.Error())
@@ -3408,7 +3456,6 @@ type processRetryChildObservation struct {
 	group     *retryAttemptGroup
 	execMeta  *testExecutionMetadata
 	result    retryAttemptResult
-	coverage  []coverage.ProcessTestCoverageFile
 	startTime time.Time
 }
 
@@ -3420,14 +3467,19 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			if cfg.ParentDeadlineOK {
 				deadline, deadlineOK = time.Unix(0, cfg.ParentDeadlineUnixNano), true
 			}
-			run, err := waitForProcessRetryBatchGate(cfg.nativeGatePath, deadline, deadlineOK)
+			state, run, err := waitForProcessRetryBatchGate(cfg.nativeGatePath, deadline, deadlineOK)
 			if err != nil {
-				writer.Write(processRetryNotRunResult(cfg, err.Error()))
+				writer.Write(processRetryNotRunResult(cfg, "invalid_invocation_state"))
 				t.Fail()
 				return
 			}
 			if !run {
 				writer.Write(processRetryNotRunResult(cfg, "native_parent_not_run"))
+				return
+			}
+			if err := applyProcessRetryBatchInvocationState(state); err != nil {
+				writer.Write(processRetryNotRunResult(cfg, "invocation_state_apply_failed"))
+				t.Fail()
 				return
 			}
 		}
@@ -3461,6 +3513,12 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		}
 		defer group.retire()
 
+		var root *processRetryNoopTest
+		defer func() {
+			if root != nil {
+				root.finishCoverage()
+			}
+		}()
 		prepare := func(attempt *retryAttemptRoot) string {
 			deadline, deadlineOK := time.Time{}, false
 			if control != nil {
@@ -3475,7 +3533,8 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			attempt.metadata = execMeta
 			execMeta.hasAdditionalFeatureWrapper = true
 			execMeta.identity = newTestIdentity("", "", cfg.TestName)
-			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
+			root = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline).(*processRetryNoopTest)
+			execMeta.test = root
 			observation.execMeta = execMeta
 			return ""
 		}
@@ -3484,12 +3543,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			if fn := runtime.FuncForPC(reflect.ValueOf(original).Pointer()); fn != nil {
 				testFile, _ := fn.FileLine(fn.Entry())
 				childBody = func(t *testing.T) {
-					collector := coverage.BeginProcessTestCoverage(testFile)
-					if collector == nil {
-						original(t)
-						return
-					}
-					defer func() { observation.coverage = collector.Finish() }()
+					root.coverage = coverage.BeginProcessTestCoverage(testFile)
 					original(t)
 				}
 			}
@@ -3611,7 +3665,6 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		Panic:             panicData != nil,
 		RaceDetected:      o.result.raceDetected,
 		RootParallel:      rootParallel,
-		Coverage:          o.coverage,
 	}
 	if o.cfg.BatchChild {
 		result.OutputTail, result.OutputTruncated = truncateProcessRetryOutputTail(o.result.output)
@@ -3619,6 +3672,7 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 	}
 	if root, ok := o.execMeta.test.(*processRetryNoopTest); ok {
 		result.Subtests = root.snapshotSubtests()
+		result.Coverage = root.finishCoverage()
 	}
 	if result.Failed {
 		if panicInfo := o.execMeta.processRetryPanic.Load(); result.Panic && panicInfo != nil {
@@ -3703,7 +3757,8 @@ func markProcessRetryChildFailed(tb testing.TB) {
 
 func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing.T) {
 	var source *processRetryTestSource
-	if fn := runtime.FuncForPC(reflect.ValueOf(original).Pointer()); fn != nil {
+	sourceFunc := runtime.FuncForPC(reflect.ValueOf(original).Pointer())
+	if fn := sourceFunc; fn != nil {
 		runtimePath, runtimeStartLine := fn.FileLine(fn.Entry())
 		source = &processRetryTestSource{RuntimePath: runtimePath, RuntimeStartLine: runtimeStartLine, FunctionName: fn.Name()}
 	}
@@ -3724,16 +3779,27 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		execMeta.test = owner.test
 		execMeta.processRetryOwner = owner
 		var collector *processRetrySubtestCollector
+		var subtestCoverage *coverage.ProcessTestCoverage
+		var parentBarrier *chan bool
+		var oldParentBarrier chan bool
 		var order uint64
 		var start time.Time
-		if root, ok := owner.test.(*processRetryNoopTest); ok {
+		root, _ := owner.test.(*processRetryNoopTest)
+		if root != nil {
 			collector = &root.subtests
 			order, start = collector.begin()
 		}
 		var finishOnce sync.Once
 		finish := func() {
 			finishOnce.Do(func() {
-				collector.finish(order, start, t, execMeta, source)
+				var files []coverage.ProcessTestCoverageFile
+				if subtestCoverage != nil {
+					files = subtestCoverage.Finish()
+				}
+				if parentBarrier != nil {
+					*parentBarrier = oldParentBarrier
+				}
+				collector.finish(order, start, t, execMeta, source, files)
 				restoreChatty()
 				deleteTestMetadata(t)
 			})
@@ -3747,10 +3813,36 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				}
 			}
 		})
-		if root, ok := owner.test.(*processRetryNoopTest); ok && root.cfg.batchTest != nil && slices.Contains(root.cfg.batchTest.DisabledSubtests, t.Name()) {
+		if root != nil && root.cfg.batchTest != nil && slices.Contains(root.cfg.batchTest.DisabledSubtests, t.Name()) {
 			reason := constants.TestDisabledSkipReason
 			execMeta.processRetrySkipReason.Store(&reason)
 			t.SkipNow()
+		}
+		if root != nil && root.cfg.batchTest != nil {
+			if itr, ok := processRetrySubtestITR(root.cfg.batchTest.ITRSubtests, t.Name()); ok {
+				execMeta.isAttemptToFix = itr.AttemptToFix
+				execMeta.isAModifiedTest = root.isModifiedSubtest(t.Name(), sourceFunc)
+				decision := decideITRSkip(true, itr.MissingLineCodeCoverage, root.cfg.itrCoverageActive, execMeta, integrations.IsTestFuncUnskippable(sourceFunc))
+				execMeta.isItrForcedRun = decision.forcedRun
+				if decision.skip {
+					execMeta.isItrSkipped = true
+					reason := constants.SkippedByITRReason
+					execMeta.processRetrySkipReason.Store(&reason)
+					t.SkipNow()
+				}
+			}
+		}
+		if root != nil && root.cfg.CollectPerTestCoverage && source != nil && coverage.CanCollect() {
+			subtestCoverage = coverage.BeginProcessTestCoverage(source.RuntimePath)
+			if subtestCoverage != nil {
+				// Runtime coverage counters are process-global, so every covered
+				// subtest must own its complete counter delta without parallel peers.
+				if parent := getTestParentPrivateFields(t); parent != nil && parent.barrier != nil {
+					parentBarrier = parent.barrier
+					oldParentBarrier = *parentBarrier
+					*parentBarrier = nil
+				}
+			}
 		}
 
 		bodyReturned := false
@@ -3780,6 +3872,15 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		original(t)
 		bodyReturned = true
 	}
+}
+
+func processRetrySubtestITR(configs []processRetrySubtestITRConfig, name string) (processRetrySubtestITRConfig, bool) {
+	for _, config := range configs {
+		if config.TestName == name {
+			return config, true
+		}
+	}
+	return processRetrySubtestITRConfig{}, false
 }
 
 func bufferProcessRetrySubtestOutput(t *testing.T) func() {
@@ -3934,8 +4035,11 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 	if len(payload) > maxBytes {
 		return errors.New("process_retry_result_too_large")
 	}
-	dir := filepath.Dir(resultPath)
-	tmp, err := os.CreateTemp(dir, ".process-retry-result-*.tmp")
+	return writeProcessRetryFileAtomically(resultPath, payload, ".process-retry-result-*.tmp")
+}
+
+func writeProcessRetryFileAtomically(path string, payload []byte, pattern string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), pattern)
 	if err != nil {
 		return err
 	}
@@ -3955,7 +4059,7 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 		return err
 	}
 	closed = true
-	return os.Rename(tmpName, resultPath)
+	return os.Rename(tmpName, path)
 }
 
 func readProcessRetryResult(resultPath string, expected processRetryChildConfig) (processRetryResult, bool, error) {
@@ -4048,13 +4152,8 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 	if len(result.Coverage) > 0 && !expected.BatchChild {
 		return fmt.Errorf("%w: unexpected process coverage", errProcessRetryResultInvalid)
 	}
-	if len(result.Coverage) > processRetryBatchMaxTests {
-		return fmt.Errorf("%w: too many process coverage files", errProcessRetryResultInvalid)
-	}
-	for _, file := range result.Coverage {
-		if strings.TrimSpace(file.Name) == "" || !processRetryJSONStringFits(file.Name, processRetryErrorMessageMaxBytes) {
-			return fmt.Errorf("%w: invalid process coverage file", errProcessRetryResultInvalid)
-		}
+	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
+		return err
 	}
 	switch result.Status {
 	case processRetryStatusPass:
@@ -4103,6 +4202,12 @@ func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
 	if result.OutputTruncated && result.OutputTail == "" {
 		return fmt.Errorf("%w: invalid subtest output mirrors", errProcessRetryResultInvalid)
 	}
+	if result.SkippedByITR && (result.ITRForcedRun || result.Status != processRetryStatusSkip || !result.Skipped || result.SkipReason != constants.SkippedByITRReason) {
+		return fmt.Errorf("%w: invalid subtest ITR mirrors", errProcessRetryResultInvalid)
+	}
+	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
+		return err
+	}
 	switch result.Status {
 	case processRetryStatusPass:
 		if result.Failed || result.Skipped || result.Panic || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" {
@@ -4122,9 +4227,21 @@ func validateProcessRetrySubtestResult(result processRetrySubtestResult) error {
 	return nil
 }
 
+func validateProcessRetryCoverageFiles(files []coverage.ProcessTestCoverageFile) error {
+	if len(files) > processRetryBatchMaxTests {
+		return fmt.Errorf("%w: too many process coverage files", errProcessRetryResultInvalid)
+	}
+	for _, file := range files {
+		if strings.TrimSpace(file.Name) == "" || !processRetryJSONStringFits(file.Name, processRetryErrorMessageMaxBytes) {
+			return fmt.Errorf("%w: invalid process coverage file", errProcessRetryResultInvalid)
+		}
+	}
+	return nil
+}
+
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "native_parent_not_run":
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "native_parent_not_run", "invalid_invocation_state", "invocation_state_apply_failed":
 		return true
 	default:
 		return false
@@ -4143,7 +4260,7 @@ func (c *processRetrySubtestCollector) begin() (uint64, time.Time) {
 	return c.next.Add(1), time.Now()
 }
 
-func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource) {
+func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile) {
 	if c == nil || t == nil || execMeta == nil {
 		return
 	}
@@ -4155,7 +4272,10 @@ func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *
 		DurationNanos:  finish.UnixNano() - start.UnixNano(),
 		Failed:         t.Failed(),
 		Skipped:        t.Skipped(),
+		SkippedByITR:   execMeta.isItrSkipped,
+		ITRForcedRun:   execMeta.isItrForcedRun,
 		Source:         source,
+		Coverage:       files,
 		order:          order,
 	}
 	flushOutputWriterPartial(t)
@@ -4216,6 +4336,9 @@ type processRetryNoopTest struct {
 	control   *processRetryControl
 	raceBase  int64
 	subtests  processRetrySubtestCollector
+	coverage  *coverage.ProcessTestCoverage
+	covOnce   sync.Once
+	covFiles  []coverage.ProcessTestCoverageFile
 }
 
 func (t *processRetryNoopTest) snapshotSubtests() []processRetrySubtestResult {
@@ -4223,6 +4346,25 @@ func (t *processRetryNoopTest) snapshotSubtests() []processRetrySubtestResult {
 		return nil
 	}
 	return t.subtests.snapshot()
+}
+
+func (t *processRetryNoopTest) finishCoverage() []coverage.ProcessTestCoverageFile {
+	if t == nil {
+		return nil
+	}
+	t.covOnce.Do(func() {
+		if t.coverage != nil {
+			t.covFiles = t.coverage.Finish()
+		}
+	})
+	return t.covFiles
+}
+
+func (t *processRetryNoopTest) isModifiedSubtest(name string, fn *runtime.Func) bool {
+	if t == nil {
+		return false
+	}
+	return integrations.IsTestFuncModifiedWithAnalyzer(t.cfg.impactedTestsAnalyzer, name, fn)
 }
 
 func newProcessRetryNoopTest(root *testing.T, cfg processRetryChildConfig, startTime time.Time, writer *processRetryResultWriter, control *processRetryControl, raceBase int64) integrations.Test {
@@ -4258,6 +4400,7 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 		ErrorMessage:      info.Message,
 		ErrorStack:        info.Stack,
 		Subtests:          t.snapshotSubtests(),
+		Coverage:          t.finishCoverage(),
 		StartUnixNano:     t.startTime.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
 		DurationNanos:     finish.Sub(t.startTime).Nanoseconds(),

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -937,6 +937,20 @@ func combineProcessRetryOutputTails(stdout, stderr *processRetryOutputCapture, m
 	return combined.String(), truncated, errors.Join(stdoutErr, stderrErr)
 }
 
+func filterProcessRetryBatchOutput(output string) string {
+	var filtered strings.Builder
+	for line := range strings.SplitAfterSeq(output, "\n") {
+		protocol := strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(line, "\n"), "\x16"))
+		if protocol == "PASS" || protocol == "FAIL" || strings.HasPrefix(protocol, "=== ") ||
+			strings.HasPrefix(protocol, "--- PASS:") || strings.HasPrefix(protocol, "--- FAIL:") ||
+			strings.HasPrefix(protocol, "--- SKIP:") || strings.HasPrefix(protocol, "coverage:") {
+			continue
+		}
+		filtered.WriteString(line)
+	}
+	return filtered.String()
+}
+
 type processRetryAttemptResult struct {
 	Result                      processRetryResult
 	TempDir                     string
@@ -1022,6 +1036,7 @@ type processRetryArgsSnapshot struct {
 	artifactOutput   string
 	artifactsEnabled bool
 	testLogFile      string
+	coverageDir      string
 	profilingEnabled bool
 	timeout          time.Duration
 	timeoutSet       bool
@@ -2017,7 +2032,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	selector := cfg.TestName
 	if childCfg.Batch != nil {
 		selector = "."
-		argsSnapshot = processRetryBatchArgsSnapshot(argsSnapshot, childTestLogPath)
+		argsSnapshot = processRetryBatchArgsSnapshot(argsSnapshot, childTestLogPath, childCfg.Batch.PreserveNativeSchedule)
 	}
 	filteredArgs, ok, reason := buildProcessRetryArgsFromSnapshot(argsSnapshot, selector, currentCPU, childTestingTimeout)
 	if !ok {
@@ -2144,6 +2159,9 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		}
 	}
 	finalizeProcessRetryOutputCaptures(hooks, cmd, &attempt, stdoutCapture, stderrCapture)
+	if cfg.Batch != nil {
+		attempt.OutputTail = filterProcessRetryBatchOutput(attempt.OutputTail)
+	}
 	if attempt.ContainmentLost {
 		containmentLost = true
 	}
@@ -2190,10 +2208,14 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	return attempt
 }
 
-func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot, testLogFile string) processRetryArgsSnapshot {
+func processRetryBatchArgsSnapshot(snapshot processRetryArgsSnapshot, testLogFile string, preserveNativeSchedule bool) processRetryArgsSnapshot {
 	snapshot.preserved = append(append([]string(nil), snapshot.preserved...), "-test.failfast=false")
 	if testLogFile != "" {
 		snapshot.preserved = append(snapshot.preserved, "-test.testlogfile="+testLogFile)
+	}
+	if preserveNativeSchedule && snapshot.coverageDir != "" {
+		// The parent's coverage report merges every pod emitted here before M.Run returns.
+		snapshot.preserved = append(snapshot.preserved, "-test.gocoverdir="+snapshot.coverageDir)
 	}
 	return snapshot
 }
@@ -2865,7 +2887,7 @@ func finishProcessRetrySubtestEvents(testInfo *commonInfo, parentMeta *testExecu
 func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnapshot {
 	preserved, boundary, runSelector, skipSelector, ok, reason := processRetryFilterArgs(originalArgs, true)
 	timeout, timeoutSet := processRetryTimeoutFromArgs(originalArgs)
-	artifactOutput, artifactsEnabled, testLogFile, profilingEnabled := processRetryOutputPolicyFromArgs(originalArgs)
+	artifactOutput, artifactsEnabled, testLogFile, coverageDir, profilingEnabled := processRetryOutputPolicyFromArgs(originalArgs)
 	return processRetryArgsSnapshot{
 		captured:         true,
 		preserved:        append([]string(nil), preserved...),
@@ -2875,6 +2897,7 @@ func captureProcessRetryArgsSnapshot(originalArgs []string) processRetryArgsSnap
 		artifactOutput:   artifactOutput,
 		artifactsEnabled: artifactsEnabled,
 		testLogFile:      testLogFile,
+		coverageDir:      coverageDir,
 		profilingEnabled: profilingEnabled,
 		timeout:          timeout,
 		timeoutSet:       timeoutSet,
@@ -2922,7 +2945,7 @@ func buildProcessRetryArgsFromSnapshot(snapshot processRetryArgsSnapshot, testNa
 	return args, true, ""
 }
 
-func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, artifactsEnabled bool, testLogFile string, profilingEnabled bool) {
+func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, artifactsEnabled bool, testLogFile, coverageDir string, profilingEnabled bool) {
 	for i := 0; i < len(originalArgs); i++ {
 		arg := originalArgs[i]
 		if arg == "--" || !processRetryIsFlagToken(arg) {
@@ -2944,11 +2967,13 @@ func processRetryOutputPolicyFromArgs(originalArgs []string) (outputDir string, 
 			}
 		case "-test.testlogfile":
 			testLogFile = value
+		case "-test.gocoverdir":
+			coverageDir = value
 		case "-test.cpuprofile", "-test.memprofile", "-test.blockprofile", "-test.mutexprofile", "-test.trace":
 			profilingEnabled = profilingEnabled || value != ""
 		}
 	}
-	return outputDir, artifactsEnabled, testLogFile, profilingEnabled
+	return outputDir, artifactsEnabled, testLogFile, coverageDir, profilingEnabled
 }
 
 func processRetryTimeoutFromArgs(originalArgs []string) (time.Duration, bool) {
@@ -3562,7 +3587,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			// its own package barrier, otherwise both native schedulers wait for
 			// the other process to enumerate the next test.
 			group.rootParallelAnnounce = func() error {
-				return os.WriteFile(cfg.nativeParallelPath, nil, processRetryBatchManifestMode)
+				return writeCurrentProcessRetryBatchInvocationState(cfg.nativeParallelPath)
 			}
 			group.rootParallelBridge = func() error {
 				deadline, deadlineOK := time.Time{}, false
@@ -3883,9 +3908,9 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 					*parentBarrier = oldParentBarrier
 				}
 				if attemptToFix {
-					if !collector.completeAttemptToFix(t.Name(), files) {
+					if !collector.completeAttemptToFix(t.Name()) {
 						collector.finishNativeAttemptToFix(order, start, t, execMeta, source, files)
-						collector.completeAttemptToFix(t.Name(), files)
+						collector.completeAttemptToFix(t.Name())
 					}
 				} else {
 					collector.finish(order, start, t, execMeta, source, files)
@@ -3921,20 +3946,34 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 				}
 			}
 		}
-		if root != nil && root.cfg.CollectPerTestCoverage && source != nil && coverage.CanCollect() {
+		collectCoverage := root != nil && root.cfg.CollectPerTestCoverage && source != nil && coverage.CanCollect()
+		suppressParallelCoverage := func() {
+			// Runtime coverage counters are process-global, so every covered
+			// subtest must own its complete counter delta without parallel peers.
+			if parent := getTestParentPrivateFields(t); parent != nil && parent.barrier != nil {
+				parentBarrier = parent.barrier
+				oldParentBarrier = *parentBarrier
+				*parentBarrier = nil
+			}
+		}
+		if collectCoverage && attemptToFix {
+			suppressParallelCoverage()
+		}
+		var attemptToFixGroup *retryAttemptGroup
+		if attemptToFix {
+			attemptToFixGroup, _ = newRetryAttemptGroupWithOutputObservation(t, true)
+		}
+		if collectCoverage && (!attemptToFix || attemptToFixGroup == nil) {
 			subtestCoverage = coverage.BeginProcessTestCoverage(source.RuntimePath)
-			if subtestCoverage != nil {
-				// Runtime coverage counters are process-global, so every covered
-				// subtest must own its complete counter delta without parallel peers.
-				if parent := getTestParentPrivateFields(t); parent != nil && parent.barrier != nil {
-					parentBarrier = parent.barrier
-					oldParentBarrier = *parentBarrier
-					*parentBarrier = nil
-				}
+			if subtestCoverage != nil && parentBarrier == nil {
+				suppressParallelCoverage()
+			} else if subtestCoverage == nil && parentBarrier != nil {
+				*parentBarrier = oldParentBarrier
+				parentBarrier = nil
 			}
 		}
 		if attemptToFix {
-			runProcessRetryChildAttemptToFixSubtest(t, original, owner, collector, source, root.cfg.attemptToFixRetries, execMeta.isItrForcedRun)
+			runProcessRetryChildAttemptToFixSubtest(t, original, owner, collector, source, attemptToFixGroup, root.cfg.attemptToFixRetries, execMeta.isItrForcedRun, collectCoverage)
 			return
 		}
 
@@ -3967,9 +4006,8 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 	}
 }
 
-func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testing.T), owner *testExecutionMetadata, collector *processRetrySubtestCollector, source *processRetryTestSource, retries int, itrForcedRun bool) {
-	group, reason := newRetryAttemptGroupWithOutputObservation(t, true)
-	if reason != "" {
+func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testing.T), owner *testExecutionMetadata, collector *processRetrySubtestCollector, source *processRetryTestSource, group *retryAttemptGroup, retries int, itrForcedRun, collectCoverage bool) {
+	if group == nil {
 		original(t)
 		return
 	}
@@ -3981,6 +4019,7 @@ func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testin
 		t:                             t,
 		retryAttemptGroupFactory:      func(*testing.T) (*retryAttemptGroup, string) { return group, "" },
 		allowProcessRetryChildRetries: true,
+		allowRetryAfterRace:           true,
 		preExecMetaAdjust: func(execMeta *testExecutionMetadata, executionIndex int) {
 			execMeta.identity = identity
 			execMeta.test = owner.test
@@ -3995,8 +4034,12 @@ func runProcessRetryChildAttemptToFixSubtest(t *testing.T, original func(*testin
 			}
 			preparedIndex = executionIndex
 			order, start := collector.begin()
+			var attemptCoverage *coverage.ProcessTestCoverage
+			if collectCoverage {
+				attemptCoverage = coverage.BeginProcessTestCoverage(source.RuntimePath)
+			}
 			execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
-				collector.finishAttemptToFix(order, start, execMeta.freshRetryAttemptTest, execMeta, source, executionIndex, result)
+				collector.finishAttemptToFix(order, start, execMeta.freshRetryAttemptTest, execMeta, source, attemptCoverage.Finish(), executionIndex, result)
 			}
 		},
 		preIsLastRetry: func(_ *testExecutionMetadata, _ int, remainingRetries int64) bool {
@@ -4432,8 +4475,8 @@ func (c *processRetrySubtestCollector) finish(order uint64, start time.Time, t *
 	c.finishWithAttempt(order, start, t, execMeta, source, files, -1, nil)
 }
 
-func (c *processRetrySubtestCollector) finishAttemptToFix(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, attempt int, retryResult retryAttemptResult) {
-	c.finishWithAttempt(order, start, t, execMeta, source, nil, attempt, &retryResult)
+func (c *processRetrySubtestCollector) finishAttemptToFix(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile, attempt int, retryResult retryAttemptResult) {
+	c.finishWithAttempt(order, start, t, execMeta, source, files, attempt, &retryResult)
 }
 
 func (c *processRetrySubtestCollector) finishNativeAttemptToFix(order uint64, start time.Time, t *testing.T, execMeta *testExecutionMetadata, source *processRetryTestSource, files []coverage.ProcessTestCoverageFile) {
@@ -4516,7 +4559,7 @@ func (c *processRetrySubtestCollector) finishWithAttempt(order uint64, start tim
 	c.mu.Unlock()
 }
 
-func (c *processRetrySubtestCollector) completeAttemptToFix(name string, files []coverage.ProcessTestCoverageFile) bool {
+func (c *processRetrySubtestCollector) completeAttemptToFix(name string) bool {
 	if c == nil {
 		return false
 	}
@@ -4525,7 +4568,6 @@ func (c *processRetrySubtestCollector) completeAttemptToFix(name string, files [
 	for index := range slices.Backward(c.results) {
 		if result := &c.results[index]; result.TestName == name && result.AttemptToFix {
 			result.AttemptToFixLast = true
-			result.Coverage = files
 			return true
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -67,6 +67,10 @@ func processRetryBatchGatePath(resultPath string, index int) string {
 	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-gate-%06d", index))
 }
 
+func processRetryBatchSkipPath(resultPath string, index int) string {
+	return processRetryBatchGatePath(resultPath, index) + ".skip"
+}
+
 func processRetryBatchParallelPath(resultPath string, index int) string {
 	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-parallel-%06d", index))
 }
@@ -97,15 +101,20 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 	return child
 }
 
-func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bool) error {
+func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bool) (bool, error) {
 	for {
 		if _, err := os.Stat(path); err == nil {
-			return nil
+			return true, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return err
+			return false, err
+		}
+		if _, err := os.Stat(path + ".skip"); err == nil {
+			return false, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
 		}
 		if deadlineOK && !time.Now().Before(deadline) {
-			return context.DeadlineExceeded
+			return false, context.DeadlineExceeded
 		}
 		time.Sleep(processRetryBatchPollInterval)
 	}
@@ -398,6 +407,10 @@ func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (pr
 	if batch == nil {
 		return processRetryAttemptResult{}, false
 	}
+	skipErr := skipUninvokedNativeScheduledTests(batch)
+	if skipErr != nil {
+		batch.cancel()
+	}
 	<-batch.done
 	if batch.attempt.OutputTail != "" {
 		_, _ = io.WriteString(os.Stdout, batch.attempt.OutputTail)
@@ -405,7 +418,30 @@ func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (pr
 	if err := coverage.MergeProcessCoverageProfile(processRetryBatchCoveragePath(batch.resultRoot)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Debug("civisibility: failed to merge isolated first-attempt coverage: %s", err.Error())
 	}
+	if skipErr != nil {
+		batch.attempt.SetupFailure = true
+		batch.attempt.Err = errors.Join(batch.attempt.Err, skipErr)
+	}
 	return batch.attempt, true
+}
+
+func skipUninvokedNativeScheduledTests(batch *nativeScheduledProcessRetryBatch) error {
+	if batch == nil || batch.batch == nil {
+		return nil
+	}
+	// Filters and -failfast can leave registered tests uninvoked; release their
+	// child gates without executing their bodies before waiting for the batch.
+	for index := range batch.batch.Tests {
+		if _, err := os.Stat(processRetryBatchGatePath(batch.resultRoot, index)); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.WriteFile(processRetryBatchSkipPath(batch.resultRoot, index), nil, processRetryBatchManifestMode); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *processRetryCoordinator) cleanupNativeScheduledBatch(phaseID uint64) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -28,6 +29,7 @@ import (
 
 const (
 	processRetryBatchVersion      = 1
+	processRetryBatchGateVersion  = 1
 	processRetryBatchTestName     = "__dd_quarantined_race_batch__"
 	processRetryBatchReason       = "quarantined_race"
 	processRetryBatchMaxTests     = 100_000
@@ -39,9 +41,16 @@ const (
 var errProcessRetryBatchFailed = errors.New("process retry batch failed")
 
 type processRetryBatchTestConfig struct {
-	TestName          string   `json:"test_name"`
-	InvocationOrdinal uint64   `json:"invocation_ordinal,omitempty"`
-	DisabledSubtests  []string `json:"disabled_subtests,omitempty"`
+	TestName          string                         `json:"test_name"`
+	InvocationOrdinal uint64                         `json:"invocation_ordinal,omitempty"`
+	DisabledSubtests  []string                       `json:"disabled_subtests,omitempty"`
+	ITRSubtests       []processRetrySubtestITRConfig `json:"itr_subtests,omitempty"`
+}
+
+type processRetrySubtestITRConfig struct {
+	TestName                string `json:"test_name"`
+	MissingLineCodeCoverage bool   `json:"missing_line_code_coverage,omitempty"`
+	AttemptToFix            bool   `json:"attempt_to_fix,omitempty"`
 }
 
 type processRetryBatchConfig struct {
@@ -49,6 +58,14 @@ type processRetryBatchConfig struct {
 	Tests                  []processRetryBatchTestConfig `json:"tests"`
 	CollectPerTestCoverage bool                          `json:"collect_per_test_coverage,omitempty"`
 	PreserveNativeSchedule bool                          `json:"preserve_native_schedule,omitempty"`
+	ITRCoverageActive      bool                          `json:"itr_coverage_active,omitempty"`
+	ImpactedTestsEnabled   bool                          `json:"impacted_tests_enabled,omitempty"`
+}
+
+type processRetryBatchInvocationState struct {
+	Version          int      `json:"version"`
+	WorkingDirectory string   `json:"working_directory"`
+	Environment      []string `json:"environment"`
 }
 
 func processRetryBatchManifestPath(resultPath string) string {
@@ -90,6 +107,10 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		CollectPerTestCoverage: root.Batch != nil && root.Batch.CollectPerTestCoverage,
 		batchTest:              &test,
 	}
+	if root.Batch != nil {
+		child.itrCoverageActive = root.Batch.ITRCoverageActive
+		child.impactedTestsAnalyzer = root.impactedTestsAnalyzer
+	}
 	if root.Batch != nil && root.Batch.PreserveNativeSchedule {
 		// The native parent owns invocation identity; the child manifest is
 		// registered before those ordinals exist and is matched by batch index.
@@ -101,23 +122,123 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 	return child
 }
 
-func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bool) (bool, error) {
+func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bool) (processRetryBatchInvocationState, bool, error) {
 	for {
 		if _, err := os.Stat(path); err == nil {
-			return true, nil
+			state, err := readProcessRetryBatchInvocationState(path)
+			return state, err == nil, err
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return false, err
+			return processRetryBatchInvocationState{}, false, err
 		}
 		if _, err := os.Stat(path + ".skip"); err == nil {
-			return false, nil
+			return processRetryBatchInvocationState{}, false, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return false, err
+			return processRetryBatchInvocationState{}, false, err
 		}
 		if deadlineOK && !time.Now().Before(deadline) {
-			return false, context.DeadlineExceeded
+			return processRetryBatchInvocationState{}, false, context.DeadlineExceeded
 		}
 		time.Sleep(processRetryBatchPollInterval)
 	}
+}
+
+func writeProcessRetryBatchInvocationState(path string, baseline *processRetryLaunchBaseline) error {
+	if baseline == nil {
+		return errors.New("missing process retry invocation state")
+	}
+	state := processRetryBatchInvocationState{
+		Version:          processRetryBatchGateVersion,
+		WorkingDirectory: baseline.workingDirectory,
+		Environment:      make([]string, 0, len(baseline.environment)),
+	}
+	for _, entry := range baseline.environment {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && key == "" {
+			continue
+		}
+		state.Environment = append(state.Environment, entry)
+	}
+	if err := validateProcessRetryBatchInvocationState(state); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	if len(payload) > processRetryBatchMaxBytes {
+		return errors.New("process retry invocation state too large")
+	}
+	return writeProcessRetryFileAtomically(path, payload, ".process-retry-gate-*.tmp")
+}
+
+func readProcessRetryBatchInvocationState(path string) (processRetryBatchInvocationState, error) {
+	state, err := readProcessRetryBatchJSON[processRetryBatchInvocationState](path, "process retry invocation state")
+	if err != nil {
+		return processRetryBatchInvocationState{}, err
+	}
+	if err := validateProcessRetryBatchInvocationState(state); err != nil {
+		return processRetryBatchInvocationState{}, err
+	}
+	return state, nil
+}
+
+func validateProcessRetryBatchInvocationState(state processRetryBatchInvocationState) error {
+	if state.Version != processRetryBatchGateVersion || !filepath.IsAbs(state.WorkingDirectory) {
+		return errors.New("invalid process retry invocation state")
+	}
+	seen := make(map[string]struct{}, len(state.Environment))
+	for _, entry := range state.Environment {
+		key, value, ok := strings.Cut(entry, "=")
+		normalizedKey := processRetryInvocationEnvironmentKey(key)
+		if !ok || key == "" || strings.IndexByte(key, 0) >= 0 || strings.IndexByte(value, 0) >= 0 ||
+			isProcessRetryInternalEnvKey(key) || strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable) {
+			return errors.New("invalid process retry invocation environment")
+		}
+		if _, duplicate := seen[normalizedKey]; duplicate {
+			return errors.New("duplicate process retry invocation environment")
+		}
+		seen[normalizedKey] = struct{}{}
+	}
+	return nil
+}
+
+func applyProcessRetryBatchInvocationState(state processRetryBatchInvocationState) error {
+	if err := validateProcessRetryBatchInvocationState(state); err != nil {
+		return err
+	}
+	if err := os.Chdir(state.WorkingDirectory); err != nil {
+		return err
+	}
+	desired := make(map[string]struct{}, len(state.Environment))
+	for _, entry := range state.Environment {
+		key, _, _ := strings.Cut(entry, "=")
+		desired[processRetryInvocationEnvironmentKey(key)] = struct{}{}
+	}
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || key == "" {
+			continue
+		}
+		if _, ok := desired[processRetryInvocationEnvironmentKey(key)]; !ok {
+			if err := os.Unsetenv(key); err != nil {
+				return err
+			}
+		}
+	}
+	for _, entry := range state.Environment {
+		key, value, _ := strings.Cut(entry, "=")
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func processRetryInvocationEnvironmentKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
 }
 
 func writeProcessRetryBatchConfig(path string, cfg *processRetryBatchConfig) error {
@@ -135,31 +256,39 @@ func writeProcessRetryBatchConfig(path string, cfg *processRetryBatchConfig) err
 }
 
 func readProcessRetryBatchConfig(path string) (*processRetryBatchConfig, error) {
-	file, err := os.Open(path)
+	cfg, err := readProcessRetryBatchJSON[processRetryBatchConfig](path, "process retry batch manifest")
 	if err != nil {
 		return nil, err
-	}
-	defer file.Close()
-	payload, err := io.ReadAll(io.LimitReader(file, processRetryBatchMaxBytes+1))
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > processRetryBatchMaxBytes {
-		return nil, errors.New("process retry batch manifest too large")
-	}
-	var cfg processRetryBatchConfig
-	decoder := json.NewDecoder(bytes.NewReader(payload))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&cfg); err != nil {
-		return nil, err
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, errors.New("process retry batch manifest has trailing data")
 	}
 	if err := validateProcessRetryBatchConfig(&cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func readProcessRetryBatchJSON[T any](path, kind string) (T, error) {
+	var value T
+	file, err := os.Open(path)
+	if err != nil {
+		return value, err
+	}
+	defer file.Close()
+	payload, err := io.ReadAll(io.LimitReader(file, processRetryBatchMaxBytes+1))
+	if err != nil {
+		return value, err
+	}
+	if len(payload) > processRetryBatchMaxBytes {
+		return value, fmt.Errorf("%s too large", kind)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return value, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return value, fmt.Errorf("%s has trailing data", kind)
+	}
+	return value, nil
 }
 
 func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
@@ -175,6 +304,16 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 			return errors.New("duplicate process retry batch test")
 		}
 		seen[test.TestName] = struct{}{}
+		seenITR := make(map[string]struct{}, len(test.ITRSubtests))
+		for _, subtest := range test.ITRSubtests {
+			if !strings.HasPrefix(subtest.TestName, test.TestName+"/") {
+				return errors.New("invalid process retry ITR subtest")
+			}
+			if _, duplicate := seenITR[subtest.TestName]; duplicate {
+				return errors.New("duplicate process retry ITR subtest")
+			}
+			seenITR[subtest.TestName] = struct{}{}
+		}
 	}
 	return nil
 }
@@ -200,6 +339,46 @@ func disabledProcessRetrySubtests(identity testIdentity, modules *net.TestManage
 	}
 	slices.Sort(disabled)
 	return disabled
+}
+
+func processRetryITRSubtests(identity testIdentity, state *itrState, modules *net.TestManagementTestsResponseDataModules) []processRetrySubtestITRConfig {
+	if state == nil || !state.testsSkippingEnabled() || state.response == nil {
+		return nil
+	}
+	suite := state.response.Skippables[identity.SuiteName]
+	prefix := identity.FullName + "/"
+	configs := make([]processRetrySubtestITRConfig, 0)
+	for name, candidates := range suite {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		config := processRetrySubtestITRConfig{TestName: name}
+		matched := false
+		for _, candidate := range candidates {
+			if strings.TrimSpace(candidate.Parameters) != "" {
+				continue
+			}
+			matched = true
+			config.MissingLineCodeCoverage = config.MissingLineCodeCoverage || candidate.MissingLineCodeCoverage
+		}
+		if !matched {
+			continue
+		}
+		if modules != nil {
+			if module, ok := modules.Modules[identity.ModuleName]; ok {
+				if managedSuite, ok := module.Suites[identity.SuiteName]; ok {
+					if test, ok := managedSuite.Tests[name]; ok {
+						config.AttemptToFix = test.Properties.AttemptToFix
+					}
+				}
+			}
+		}
+		configs = append(configs, config)
+	}
+	slices.SortFunc(configs, func(a, b processRetrySubtestITRConfig) int {
+		return strings.Compare(a.TestName, b.TestName)
+	})
+	return configs
 }
 
 type deferredProcessRetryBatchRunner func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult
@@ -256,6 +435,7 @@ func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdent
 	spec := processRetryBatchTestConfig{
 		TestName:         identity.FullName,
 		DisabledSubtests: disabledProcessRetrySubtests(identity, testManagementData),
+		ITRSubtests:      processRetryITRSubtests(identity, currentITRState(), testManagementData),
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -305,6 +485,10 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 		PreserveNativeSchedule: true,
 	}
+	if state := currentITRState(); state != nil {
+		batchConfig.ITRCoverageActive = state.coverageActive
+		batchConfig.ImpactedTestsEnabled = state.settings != nil && state.settings.ImpactedTestsEnabled
+	}
 	rootCfg := processRetryChildConfig{
 		TestName:          processRetryBatchTestName,
 		Attempt:           1,
@@ -347,7 +531,7 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 		now := time.Now()
 		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 	}
-	if err := os.WriteFile(processRetryBatchGatePath(batch.resultRoot, index), nil, processRetryBatchManifestMode); err != nil {
+	if err := writeProcessRetryBatchInvocationState(processRetryBatchGatePath(batch.resultRoot, index), group.launchBaseline); err != nil {
 		now := time.Now()
 		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 	}
@@ -414,6 +598,7 @@ func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (pr
 		batch.cancel()
 	}
 	<-batch.done
+	mergePendingProcessRetryTestLog(&batch.attempt)
 	if batch.attempt.OutputTail != "" {
 		_, _ = io.WriteString(os.Stdout, batch.attempt.OutputTail)
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
@@ -32,6 +33,7 @@ const (
 	processRetryBatchMaxTests     = 100_000
 	processRetryBatchMaxBytes     = 16 * 1024 * 1024
 	processRetryBatchManifestMode = 0o600
+	processRetryBatchPollInterval = 5 * time.Millisecond
 )
 
 var errProcessRetryBatchFailed = errors.New("process retry batch failed")
@@ -46,6 +48,7 @@ type processRetryBatchConfig struct {
 	Version                int                           `json:"version"`
 	Tests                  []processRetryBatchTestConfig `json:"tests"`
 	CollectPerTestCoverage bool                          `json:"collect_per_test_coverage,omitempty"`
+	PreserveNativeSchedule bool                          `json:"preserve_native_schedule,omitempty"`
 }
 
 func processRetryBatchManifestPath(resultPath string) string {
@@ -60,8 +63,16 @@ func processRetryBatchResultPath(resultPath string, index int) string {
 	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-result-%06d.json", index))
 }
 
+func processRetryBatchGatePath(resultPath string, index int) string {
+	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-gate-%06d", index))
+}
+
+func processRetryBatchParallelPath(resultPath string, index int) string {
+	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-parallel-%06d", index))
+}
+
 func processRetryBatchChildConfig(root processRetryChildConfig, index int, test processRetryBatchTestConfig) processRetryChildConfig {
-	return processRetryChildConfig{
+	child := processRetryChildConfig{
 		ResultPath:             processRetryBatchResultPath(root.ResultPath, index),
 		TestName:               test.TestName,
 		Attempt:                root.Attempt,
@@ -74,6 +85,29 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		BatchChild:             true,
 		CollectPerTestCoverage: root.Batch != nil && root.Batch.CollectPerTestCoverage,
 		batchTest:              &test,
+	}
+	if root.Batch != nil && root.Batch.PreserveNativeSchedule {
+		// The native parent owns invocation identity; the child manifest is
+		// registered before those ordinals exist and is matched by batch index.
+		child.MRunEpoch = 0
+		child.InvocationOrdinal = 0
+		child.nativeGatePath = processRetryBatchGatePath(root.ResultPath, index)
+		child.nativeParallelPath = processRetryBatchParallelPath(root.ResultPath, index)
+	}
+	return child
+}
+
+func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bool) error {
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if deadlineOK && !time.Now().Before(deadline) {
+			return context.DeadlineExceeded
+		}
+		time.Sleep(processRetryBatchPollInterval)
 	}
 }
 
@@ -165,6 +199,193 @@ type deferredProcessRetryBatchOnceRunner func(
 	context.Context,
 	[]*deferredProcessRetryGroup,
 ) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult)
+
+type nativeScheduledProcessRetryBatch struct {
+	rootCfg    processRetryChildConfig
+	batch      *processRetryBatchConfig
+	resultRoot string
+	done       chan struct{}
+	cancel     context.CancelFunc
+	attempt    processRetryAttemptResult
+}
+
+func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdentity) {
+	if c == nil || identity.FullName == "" || len(identity.Segments) != 1 {
+		return
+	}
+	var testManagementData *net.TestManagementTestsResponseDataModules
+	if settings := integrations.GetSettings(); settings != nil && settings.SubtestFeaturesEnabled {
+		testManagementData = integrations.GetTestManagementTestsData()
+	}
+	spec := processRetryBatchTestConfig{
+		TestName:         identity.FullName,
+		DisabledSubtests: disabledProcessRetrySubtests(identity, testManagementData),
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.state != processRetryCoordinatorAccepting {
+		return
+	}
+	if c.nativeTestIndex == nil {
+		c.nativeTestIndex = make(map[string]int)
+	}
+	if _, exists := c.nativeTestIndex[identity.FullName]; exists {
+		return
+	}
+	c.nativeTestIndex[identity.FullName] = len(c.nativeTests)
+	c.nativeTests = append(c.nativeTests, spec)
+}
+
+func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProcessRetryGroup) (*nativeScheduledProcessRetryBatch, int, error) {
+	if c == nil || group == nil {
+		return nil, 0, errors.New("missing native process retry batch")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	index, found := c.nativeTestIndex[group.identity.FullName]
+	if !found || len(c.nativeTests) == 0 {
+		return nil, 0, errors.New("native process retry test was not registered")
+	}
+	if batch := c.nativeBatches[group.phaseID]; batch != nil {
+		return batch, index, nil
+	}
+	tempDir, err := os.MkdirTemp("", "dd-process-retry-native-*")
+	if err != nil {
+		return nil, 0, err
+	}
+	batchConfig := &processRetryBatchConfig{
+		Version:                processRetryBatchVersion,
+		Tests:                  append([]processRetryBatchTestConfig(nil), c.nativeTests...),
+		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
+		PreserveNativeSchedule: true,
+	}
+	rootCfg := processRetryChildConfig{
+		TestName:          processRetryBatchTestName,
+		Attempt:           1,
+		RetryReason:       processRetryBatchReason,
+		MRunEpoch:         group.mRunEpoch,
+		InvocationOrdinal: group.invocationOrdinal,
+		Batch:             batchConfig,
+		tempDir:           tempDir,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	batch := &nativeScheduledProcessRetryBatch{
+		rootCfg:    rootCfg,
+		batch:      batchConfig,
+		resultRoot: filepath.Join(tempDir, "result.json"),
+		done:       make(chan struct{}),
+		cancel:     cancel,
+	}
+	if c.nativeBatches == nil {
+		c.nativeBatches = make(map[uint64]*nativeScheduledProcessRetryBatch)
+	}
+	c.nativeBatches[group.phaseID] = batch
+	go func() {
+		batch.attempt = runProcessRetryAttemptWithBaselineAndShutdown(
+			ctx,
+			rootCfg,
+			group.parentDeadline,
+			group.parentDeadlineOK,
+			group.launchBaseline,
+			group.shutdown(),
+		)
+		close(batch.done)
+	}()
+	return batch, index, nil
+}
+
+func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferredProcessRetryGroup, t *testing.T) processRetryAttemptResult {
+	batch, index, err := c.startNativeScheduledBatch(group)
+	if err != nil {
+		now := time.Now()
+		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
+	}
+	if err := os.WriteFile(processRetryBatchGatePath(batch.resultRoot, index), nil, processRetryBatchManifestMode); err != nil {
+		now := time.Now()
+		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
+	}
+	expectedRoot := batch.rootCfg
+	expectedRoot.ResultPath = batch.resultRoot
+	expectedRoot.ParentDeadlineOK = group.parentDeadlineOK
+	expected := processRetryBatchChildConfig(expectedRoot, index, batch.batch.Tests[index])
+	parallelPath := processRetryBatchParallelPath(batch.resultRoot, index)
+	parallel := false
+	readAttempt := func() (processRetryAttemptResult, bool) {
+		result, timingOK, readErr := readProcessRetryResult(expected.ResultPath, expected)
+		if readErr != nil {
+			return processRetryAttemptResult{}, false
+		}
+		attempt := completedProcessRetryAttempt(result)
+		if timingOK {
+			attempt.StartTime = time.Unix(0, result.StartUnixNano)
+			attempt.FinishTime = time.Unix(0, result.FinishUnixNano)
+		}
+		return attempt, true
+	}
+	ticker := time.NewTicker(processRetryBatchPollInterval)
+	defer ticker.Stop()
+	for {
+		if attempt, ok := readAttempt(); ok {
+			return attempt
+		}
+		if !parallel {
+			if _, statErr := os.Stat(parallelPath); statErr == nil {
+				parallel = true
+				t.Parallel()
+			}
+		}
+		select {
+		case <-batch.done:
+			if attempt, ok := readAttempt(); ok {
+				return attempt
+			}
+			attempt := batch.attempt
+			attempt.Cleanup = nil
+			return attempt
+		case <-ticker.C:
+		case <-c.shutdown:
+			now := time.Now()
+			return processRetryAttemptResult{SetupFailure: true, Err: errProcessRetryShutdown, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
+		}
+	}
+}
+
+func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (processRetryAttemptResult, bool) {
+	if c == nil {
+		return processRetryAttemptResult{}, false
+	}
+	c.mu.Lock()
+	batch := c.nativeBatches[phaseID]
+	c.mu.Unlock()
+	if batch == nil {
+		return processRetryAttemptResult{}, false
+	}
+	<-batch.done
+	if batch.attempt.OutputTail != "" {
+		_, _ = io.WriteString(os.Stdout, batch.attempt.OutputTail)
+	}
+	if err := coverage.MergeProcessCoverageProfile(processRetryBatchCoveragePath(batch.resultRoot)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Debug("civisibility: failed to merge isolated first-attempt coverage: %s", err.Error())
+	}
+	return batch.attempt, true
+}
+
+func (c *processRetryCoordinator) cleanupNativeScheduledBatch(phaseID uint64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	batch := c.nativeBatches[phaseID]
+	delete(c.nativeBatches, phaseID)
+	c.mu.Unlock()
+	if batch == nil {
+		return
+	}
+	batch.cancel()
+	if batch.attempt.Cleanup != nil {
+		batch.attempt.Cleanup()
+	}
+}
 
 func runDeferredQuarantinedProcessRetryBatch(
 	ctx context.Context,

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -45,6 +45,7 @@ type processRetryBatchTestConfig struct {
 	TestName             string                         `json:"test_name"`
 	InvocationOrdinal    uint64                         `json:"invocation_ordinal,omitempty"`
 	DisabledSubtests     []string                       `json:"disabled_subtests,omitempty"`
+	QuarantinedSubtests  []string                       `json:"quarantined_subtests,omitempty"`
 	AttemptToFixSubtests []string                       `json:"attempt_to_fix_subtests,omitempty"`
 	ITRSubtests          []processRetrySubtestITRConfig `json:"itr_subtests,omitempty"`
 }
@@ -363,6 +364,16 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 				seenDirectives[name] = struct{}{}
 			}
 		}
+		seenQuarantined := make(map[string]struct{}, len(test.QuarantinedSubtests))
+		for _, name := range test.QuarantinedSubtests {
+			if !strings.HasPrefix(name, test.TestName+"/") {
+				return errors.New("invalid process retry quarantined subtest")
+			}
+			if _, duplicate := seenQuarantined[name]; duplicate {
+				return errors.New("duplicate process retry quarantined subtest")
+			}
+			seenQuarantined[name] = struct{}{}
+		}
 		seenITR := make(map[string]struct{}, len(test.ITRSubtests))
 		for _, subtest := range test.ITRSubtests {
 			if !strings.HasPrefix(subtest.TestName, test.TestName+"/") {
@@ -377,17 +388,17 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 	return nil
 }
 
-func processRetryTestManagementSubtests(identity testIdentity, modules *net.TestManagementTestsResponseDataModules) (disabled, attemptToFix []string) {
+func processRetryTestManagementSubtests(identity testIdentity, modules *net.TestManagementTestsResponseDataModules) (disabled, quarantined, attemptToFix []string) {
 	if modules == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	module, ok := modules.Modules[identity.ModuleName]
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	suite, ok := module.Suites[identity.SuiteName]
 	if !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
 	prefix := identity.FullName + "/"
 	for name, test := range suite.Tests {
@@ -399,10 +410,14 @@ func processRetryTestManagementSubtests(identity testIdentity, modules *net.Test
 		} else if test.Properties.Disabled {
 			disabled = append(disabled, name)
 		}
+		if test.Properties.Quarantined {
+			quarantined = append(quarantined, name)
+		}
 	}
 	slices.Sort(disabled)
+	slices.Sort(quarantined)
 	slices.Sort(attemptToFix)
-	return disabled, attemptToFix
+	return disabled, quarantined, attemptToFix
 }
 
 func processRetryAttemptToFixRetries() int {
@@ -471,10 +486,11 @@ func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdent
 	if settings := integrations.GetSettings(); settings != nil && settings.SubtestFeaturesEnabled {
 		testManagementData = integrations.GetTestManagementTestsData()
 	}
-	disabled, attemptToFix := processRetryTestManagementSubtests(identity, testManagementData)
+	disabled, quarantined, attemptToFix := processRetryTestManagementSubtests(identity, testManagementData)
 	spec := processRetryBatchTestConfig{
 		TestName:             identity.FullName,
 		DisabledSubtests:     disabled,
+		QuarantinedSubtests:  quarantined,
 		AttemptToFixSubtests: attemptToFix,
 		ITRSubtests:          processRetryITRSubtests(identity, currentITRState()),
 	}
@@ -725,7 +741,7 @@ func (c *processRetryCoordinator) nativeScheduledBatchResult(invocationOrdinal u
 	}
 	<-batch.done
 	mergePendingProcessRetryTestLog(&batch.attempt)
-	if batch.attempt.OutputTail != "" {
+	if batch.attempt.OutputTail != "" && !batch.attempt.outputStreamed {
 		_, _ = io.WriteString(os.Stdout, batch.attempt.OutputTail)
 	}
 	if err := coverage.MergeProcessCoverageProfile(processRetryBatchCoveragePath(batch.resultRoot)); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -902,11 +918,12 @@ func runDeferredProcessRetryBatchOnce(
 		testManagementData = integrations.GetTestManagementTestsData()
 	}
 	for _, group := range groups {
-		disabled, attemptToFix := processRetryTestManagementSubtests(group.identity, testManagementData)
+		disabled, quarantined, attemptToFix := processRetryTestManagementSubtests(group.identity, testManagementData)
 		spec := processRetryBatchTestConfig{
 			TestName:             group.identity.FullName,
 			InvocationOrdinal:    group.invocationOrdinal,
 			DisabledSubtests:     disabled,
+			QuarantinedSubtests:  quarantined,
 			AttemptToFixSubtests: attemptToFix,
 		}
 		if preserveNativeSchedule {
@@ -948,7 +965,7 @@ func runDeferredProcessRetryBatchOnce(
 		first.launchBaseline,
 		first.shutdown(),
 	)
-	if processAttempt.OutputTail != "" {
+	if processAttempt.OutputTail != "" && !processAttempt.outputStreamed {
 		_, _ = io.WriteString(os.Stdout, processAttempt.OutputTail)
 	}
 	mergePendingProcessRetryTestLog(&processAttempt)

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -606,12 +606,22 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 	for {
 		if !parallel {
 			if attempt, readErr := readAttempt(); readErr == nil {
+				// Wait for the child M.Run coverage report before the parent test can finish.
+				<-batch.done
 				return attempt
 			}
 		}
 		if !parallel {
 			if _, statErr := os.Stat(parallelPath); statErr == nil {
 				parallel = true
+				// Mirror mutations made before t.Parallel before the parent continues enumeration.
+				state, stateErr := readProcessRetryBatchInvocationState(parallelPath)
+				if stateErr == nil {
+					stateErr = applyProcessRetryBatchFinalState(state)
+				}
+				if stateErr != nil {
+					return failedNativeScheduledAttempt(stateErr)
+				}
 				// The child is paused inside t.Parallel while both native schedulers
 				// enumerate. Reacquire admission before opening the bridge so the test
 				// body remains subject to the configured process concurrency limit.

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -375,7 +375,9 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 		if attempt, ok := readAttempt(); ok {
 			return attempt
 		}
-		if !parallel {
+		// Covered batch bodies stay serial because their counters are process-global;
+		// mirroring t.Parallel in the parent would race with coverage's barrier guard.
+		if !parallel && !batch.batch.CollectPerTestCoverage {
 			if _, statErr := os.Stat(parallelPath); statErr == nil {
 				parallel = true
 				t.Parallel()

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -17,6 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
 const (
@@ -34,12 +37,17 @@ type processRetryBatchTestConfig struct {
 }
 
 type processRetryBatchConfig struct {
-	Version int                           `json:"version"`
-	Tests   []processRetryBatchTestConfig `json:"tests"`
+	Version                int                           `json:"version"`
+	Tests                  []processRetryBatchTestConfig `json:"tests"`
+	CollectPerTestCoverage bool                          `json:"collect_per_test_coverage,omitempty"`
 }
 
 func processRetryBatchManifestPath(resultPath string) string {
 	return filepath.Clean(resultPath) + ".batch.json"
+}
+
+func processRetryBatchCoveragePath(resultPath string) string {
+	return filepath.Clean(resultPath) + ".coverage.out"
 }
 
 func processRetryBatchResultPath(resultPath string, index int) string {
@@ -58,6 +66,7 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		ParentDeadlineOK:       root.ParentDeadlineOK,
 		ObservedGOMAXPROCS:     root.ObservedGOMAXPROCS,
 		BatchChild:             true,
+		CollectPerTestCoverage: root.Batch != nil && root.Batch.CollectPerTestCoverage,
 	}
 }
 
@@ -151,6 +160,17 @@ func runDeferredQuarantinedProcessRetryBatchWithRunner(
 			maps.Copy(results, missing)
 			break
 		}
+		globalStop := false
+		for _, attempt := range missing {
+			if deferredProcessRetryGlobalStopReason(attempt) != "" {
+				globalStop = true
+				break
+			}
+		}
+		if globalStop {
+			maps.Copy(results, missing)
+			break
+		}
 		if len(completed) > 0 {
 			next := pending[:0]
 			for _, group := range pending {
@@ -186,7 +206,11 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		return completed, missing
 	}
 	first := groups[0]
-	batch := &processRetryBatchConfig{Version: processRetryBatchVersion, Tests: make([]processRetryBatchTestConfig, 0, len(groups))}
+	batch := &processRetryBatchConfig{
+		Version:                processRetryBatchVersion,
+		Tests:                  make([]processRetryBatchTestConfig, 0, len(groups)),
+		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
+	}
 	for _, group := range groups {
 		batch.Tests = append(batch.Tests, processRetryBatchTestConfig{
 			TestName:          group.identity.FullName,
@@ -210,6 +234,7 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		first.launchBaseline,
 		first.shutdown(),
 	)
+	replayDeferredProcessRetryBatchOutput(os.Stdout, processAttempt)
 	if processAttempt.TempDir == "" {
 		for _, group := range groups {
 			attempt := processAttempt
@@ -222,6 +247,9 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		return completed, missing
 	}
 	resultRoot := filepath.Join(processAttempt.TempDir, "result.json")
+	if err := coverage.MergeProcessCoverageProfile(processRetryBatchCoveragePath(resultRoot)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Debug("civisibility: failed to merge isolated first-attempt coverage: %s", err.Error())
+	}
 	expectedRoot := rootCfg
 	expectedRoot.ResultPath = resultRoot
 	expectedRoot.ParentDeadlineOK = parentDeadlineOK
@@ -248,6 +276,12 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		processAttempt.Cleanup()
 	}
 	return completed, missing
+}
+
+func replayDeferredProcessRetryBatchOutput(writer io.Writer, attempt processRetryAttemptResult) {
+	if writer != nil && attempt.OutputTail != "" {
+		_, _ = io.WriteString(writer, attempt.OutputTail)
+	}
 }
 
 func earliestDeferredProcessRetryDeadline(groups []*deferredProcessRetryGroup) (time.Time, bool) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,6 +93,10 @@ func processRetryBatchParallelPath(resultPath string, index int) string {
 	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-parallel-%06d", index))
 }
 
+func processRetryBatchEnumerationPath(resultPath string) string {
+	return filepath.Join(filepath.Dir(resultPath), "batch-parent-enumerated")
+}
+
 func processRetryBatchChildConfig(root processRetryChildConfig, index int, test processRetryBatchTestConfig) processRetryChildConfig {
 	child := processRetryChildConfig{
 		ResultPath:             processRetryBatchResultPath(root.ResultPath, index),
@@ -118,6 +123,7 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		child.InvocationOrdinal = 0
 		child.nativeGatePath = processRetryBatchGatePath(root.ResultPath, index)
 		child.nativeParallelPath = processRetryBatchParallelPath(root.ResultPath, index)
+		child.nativeEnumerationPath = processRetryBatchEnumerationPath(root.ResultPath)
 	}
 	return child
 }
@@ -137,6 +143,20 @@ func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bo
 		}
 		if deadlineOK && !time.Now().Before(deadline) {
 			return processRetryBatchInvocationState{}, false, context.DeadlineExceeded
+		}
+		time.Sleep(processRetryBatchPollInterval)
+	}
+}
+
+func waitForProcessRetryBatchSignal(path string, deadline time.Time, deadlineOK bool) error {
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if deadlineOK && !time.Now().Before(deadline) {
+			return context.DeadlineExceeded
 		}
 		time.Sleep(processRetryBatchPollInterval)
 	}
@@ -396,6 +416,7 @@ type nativeScheduledProcessRetryBatch struct {
 	done       chan struct{}
 	cancel     context.CancelFunc
 	attempt    processRetryAttemptResult
+	signal     func() error
 }
 
 func (c *processRetryCoordinator) setNativeTestOrder(order func() []string) {
@@ -499,13 +520,17 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		tempDir:           tempDir,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	resultRoot := filepath.Join(tempDir, "result.json")
 	batch := &nativeScheduledProcessRetryBatch{
 		rootCfg:    rootCfg,
 		batch:      batchConfig,
 		testIndex:  indexes,
-		resultRoot: filepath.Join(tempDir, "result.json"),
+		resultRoot: resultRoot,
 		done:       make(chan struct{}),
 		cancel:     cancel,
+		signal: sync.OnceValue(func() error {
+			return os.WriteFile(processRetryBatchEnumerationPath(resultRoot), nil, processRetryBatchManifestMode)
+		}),
 	}
 	if c.nativeBatches == nil {
 		c.nativeBatches = make(map[uint64]*nativeScheduledProcessRetryBatch)
@@ -528,12 +553,10 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferredProcessRetryGroup, t *testing.T) processRetryAttemptResult {
 	batch, index, err := c.startNativeScheduledBatch(group)
 	if err != nil {
-		now := time.Now()
-		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
+		return failedNativeScheduledAttempt(err)
 	}
 	if err := writeProcessRetryBatchInvocationState(processRetryBatchGatePath(batch.resultRoot, index), group.launchBaseline); err != nil {
-		now := time.Now()
-		return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
+		return failedNativeScheduledAttempt(err)
 	}
 	expectedRoot := batch.rootCfg
 	expectedRoot.ResultPath = batch.resultRoot
@@ -541,22 +564,22 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 	expected := processRetryBatchChildConfig(expectedRoot, index, batch.batch.Tests[index])
 	parallelPath := processRetryBatchParallelPath(batch.resultRoot, index)
 	parallel := false
-	readAttempt := func() (processRetryAttemptResult, bool) {
+	readAttempt := func() (processRetryAttemptResult, error) {
 		result, timingOK, readErr := readProcessRetryResult(expected.ResultPath, expected)
 		if readErr != nil {
-			return processRetryAttemptResult{}, false
+			return processRetryAttemptResult{}, readErr
 		}
 		attempt := completedProcessRetryAttempt(result)
 		if timingOK {
 			attempt.StartTime = time.Unix(0, result.StartUnixNano)
 			attempt.FinishTime = time.Unix(0, result.FinishUnixNano)
 		}
-		return attempt, true
+		return attempt, nil
 	}
 	ticker := time.NewTicker(processRetryBatchPollInterval)
 	defer ticker.Stop()
 	for {
-		if attempt, ok := readAttempt(); ok {
+		if attempt, readErr := readAttempt(); readErr == nil {
 			return attempt
 		}
 		// Covered batch bodies stay serial because their counters are process-global;
@@ -565,12 +588,18 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 			if _, statErr := os.Stat(parallelPath); statErr == nil {
 				parallel = true
 				t.Parallel()
+				if err := batch.signal(); err != nil {
+					return failedNativeScheduledAttempt(err)
+				}
 			}
 		}
 		select {
 		case <-batch.done:
-			if attempt, ok := readAttempt(); ok {
+			if attempt, readErr := readAttempt(); readErr == nil {
 				return attempt
+			} else if errors.Is(readErr, errProcessRetryResultMissing) && deferredProcessRetryGlobalStopReason(batch.attempt) == "" {
+				now := time.Now()
+				return processRetryAttemptResult{Err: readErr, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 			}
 			attempt := batch.attempt
 			attempt.Cleanup = nil
@@ -581,6 +610,11 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 			return processRetryAttemptResult{SetupFailure: true, Err: errProcessRetryShutdown, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 		}
 	}
+}
+
+func failedNativeScheduledAttempt(err error) processRetryAttemptResult {
+	now := time.Now()
+	return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 }
 
 func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (processRetryAttemptResult, bool) {
@@ -655,6 +689,13 @@ func runDeferredQuarantinedProcessRetryBatch(
 	return runDeferredQuarantinedProcessRetryBatchWithRunner(ctx, groups, runDeferredQuarantinedProcessRetryBatchOnce)
 }
 
+func runDeferredNativeScheduledProcessRetryBatch(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+	return runDeferredQuarantinedProcessRetryBatchWithRunner(ctx, groups, runDeferredNativeScheduledProcessRetryBatchOnce)
+}
+
 func runDeferredQuarantinedProcessRetryBatchWithRunner(
 	ctx context.Context,
 	groups []*deferredProcessRetryGroup,
@@ -712,27 +753,60 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 	ctx context.Context,
 	groups []*deferredProcessRetryGroup,
 ) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult) {
+	return runDeferredProcessRetryBatchOnce(ctx, groups, false)
+}
+
+func runDeferredNativeScheduledProcessRetryBatchOnce(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult) {
+	return runDeferredProcessRetryBatchOnce(ctx, groups, true)
+}
+
+func runDeferredProcessRetryBatchOnce(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+	preserveNativeSchedule bool,
+) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult) {
 	completed := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
 	missing := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
 	if len(groups) == 0 {
 		return completed, missing
+	}
+	fail := func(err error) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		attempt := failedNativeScheduledAttempt(err)
+		for _, group := range groups {
+			missing[group] = attempt
+		}
+		return missing
 	}
 	first := groups[0]
 	batch := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
 		Tests:                  make([]processRetryBatchTestConfig, 0, len(groups)),
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
+		PreserveNativeSchedule: preserveNativeSchedule,
+	}
+	if preserveNativeSchedule {
+		if state := currentITRState(); state != nil {
+			batch.ITRCoverageActive = state.coverageActive
+			batch.ImpactedTestsEnabled = state.settings != nil && state.settings.ImpactedTestsEnabled
+		}
 	}
 	var testManagementData *net.TestManagementTestsResponseDataModules
 	if settings := integrations.GetSettings(); settings != nil && settings.SubtestFeaturesEnabled {
 		testManagementData = integrations.GetTestManagementTestsData()
 	}
 	for _, group := range groups {
-		batch.Tests = append(batch.Tests, processRetryBatchTestConfig{
+		spec := processRetryBatchTestConfig{
 			TestName:          group.identity.FullName,
 			InvocationOrdinal: group.invocationOrdinal,
 			DisabledSubtests:  disabledProcessRetrySubtests(group.identity, testManagementData),
-		})
+		}
+		if preserveNativeSchedule {
+			spec.ITRSubtests = processRetryITRSubtests(group.identity, currentITRState(), testManagementData)
+		}
+		batch.Tests = append(batch.Tests, spec)
 	}
 	parentDeadline, parentDeadlineOK := earliestDeferredProcessRetryDeadline(groups)
 	rootCfg := processRetryChildConfig{
@@ -742,6 +816,23 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		MRunEpoch:         first.mRunEpoch,
 		InvocationOrdinal: first.invocationOrdinal,
 		Batch:             batch,
+	}
+	if preserveNativeSchedule {
+		tempDir, err := os.MkdirTemp("", "dd-process-retry-native-*")
+		if err != nil {
+			return completed, fail(err)
+		}
+		defer func() { _ = os.RemoveAll(tempDir) }()
+		rootCfg.tempDir = tempDir
+		resultRoot := filepath.Join(tempDir, "result.json")
+		for index, group := range groups {
+			if err := writeProcessRetryBatchInvocationState(processRetryBatchGatePath(resultRoot, index), group.launchBaseline); err != nil {
+				return completed, fail(err)
+			}
+		}
+		if err := os.WriteFile(processRetryBatchEnumerationPath(resultRoot), nil, processRetryBatchManifestMode); err != nil {
+			return completed, fail(err)
+		}
 	}
 	processAttempt := runProcessRetryAttemptWithBaselineAndShutdown(
 		ctx,

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -97,6 +97,10 @@ func processRetryBatchEnumerationPath(resultPath string) string {
 	return filepath.Join(filepath.Dir(resultPath), "batch-parent-enumerated")
 }
 
+func processRetryBatchFinalStatePath(resultPath string) string {
+	return filepath.Clean(resultPath) + ".state"
+}
+
 func processRetryBatchChildConfig(root processRetryChildConfig, index int, test processRetryBatchTestConfig) processRetryChildConfig {
 	child := processRetryChildConfig{
 		ResultPath:             processRetryBatchResultPath(root.ResultPath, index),
@@ -406,40 +410,14 @@ type deferredProcessRetryBatchOnceRunner func(
 ) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult)
 
 type nativeScheduledProcessRetryBatch struct {
-	rootCfg    processRetryChildConfig
-	batch      *processRetryBatchConfig
-	testIndex  map[string]int
-	resultRoot string
-	done       chan struct{}
-	cancel     context.CancelFunc
-	attempt    processRetryAttemptResult
-	signal     func() error
-}
-
-func (c *processRetryCoordinator) setNativeTestOrder(order func() []string) {
-	if c == nil {
-		return
-	}
-	c.mu.Lock()
-	c.nativeTestOrder = order
-	c.mu.Unlock()
-}
-
-func nativeScheduledTestsInParentOrder(tests []processRetryBatchTestConfig, registeredIndexes map[string]int, parentOrder []string) ([]processRetryBatchTestConfig, map[string]int, error) {
-	ordered := make([]processRetryBatchTestConfig, 0, len(tests))
-	indexes := make(map[string]int, len(tests))
-	for _, name := range parentOrder {
-		registeredIndex, found := registeredIndexes[name]
-		if !found {
-			continue
-		}
-		indexes[name] = len(ordered)
-		ordered = append(ordered, tests[registeredIndex])
-	}
-	if len(ordered) != len(tests) {
-		return nil, nil, errors.New("native process retry test order is incomplete")
-	}
-	return ordered, indexes, nil
+	rootCfg            processRetryChildConfig
+	batch              *processRetryBatchConfig
+	resultRoot         string
+	done               chan struct{}
+	cancel             context.CancelFunc
+	attempt            processRetryAttemptResult
+	signal             func() error
+	processSlotRelease <-chan processRetryLimiterRelease
 }
 
 func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdentity) {
@@ -470,36 +448,26 @@ func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdent
 	c.nativeTests = append(c.nativeTests, spec)
 }
 
-func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProcessRetryGroup) (*nativeScheduledProcessRetryBatch, int, error) {
+func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProcessRetryGroup) (*nativeScheduledProcessRetryBatch, error) {
 	if c == nil || group == nil {
-		return nil, 0, errors.New("missing native process retry batch")
+		return nil, errors.New("missing native process retry batch")
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, found := c.nativeTestIndex[group.identity.FullName]; !found || len(c.nativeTests) == 0 {
-		return nil, 0, errors.New("native process retry test was not registered")
+	registeredIndex, found := c.nativeTestIndex[group.identity.FullName]
+	if !found || registeredIndex >= len(c.nativeTests) {
+		return nil, errors.New("native process retry test was not registered")
 	}
-	if batch := c.nativeBatches[group.phaseID]; batch != nil {
-		index, found := batch.testIndex[group.identity.FullName]
-		if !found {
-			return nil, 0, errors.New("native process retry test is missing from batch")
-		}
-		return batch, index, nil
-	}
-	if c.nativeTestOrder == nil {
-		return nil, 0, errors.New("native process retry test order is unavailable")
-	}
-	tests, indexes, err := nativeScheduledTestsInParentOrder(c.nativeTests, c.nativeTestIndex, c.nativeTestOrder())
-	if err != nil {
-		return nil, 0, err
+	if batch := c.nativeBatches[group.invocationOrdinal]; batch != nil {
+		return batch, nil
 	}
 	tempDir, err := os.MkdirTemp("", "dd-process-retry-native-*")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	batchConfig := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
-		Tests:                  tests,
+		Tests:                  []processRetryBatchTestConfig{c.nativeTests[registeredIndex]},
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 		PreserveNativeSchedule: true,
 	}
@@ -518,13 +486,15 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	resultRoot := filepath.Join(tempDir, "result.json")
+	processSlotRelease := make(chan processRetryLimiterRelease, 1)
+	rootCfg.processSlotRelease = processSlotRelease
 	batch := &nativeScheduledProcessRetryBatch{
-		rootCfg:    rootCfg,
-		batch:      batchConfig,
-		testIndex:  indexes,
-		resultRoot: resultRoot,
-		done:       make(chan struct{}),
-		cancel:     cancel,
+		rootCfg:            rootCfg,
+		batch:              batchConfig,
+		resultRoot:         resultRoot,
+		done:               make(chan struct{}),
+		cancel:             cancel,
+		processSlotRelease: processSlotRelease,
 		signal: sync.OnceValue(func() error {
 			return writeCurrentProcessRetryBatchInvocationState(processRetryBatchEnumerationPath(resultRoot))
 		}),
@@ -532,7 +502,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	if c.nativeBatches == nil {
 		c.nativeBatches = make(map[uint64]*nativeScheduledProcessRetryBatch)
 	}
-	c.nativeBatches[group.phaseID] = batch
+	c.nativeBatches[group.invocationOrdinal] = batch
 	go func() {
 		batch.attempt = runProcessRetryAttemptWithBaselineAndShutdown(
 			ctx,
@@ -544,14 +514,15 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		)
 		close(batch.done)
 	}()
-	return batch, indexes[group.identity.FullName], nil
+	return batch, nil
 }
 
 func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferredProcessRetryGroup, t *testing.T) processRetryAttemptResult {
-	batch, index, err := c.startNativeScheduledBatch(group)
+	batch, err := c.startNativeScheduledBatch(group)
 	if err != nil {
 		return failedNativeScheduledAttempt(err)
 	}
+	index := 0
 	if err := writeProcessRetryBatchInvocationState(processRetryBatchGatePath(batch.resultRoot, index), group.launchBaseline); err != nil {
 		return failedNativeScheduledAttempt(err)
 	}
@@ -566,6 +537,15 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 		if readErr != nil {
 			return processRetryAttemptResult{}, readErr
 		}
+		if result.Status != processRetryStatusNotRun && !result.RootParallel {
+			state, stateErr := readProcessRetryBatchInvocationState(processRetryBatchFinalStatePath(expected.ResultPath))
+			if stateErr == nil {
+				stateErr = applyProcessRetryBatchInvocationState(state)
+			}
+			if stateErr != nil {
+				return failedNativeScheduledAttempt(stateErr), nil
+			}
+		}
 		attempt := completedProcessRetryAttempt(result)
 		if timingOK {
 			attempt.StartTime = time.Unix(0, result.StartUnixNano)
@@ -579,12 +559,15 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 		if attempt, readErr := readAttempt(); readErr == nil {
 			return attempt
 		}
-		// Covered batch bodies stay serial because their counters are process-global;
-		// mirroring t.Parallel in the parent would race with coverage's barrier guard.
-		if !parallel && !batch.batch.CollectPerTestCoverage {
+		if !parallel {
 			if _, statErr := os.Stat(parallelPath); statErr == nil {
 				parallel = true
-				t.Parallel()
+				// The parent scheduler bounds the body after the parallel transition.
+				// Release process admission first so a limit of one cannot block enumeration.
+				(<-batch.processSlotRelease)()
+				if err := transitionNativeScheduledTestToParallel(t); err != nil {
+					return failedNativeScheduledAttempt(err)
+				}
 				if err := batch.signal(); err != nil {
 					return failedNativeScheduledAttempt(err)
 				}
@@ -609,17 +592,41 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 	}
 }
 
+func transitionNativeScheduledTestToParallel(t *testing.T) error {
+	// Per-test coverage temporarily replaces the shared parent barrier while
+	// serial tests run. Capture it before releasing enumeration so the parallel
+	// transition cannot race with that replacement.
+	layout, reason := getRetryAttemptLayout()
+	if reason != "" {
+		return errors.New(reason)
+	}
+	base := commonBaseForTest(t, layout)
+	parentBase := pointerWord(base, layout.common.parent)
+	if base == nil || parentBase == nil {
+		return errors.New("testing_t_parent_layout_unsupported")
+	}
+	barrier := *fieldPtr[chan bool](parentBase, layout.common.barrier)
+	if barrier == nil {
+		return errors.New("testing_t_parent_barrier_unavailable")
+	}
+	group := retryAttemptGroup{original: t, layout: layout, originalParentBarrier: barrier}
+	group.transitionOriginalToParallel()
+	testingTestStateWaitParallel(getTestState(t))
+	initializeRetryAttemptStart(base, layout.common.start.unsafeField)
+	return nil
+}
+
 func failedNativeScheduledAttempt(err error) processRetryAttemptResult {
 	now := time.Now()
 	return processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 }
 
-func (c *processRetryCoordinator) nativeScheduledBatchResult(phaseID uint64) (processRetryAttemptResult, bool) {
+func (c *processRetryCoordinator) nativeScheduledBatchResult(invocationOrdinal uint64) (processRetryAttemptResult, bool) {
 	if c == nil {
 		return processRetryAttemptResult{}, false
 	}
 	c.mu.Lock()
-	batch := c.nativeBatches[phaseID]
+	batch := c.nativeBatches[invocationOrdinal]
 	c.mu.Unlock()
 	if batch == nil {
 		return processRetryAttemptResult{}, false
@@ -662,13 +669,13 @@ func skipUninvokedNativeScheduledTests(batch *nativeScheduledProcessRetryBatch) 
 	return nil
 }
 
-func (c *processRetryCoordinator) cleanupNativeScheduledBatch(phaseID uint64) {
+func (c *processRetryCoordinator) cleanupNativeScheduledBatch(invocationOrdinal uint64) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
-	batch := c.nativeBatches[phaseID]
-	delete(c.nativeBatches, phaseID)
+	batch := c.nativeBatches[invocationOrdinal]
+	delete(c.nativeBatches, invocationOrdinal)
 	c.mu.Unlock()
 	if batch == nil {
 		return
@@ -690,7 +697,15 @@ func runDeferredNativeScheduledProcessRetryBatch(
 	ctx context.Context,
 	groups []*deferredProcessRetryGroup,
 ) map[*deferredProcessRetryGroup]processRetryAttemptResult {
-	return runDeferredQuarantinedProcessRetryBatchWithRunner(ctx, groups, runDeferredNativeScheduledProcessRetryBatchOnce)
+	results := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+	for _, group := range groups {
+		maps.Copy(results, runDeferredQuarantinedProcessRetryBatchWithRunner(
+			ctx,
+			[]*deferredProcessRetryGroup{group},
+			runDeferredNativeScheduledProcessRetryBatchOnce,
+		))
+	}
+	return results
 }
 
 func runDeferredQuarantinedProcessRetryBatchWithRunner(
@@ -776,6 +791,9 @@ func runDeferredProcessRetryBatchOnce(
 			missing[group] = attempt
 		}
 		return missing
+	}
+	if preserveNativeSchedule && len(groups) != 1 {
+		return completed, fail(errors.New("native process retry batch must contain one test"))
 	}
 	first := groups[0]
 	batch := &processRetryBatchConfig{

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -148,20 +148,6 @@ func waitForProcessRetryBatchGate(path string, deadline time.Time, deadlineOK bo
 	}
 }
 
-func waitForProcessRetryBatchSignal(path string, deadline time.Time, deadlineOK bool) error {
-	for {
-		if _, err := os.Stat(path); err == nil {
-			return nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-		if deadlineOK && !time.Now().Before(deadline) {
-			return context.DeadlineExceeded
-		}
-		time.Sleep(processRetryBatchPollInterval)
-	}
-}
-
 func writeProcessRetryBatchInvocationState(path string, baseline *processRetryLaunchBaseline) error {
 	if baseline == nil {
 		return errors.New("missing process retry invocation state")
@@ -189,6 +175,17 @@ func writeProcessRetryBatchInvocationState(path string, baseline *processRetryLa
 		return errors.New("process retry invocation state too large")
 	}
 	return writeProcessRetryFileAtomically(path, payload, ".process-retry-gate-*.tmp")
+}
+
+func writeCurrentProcessRetryBatchInvocationState(path string) error {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return writeProcessRetryBatchInvocationState(path, &processRetryLaunchBaseline{
+		workingDirectory: workingDirectory,
+		environment:      sanitizeProcessRetryBaseEnv(os.Environ()),
+	})
 }
 
 func readProcessRetryBatchInvocationState(path string) (processRetryBatchInvocationState, error) {
@@ -529,7 +526,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		done:       make(chan struct{}),
 		cancel:     cancel,
 		signal: sync.OnceValue(func() error {
-			return os.WriteFile(processRetryBatchEnumerationPath(resultRoot), nil, processRetryBatchManifestMode)
+			return writeCurrentProcessRetryBatchInvocationState(processRetryBatchEnumerationPath(resultRoot))
 		}),
 	}
 	if c.nativeBatches == nil {
@@ -830,7 +827,7 @@ func runDeferredProcessRetryBatchOnce(
 				return completed, fail(err)
 			}
 		}
-		if err := os.WriteFile(processRetryBatchEnumerationPath(resultRoot), nil, processRetryBatchManifestMode); err != nil {
+		if err := writeCurrentProcessRetryBatchInvocationState(processRetryBatchEnumerationPath(resultRoot)); err != nil {
 			return completed, fail(err)
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,16 +143,12 @@ func runDeferredQuarantinedProcessRetryBatchWithRunner(
 	pending := append([]*deferredProcessRetryGroup(nil), groups...)
 	for len(pending) > 0 {
 		completed, missing := runOnce(ctx, pending)
-		for group, result := range completed {
-			results[group] = result
-		}
+		maps.Copy(results, completed)
 		if len(missing) == 0 {
 			break
 		}
 		if ctx.Err() != nil {
-			for group, result := range missing {
-				results[group] = result
-			}
+			maps.Copy(results, missing)
 			break
 		}
 		if len(completed) > 0 {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -1,0 +1,269 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	processRetryBatchVersion      = 1
+	processRetryBatchTestName     = "__dd_quarantined_race_batch__"
+	processRetryBatchReason       = "quarantined_race"
+	processRetryBatchMaxTests     = 100_000
+	processRetryBatchMaxBytes     = 16 * 1024 * 1024
+	processRetryBatchManifestMode = 0o600
+)
+
+type processRetryBatchTestConfig struct {
+	TestName          string `json:"test_name"`
+	InvocationOrdinal uint64 `json:"invocation_ordinal,omitempty"`
+}
+
+type processRetryBatchConfig struct {
+	Version int                           `json:"version"`
+	Tests   []processRetryBatchTestConfig `json:"tests"`
+}
+
+func processRetryBatchManifestPath(resultPath string) string {
+	return filepath.Clean(resultPath) + ".batch.json"
+}
+
+func processRetryBatchResultPath(resultPath string, index int) string {
+	return filepath.Join(filepath.Dir(resultPath), fmt.Sprintf("batch-result-%06d.json", index))
+}
+
+func processRetryBatchChildConfig(root processRetryChildConfig, index int, test processRetryBatchTestConfig) processRetryChildConfig {
+	return processRetryChildConfig{
+		ResultPath:             processRetryBatchResultPath(root.ResultPath, index),
+		TestName:               test.TestName,
+		Attempt:                root.Attempt,
+		RetryReason:            root.RetryReason,
+		MRunEpoch:              root.MRunEpoch,
+		InvocationOrdinal:      test.InvocationOrdinal,
+		ParentDeadlineUnixNano: root.ParentDeadlineUnixNano,
+		ParentDeadlineOK:       root.ParentDeadlineOK,
+		ObservedGOMAXPROCS:     root.ObservedGOMAXPROCS,
+		BatchChild:             true,
+	}
+}
+
+func writeProcessRetryBatchConfig(path string, cfg *processRetryBatchConfig) error {
+	if err := validateProcessRetryBatchConfig(cfg); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	if len(payload) > processRetryBatchMaxBytes {
+		return errors.New("process retry batch manifest too large")
+	}
+	return os.WriteFile(path, payload, processRetryBatchManifestMode)
+}
+
+func readProcessRetryBatchConfig(path string) (*processRetryBatchConfig, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	payload, err := io.ReadAll(io.LimitReader(file, processRetryBatchMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > processRetryBatchMaxBytes {
+		return nil, errors.New("process retry batch manifest too large")
+	}
+	var cfg processRetryBatchConfig
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("process retry batch manifest has trailing data")
+	}
+	if err := validateProcessRetryBatchConfig(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
+	if cfg == nil || cfg.Version != processRetryBatchVersion || len(cfg.Tests) == 0 || len(cfg.Tests) > processRetryBatchMaxTests {
+		return errors.New("invalid process retry batch manifest")
+	}
+	seen := make(map[string]struct{}, len(cfg.Tests))
+	for _, test := range cfg.Tests {
+		if strings.TrimSpace(test.TestName) == "" {
+			return errors.New("invalid process retry batch test")
+		}
+		if _, duplicate := seen[test.TestName]; duplicate {
+			return errors.New("duplicate process retry batch test")
+		}
+		seen[test.TestName] = struct{}{}
+	}
+	return nil
+}
+
+type deferredProcessRetryBatchRunner func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult
+
+type deferredProcessRetryBatchOnceRunner func(
+	context.Context,
+	[]*deferredProcessRetryGroup,
+) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult)
+
+func runDeferredQuarantinedProcessRetryBatch(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+	return runDeferredQuarantinedProcessRetryBatchWithRunner(ctx, groups, runDeferredQuarantinedProcessRetryBatchOnce)
+}
+
+func runDeferredQuarantinedProcessRetryBatchWithRunner(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+	runOnce deferredProcessRetryBatchOnceRunner,
+) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+	results := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+	pending := append([]*deferredProcessRetryGroup(nil), groups...)
+	for len(pending) > 0 {
+		completed, missing := runOnce(ctx, pending)
+		for group, result := range completed {
+			results[group] = result
+		}
+		if len(missing) == 0 {
+			break
+		}
+		if ctx.Err() != nil {
+			for group, result := range missing {
+				results[group] = result
+			}
+			break
+		}
+		if len(completed) > 0 {
+			next := pending[:0]
+			for _, group := range pending {
+				if _, stillMissing := missing[group]; stillMissing {
+					next = append(next, group)
+				}
+			}
+			pending = next
+			continue
+		}
+		for _, group := range pending {
+			oneCompleted, oneMissing := runOnce(ctx, []*deferredProcessRetryGroup{group})
+			if result, ok := oneCompleted[group]; ok {
+				results[group] = result
+				continue
+			}
+			if result, ok := oneMissing[group]; ok {
+				results[group] = result
+			}
+		}
+		break
+	}
+	return results
+}
+
+func runDeferredQuarantinedProcessRetryBatchOnce(
+	ctx context.Context,
+	groups []*deferredProcessRetryGroup,
+) (map[*deferredProcessRetryGroup]processRetryAttemptResult, map[*deferredProcessRetryGroup]processRetryAttemptResult) {
+	completed := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+	missing := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+	if len(groups) == 0 {
+		return completed, missing
+	}
+	first := groups[0]
+	batch := &processRetryBatchConfig{Version: processRetryBatchVersion, Tests: make([]processRetryBatchTestConfig, 0, len(groups))}
+	for _, group := range groups {
+		batch.Tests = append(batch.Tests, processRetryBatchTestConfig{
+			TestName:          group.identity.FullName,
+			InvocationOrdinal: group.invocationOrdinal,
+		})
+	}
+	parentDeadline, parentDeadlineOK := earliestDeferredProcessRetryDeadline(groups)
+	rootCfg := processRetryChildConfig{
+		TestName:          processRetryBatchTestName,
+		Attempt:           1,
+		RetryReason:       processRetryBatchReason,
+		MRunEpoch:         first.mRunEpoch,
+		InvocationOrdinal: first.invocationOrdinal,
+		Batch:             batch,
+	}
+	processAttempt := runProcessRetryAttemptWithBaselineAndShutdown(
+		ctx,
+		rootCfg,
+		parentDeadline,
+		parentDeadlineOK,
+		first.launchBaseline,
+		first.shutdown(),
+	)
+	if processAttempt.TempDir == "" {
+		for _, group := range groups {
+			attempt := processAttempt
+			attempt.Cleanup = nil
+			missing[group] = attempt
+		}
+		if processAttempt.Cleanup != nil {
+			processAttempt.Cleanup()
+		}
+		return completed, missing
+	}
+	resultRoot := filepath.Join(processAttempt.TempDir, "result.json")
+	expectedRoot := rootCfg
+	expectedRoot.ResultPath = resultRoot
+	expectedRoot.ParentDeadlineOK = parentDeadlineOK
+	for index, group := range groups {
+		expected := processRetryBatchChildConfig(expectedRoot, index, batch.Tests[index])
+		result, timingOK, err := readProcessRetryResult(expected.ResultPath, expected)
+		if err != nil {
+			attempt := processAttempt
+			attempt.Cleanup = nil
+			missing[group] = attempt
+			continue
+		}
+		attempt := completedProcessRetryAttempt(result)
+		if timingOK {
+			attempt.StartTime = time.Unix(0, result.StartUnixNano)
+			attempt.FinishTime = time.Unix(0, result.FinishUnixNano)
+		} else {
+			attempt.StartTime = processAttempt.StartTime
+			attempt.FinishTime = processAttempt.FinishTime
+		}
+		completed[group] = attempt
+	}
+	if processAttempt.Cleanup != nil {
+		processAttempt.Cleanup()
+	}
+	return completed, missing
+}
+
+func earliestDeferredProcessRetryDeadline(groups []*deferredProcessRetryGroup) (time.Time, bool) {
+	var earliest time.Time
+	found := false
+	for _, group := range groups {
+		if group == nil || !group.parentDeadlineOK {
+			continue
+		}
+		if !found || group.parentDeadline.Before(earliest) {
+			earliest = group.parentDeadline
+			found = true
+		}
+	}
+	return earliest, found
+}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -234,7 +234,9 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		first.launchBaseline,
 		first.shutdown(),
 	)
-	replayDeferredProcessRetryBatchOutput(os.Stdout, processAttempt)
+	if processAttempt.OutputTail != "" {
+		_, _ = io.WriteString(os.Stdout, processAttempt.OutputTail)
+	}
 	if processAttempt.TempDir == "" {
 		for _, group := range groups {
 			attempt := processAttempt
@@ -276,12 +278,6 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		processAttempt.Cleanup()
 	}
 	return completed, missing
-}
-
-func replayDeferredProcessRetryBatchOutput(writer io.Writer, attempt processRetryAttemptResult) {
-	if writer != nil && attempt.OutputTail != "" {
-		_, _ = io.WriteString(writer, attempt.OutputTail)
-	}
 }
 
 func earliestDeferredProcessRetryDeadline(groups []*deferredProcessRetryGroup) (time.Time, bool) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -212,7 +212,7 @@ func validateProcessRetryBatchInvocationState(state processRetryBatchInvocationS
 		key, value, ok := strings.Cut(entry, "=")
 		normalizedKey := processRetryInvocationEnvironmentKey(key)
 		if !ok || key == "" || strings.IndexByte(key, 0) >= 0 || strings.IndexByte(value, 0) >= 0 ||
-			isProcessRetryInternalEnvKey(key) || strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable) {
+			isProcessRetryExcludedEnvKey(key) {
 			return errors.New("invalid process retry invocation environment")
 		}
 		if _, duplicate := seen[normalizedKey]; duplicate {
@@ -224,6 +224,14 @@ func validateProcessRetryBatchInvocationState(state processRetryBatchInvocationS
 }
 
 func applyProcessRetryBatchInvocationState(state processRetryBatchInvocationState) error {
+	return applyProcessRetryBatchInvocationStateWithOptions(state, false)
+}
+
+func applyProcessRetryBatchFinalState(state processRetryBatchInvocationState) error {
+	return applyProcessRetryBatchInvocationStateWithOptions(state, true)
+}
+
+func applyProcessRetryBatchInvocationStateWithOptions(state processRetryBatchInvocationState, preserveExcludedEnvironment bool) error {
 	if err := validateProcessRetryBatchInvocationState(state); err != nil {
 		return err
 	}
@@ -238,6 +246,9 @@ func applyProcessRetryBatchInvocationState(state processRetryBatchInvocationStat
 	for _, entry := range os.Environ() {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok || key == "" {
+			continue
+		}
+		if preserveExcludedEnvironment && isProcessRetryExcludedEnvKey(key) {
 			continue
 		}
 		if _, ok := desired[processRetryInvocationEnvironmentKey(key)]; !ok {
@@ -413,6 +424,7 @@ type nativeScheduledProcessRetryBatch struct {
 	rootCfg            processRetryChildConfig
 	batch              *processRetryBatchConfig
 	resultRoot         string
+	ctx                context.Context
 	done               chan struct{}
 	cancel             context.CancelFunc
 	attempt            processRetryAttemptResult
@@ -492,6 +504,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		rootCfg:            rootCfg,
 		batch:              batchConfig,
 		resultRoot:         resultRoot,
+		ctx:                ctx,
 		done:               make(chan struct{}),
 		cancel:             cancel,
 		processSlotRelease: processSlotRelease,
@@ -504,6 +517,8 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	}
 	c.nativeBatches[group.invocationOrdinal] = batch
 	go func() {
+		defer close(batch.done)
+		defer cancel()
 		batch.attempt = runProcessRetryAttemptWithBaselineAndShutdown(
 			ctx,
 			rootCfg,
@@ -512,7 +527,6 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 			group.launchBaseline,
 			group.shutdown(),
 		)
-		close(batch.done)
 	}()
 	return batch, nil
 }
@@ -540,7 +554,7 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 		if result.Status != processRetryStatusNotRun && !result.RootParallel {
 			state, stateErr := readProcessRetryBatchInvocationState(processRetryBatchFinalStatePath(expected.ResultPath))
 			if stateErr == nil {
-				stateErr = applyProcessRetryBatchInvocationState(state)
+				stateErr = applyProcessRetryBatchFinalState(state)
 			}
 			if stateErr != nil {
 				return failedNativeScheduledAttempt(stateErr), nil
@@ -556,18 +570,35 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 	ticker := time.NewTicker(processRetryBatchPollInterval)
 	defer ticker.Stop()
 	for {
-		if attempt, readErr := readAttempt(); readErr == nil {
-			return attempt
+		if !parallel {
+			if attempt, readErr := readAttempt(); readErr == nil {
+				return attempt
+			}
 		}
 		if !parallel {
 			if _, statErr := os.Stat(parallelPath); statErr == nil {
 				parallel = true
-				// The parent scheduler bounds the body after the parallel transition.
-				// Release process admission first so a limit of one cannot block enumeration.
+				// The child is paused inside t.Parallel while both native schedulers
+				// enumerate. Reacquire admission before opening the bridge so the test
+				// body remains subject to the configured process concurrency limit.
 				(<-batch.processSlotRelease)()
 				if err := transitionNativeScheduledTestToParallel(t); err != nil {
 					return failedNativeScheduledAttempt(err)
 				}
+				limiterResult := acquireNativeScheduledProcessSlot(batch, group)
+				if limiterResult.Cause != processRetryLimiterAcquired {
+					if errors.Is(limiterResult.Err, context.Canceled) {
+						<-batch.done
+						return nativeScheduledBatchAttempt(batch)
+					}
+					select {
+					case <-batch.done:
+						return nativeScheduledBatchAttempt(batch)
+					default:
+						return failedNativeScheduledAttempt(limiterResult.Err)
+					}
+				}
+				defer limiterResult.Release()
 				if err := batch.signal(); err != nil {
 					return failedNativeScheduledAttempt(err)
 				}
@@ -581,15 +612,28 @@ func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferre
 				now := time.Now()
 				return processRetryAttemptResult{Err: readErr, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 			}
-			attempt := batch.attempt
-			attempt.Cleanup = nil
-			return attempt
+			return nativeScheduledBatchAttempt(batch)
 		case <-ticker.C:
 		case <-c.shutdown:
 			now := time.Now()
 			return processRetryAttemptResult{SetupFailure: true, Err: errProcessRetryShutdown, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now}
 		}
 	}
+}
+
+func nativeScheduledBatchAttempt(batch *nativeScheduledProcessRetryBatch) processRetryAttemptResult {
+	attempt := batch.attempt
+	attempt.Cleanup = nil
+	return attempt
+}
+
+func acquireNativeScheduledProcessSlot(batch *nativeScheduledProcessRetryBatch, group *deferredProcessRetryGroup) processRetryLimiterAcquireResult {
+	return getProcessRetryLimiter().acquireWithShutdownLimit(
+		batch.ctx,
+		nil,
+		group.shutdown(),
+		int(processRetryParallelMaxConcurrencyForBaseline(group.launchBaseline)),
+	)
 }
 
 func transitionNativeScheduledTestToParallel(t *testing.T) error {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -42,21 +42,22 @@ const (
 var errProcessRetryBatchFailed = errors.New("process retry batch failed")
 
 type processRetryBatchTestConfig struct {
-	TestName          string                         `json:"test_name"`
-	InvocationOrdinal uint64                         `json:"invocation_ordinal,omitempty"`
-	DisabledSubtests  []string                       `json:"disabled_subtests,omitempty"`
-	ITRSubtests       []processRetrySubtestITRConfig `json:"itr_subtests,omitempty"`
+	TestName             string                         `json:"test_name"`
+	InvocationOrdinal    uint64                         `json:"invocation_ordinal,omitempty"`
+	DisabledSubtests     []string                       `json:"disabled_subtests,omitempty"`
+	AttemptToFixSubtests []string                       `json:"attempt_to_fix_subtests,omitempty"`
+	ITRSubtests          []processRetrySubtestITRConfig `json:"itr_subtests,omitempty"`
 }
 
 type processRetrySubtestITRConfig struct {
 	TestName                string `json:"test_name"`
 	MissingLineCodeCoverage bool   `json:"missing_line_code_coverage,omitempty"`
-	AttemptToFix            bool   `json:"attempt_to_fix,omitempty"`
 }
 
 type processRetryBatchConfig struct {
 	Version                int                           `json:"version"`
 	Tests                  []processRetryBatchTestConfig `json:"tests"`
+	AttemptToFixRetries    int                           `json:"attempt_to_fix_retries,omitempty"`
 	CollectPerTestCoverage bool                          `json:"collect_per_test_coverage,omitempty"`
 	PreserveNativeSchedule bool                          `json:"preserve_native_schedule,omitempty"`
 	ITRCoverageActive      bool                          `json:"itr_coverage_active,omitempty"`
@@ -117,6 +118,7 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		batchTest:              &test,
 	}
 	if root.Batch != nil {
+		child.attemptToFixRetries = root.Batch.AttemptToFixRetries
 		child.itrCoverageActive = root.Batch.ITRCoverageActive
 		child.impactedTestsAnalyzer = root.impactedTestsAnalyzer
 	}
@@ -243,12 +245,21 @@ func applyProcessRetryBatchInvocationStateWithOptions(state processRetryBatchInv
 		key, _, _ := strings.Cut(entry, "=")
 		desired[processRetryInvocationEnvironmentKey(key)] = struct{}{}
 	}
+	preserved := make(map[string]struct{})
+	if preserveExcludedEnvironment {
+		for _, entry := range os.Environ() {
+			key, value, ok := strings.Cut(entry, "=")
+			if ok && (isProcessRetryExcludedEnvKey(key) || isProcessRetryParentOnlyEnv(key, value)) {
+				preserved[processRetryInvocationEnvironmentKey(key)] = struct{}{}
+			}
+		}
+	}
 	for _, entry := range os.Environ() {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok || key == "" {
 			continue
 		}
-		if preserveExcludedEnvironment && isProcessRetryExcludedEnvKey(key) {
+		if _, ok := preserved[processRetryInvocationEnvironmentKey(key)]; ok {
 			continue
 		}
 		if _, ok := desired[processRetryInvocationEnvironmentKey(key)]; !ok {
@@ -259,6 +270,9 @@ func applyProcessRetryBatchInvocationStateWithOptions(state processRetryBatchInv
 	}
 	for _, entry := range state.Environment {
 		key, value, _ := strings.Cut(entry, "=")
+		if _, ok := preserved[processRetryInvocationEnvironmentKey(key)]; ok {
+			continue
+		}
 		if err := os.Setenv(key, value); err != nil {
 			return err
 		}
@@ -324,7 +338,8 @@ func readProcessRetryBatchJSON[T any](path, kind string) (T, error) {
 }
 
 func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
-	if cfg == nil || cfg.Version != processRetryBatchVersion || len(cfg.Tests) == 0 || len(cfg.Tests) > processRetryBatchMaxTests {
+	if cfg == nil || cfg.Version != processRetryBatchVersion || len(cfg.Tests) == 0 || len(cfg.Tests) > processRetryBatchMaxTests ||
+		cfg.AttemptToFixRetries < 0 || cfg.AttemptToFixRetries > processRetryBatchMaxTests {
 		return errors.New("invalid process retry batch manifest")
 	}
 	seen := make(map[string]struct{}, len(cfg.Tests))
@@ -336,6 +351,18 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 			return errors.New("duplicate process retry batch test")
 		}
 		seen[test.TestName] = struct{}{}
+		seenDirectives := make(map[string]struct{}, len(test.DisabledSubtests)+len(test.AttemptToFixSubtests))
+		for _, names := range [][]string{test.DisabledSubtests, test.AttemptToFixSubtests} {
+			for _, name := range names {
+				if !strings.HasPrefix(name, test.TestName+"/") {
+					return errors.New("invalid process retry managed subtest")
+				}
+				if _, duplicate := seenDirectives[name]; duplicate {
+					return errors.New("duplicate process retry managed subtest")
+				}
+				seenDirectives[name] = struct{}{}
+			}
+		}
 		seenITR := make(map[string]struct{}, len(test.ITRSubtests))
 		for _, subtest := range test.ITRSubtests {
 			if !strings.HasPrefix(subtest.TestName, test.TestName+"/") {
@@ -350,30 +377,43 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 	return nil
 }
 
-func disabledProcessRetrySubtests(identity testIdentity, modules *net.TestManagementTestsResponseDataModules) []string {
+func processRetryTestManagementSubtests(identity testIdentity, modules *net.TestManagementTestsResponseDataModules) (disabled, attemptToFix []string) {
 	if modules == nil {
-		return nil
+		return nil, nil
 	}
 	module, ok := modules.Modules[identity.ModuleName]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	suite, ok := module.Suites[identity.SuiteName]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	prefix := identity.FullName + "/"
-	var disabled []string
 	for name, test := range suite.Tests {
-		if strings.HasPrefix(name, prefix) && test.Properties.Disabled && !test.Properties.AttemptToFix {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if test.Properties.AttemptToFix {
+			attemptToFix = append(attemptToFix, name)
+		} else if test.Properties.Disabled {
 			disabled = append(disabled, name)
 		}
 	}
 	slices.Sort(disabled)
-	return disabled
+	slices.Sort(attemptToFix)
+	return disabled, attemptToFix
 }
 
-func processRetryITRSubtests(identity testIdentity, state *itrState, modules *net.TestManagementTestsResponseDataModules) []processRetrySubtestITRConfig {
+func processRetryAttemptToFixRetries() int {
+	settings := integrations.GetSettings()
+	if settings == nil || !settings.SubtestFeaturesEnabled {
+		return 0
+	}
+	return max(settings.TestManagement.AttemptToFixRetries, 0)
+}
+
+func processRetryITRSubtests(identity testIdentity, state *itrState) []processRetrySubtestITRConfig {
 	if state == nil || !state.testsSkippingEnabled() || state.response == nil {
 		return nil
 	}
@@ -395,15 +435,6 @@ func processRetryITRSubtests(identity testIdentity, state *itrState, modules *ne
 		}
 		if !matched {
 			continue
-		}
-		if modules != nil {
-			if module, ok := modules.Modules[identity.ModuleName]; ok {
-				if managedSuite, ok := module.Suites[identity.SuiteName]; ok {
-					if test, ok := managedSuite.Tests[name]; ok {
-						config.AttemptToFix = test.Properties.AttemptToFix
-					}
-				}
-			}
 		}
 		configs = append(configs, config)
 	}
@@ -440,10 +471,12 @@ func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdent
 	if settings := integrations.GetSettings(); settings != nil && settings.SubtestFeaturesEnabled {
 		testManagementData = integrations.GetTestManagementTestsData()
 	}
+	disabled, attemptToFix := processRetryTestManagementSubtests(identity, testManagementData)
 	spec := processRetryBatchTestConfig{
-		TestName:         identity.FullName,
-		DisabledSubtests: disabledProcessRetrySubtests(identity, testManagementData),
-		ITRSubtests:      processRetryITRSubtests(identity, currentITRState(), testManagementData),
+		TestName:             identity.FullName,
+		DisabledSubtests:     disabled,
+		AttemptToFixSubtests: attemptToFix,
+		ITRSubtests:          processRetryITRSubtests(identity, currentITRState()),
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -480,6 +513,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	batchConfig := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
 		Tests:                  []processRetryBatchTestConfig{c.nativeTests[registeredIndex]},
+		AttemptToFixRetries:    processRetryAttemptToFixRetries(),
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 		PreserveNativeSchedule: true,
 	}
@@ -843,6 +877,7 @@ func runDeferredProcessRetryBatchOnce(
 	batch := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
 		Tests:                  make([]processRetryBatchTestConfig, 0, len(groups)),
+		AttemptToFixRetries:    processRetryAttemptToFixRetries(),
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 		PreserveNativeSchedule: preserveNativeSchedule,
 	}
@@ -857,13 +892,15 @@ func runDeferredProcessRetryBatchOnce(
 		testManagementData = integrations.GetTestManagementTestsData()
 	}
 	for _, group := range groups {
+		disabled, attemptToFix := processRetryTestManagementSubtests(group.identity, testManagementData)
 		spec := processRetryBatchTestConfig{
-			TestName:          group.identity.FullName,
-			InvocationOrdinal: group.invocationOrdinal,
-			DisabledSubtests:  disabledProcessRetrySubtests(group.identity, testManagementData),
+			TestName:             group.identity.FullName,
+			InvocationOrdinal:    group.invocationOrdinal,
+			DisabledSubtests:     disabled,
+			AttemptToFixSubtests: attemptToFix,
 		}
 		if preserveNativeSchedule {
-			spec.ITRSubtests = processRetryITRSubtests(group.identity, currentITRState(), testManagementData)
+			spec.ITRSubtests = processRetryITRSubtests(group.identity, currentITRState())
 		}
 		batch.Tests = append(batch.Tests, spec)
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -15,10 +15,13 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
@@ -31,9 +34,12 @@ const (
 	processRetryBatchManifestMode = 0o600
 )
 
+var errProcessRetryBatchFailed = errors.New("process retry batch failed")
+
 type processRetryBatchTestConfig struct {
-	TestName          string `json:"test_name"`
-	InvocationOrdinal uint64 `json:"invocation_ordinal,omitempty"`
+	TestName          string   `json:"test_name"`
+	InvocationOrdinal uint64   `json:"invocation_ordinal,omitempty"`
+	DisabledSubtests  []string `json:"disabled_subtests,omitempty"`
 }
 
 type processRetryBatchConfig struct {
@@ -67,6 +73,7 @@ func processRetryBatchChildConfig(root processRetryChildConfig, index int, test 
 		ObservedGOMAXPROCS:     root.ObservedGOMAXPROCS,
 		BatchChild:             true,
 		CollectPerTestCoverage: root.Batch != nil && root.Batch.CollectPerTestCoverage,
+		batchTest:              &test,
 	}
 }
 
@@ -127,6 +134,29 @@ func validateProcessRetryBatchConfig(cfg *processRetryBatchConfig) error {
 		seen[test.TestName] = struct{}{}
 	}
 	return nil
+}
+
+func disabledProcessRetrySubtests(identity testIdentity, modules *net.TestManagementTestsResponseDataModules) []string {
+	if modules == nil {
+		return nil
+	}
+	module, ok := modules.Modules[identity.ModuleName]
+	if !ok {
+		return nil
+	}
+	suite, ok := module.Suites[identity.SuiteName]
+	if !ok {
+		return nil
+	}
+	prefix := identity.FullName + "/"
+	var disabled []string
+	for name, test := range suite.Tests {
+		if strings.HasPrefix(name, prefix) && test.Properties.Disabled && !test.Properties.AttemptToFix {
+			disabled = append(disabled, name)
+		}
+	}
+	slices.Sort(disabled)
+	return disabled
 }
 
 type deferredProcessRetryBatchRunner func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult
@@ -211,10 +241,15 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		Tests:                  make([]processRetryBatchTestConfig, 0, len(groups)),
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 	}
+	var testManagementData *net.TestManagementTestsResponseDataModules
+	if settings := integrations.GetSettings(); settings != nil && settings.SubtestFeaturesEnabled {
+		testManagementData = integrations.GetTestManagementTestsData()
+	}
 	for _, group := range groups {
 		batch.Tests = append(batch.Tests, processRetryBatchTestConfig{
 			TestName:          group.identity.FullName,
 			InvocationOrdinal: group.invocationOrdinal,
+			DisabledSubtests:  disabledProcessRetrySubtests(group.identity, testManagementData),
 		})
 	}
 	parentDeadline, parentDeadlineOK := earliestDeferredProcessRetryDeadline(groups)
@@ -274,10 +309,37 @@ func runDeferredQuarantinedProcessRetryBatchOnce(
 		}
 		completed[group] = attempt
 	}
+	preserveProcessRetryBatchFailure(processAttempt, groups, completed)
 	if processAttempt.Cleanup != nil {
 		processAttempt.Cleanup()
 	}
 	return completed, missing
+}
+
+func preserveProcessRetryBatchFailure(
+	processAttempt processRetryAttemptResult,
+	groups []*deferredProcessRetryGroup,
+	completed map[*deferredProcessRetryGroup]processRetryAttemptResult,
+) {
+	if !processAttempt.ExitStatusObserved || processAttempt.ExitCode == 0 {
+		return
+	}
+	for _, attempt := range completed {
+		if effectiveProcessRetryStatus(attempt, false).Failed {
+			return
+		}
+	}
+	for _, group := range groups {
+		attempt, ok := completed[group]
+		if !ok {
+			continue
+		}
+		attempt.ExitCode = processAttempt.ExitCode
+		attempt.ExitStatusObserved = true
+		attempt.Err = errors.Join(processAttempt.Err, errProcessRetryBatchFailed)
+		completed[group] = attempt
+		return
+	}
 }
 
 func earliestDeferredProcessRetryDeadline(groups []*deferredProcessRetryGroup) (time.Time, bool) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -842,6 +842,7 @@ func runDeferredProcessRetryBatchOnce(
 	if processAttempt.OutputTail != "" {
 		_, _ = io.WriteString(os.Stdout, processAttempt.OutputTail)
 	}
+	mergePendingProcessRetryTestLog(&processAttempt)
 	if processAttempt.TempDir == "" {
 		for _, group := range groups {
 			attempt := processAttempt

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -203,10 +203,37 @@ type deferredProcessRetryBatchOnceRunner func(
 type nativeScheduledProcessRetryBatch struct {
 	rootCfg    processRetryChildConfig
 	batch      *processRetryBatchConfig
+	testIndex  map[string]int
 	resultRoot string
 	done       chan struct{}
 	cancel     context.CancelFunc
 	attempt    processRetryAttemptResult
+}
+
+func (c *processRetryCoordinator) setNativeTestOrder(order func() []string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.nativeTestOrder = order
+	c.mu.Unlock()
+}
+
+func nativeScheduledTestsInParentOrder(tests []processRetryBatchTestConfig, registeredIndexes map[string]int, parentOrder []string) ([]processRetryBatchTestConfig, map[string]int, error) {
+	ordered := make([]processRetryBatchTestConfig, 0, len(tests))
+	indexes := make(map[string]int, len(tests))
+	for _, name := range parentOrder {
+		registeredIndex, found := registeredIndexes[name]
+		if !found {
+			continue
+		}
+		indexes[name] = len(ordered)
+		ordered = append(ordered, tests[registeredIndex])
+	}
+	if len(ordered) != len(tests) {
+		return nil, nil, errors.New("native process retry test order is incomplete")
+	}
+	return ordered, indexes, nil
 }
 
 func (c *processRetryCoordinator) registerNativeScheduledTest(identity testIdentity) {
@@ -242,12 +269,22 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	index, found := c.nativeTestIndex[group.identity.FullName]
-	if !found || len(c.nativeTests) == 0 {
+	if _, found := c.nativeTestIndex[group.identity.FullName]; !found || len(c.nativeTests) == 0 {
 		return nil, 0, errors.New("native process retry test was not registered")
 	}
 	if batch := c.nativeBatches[group.phaseID]; batch != nil {
+		index, found := batch.testIndex[group.identity.FullName]
+		if !found {
+			return nil, 0, errors.New("native process retry test is missing from batch")
+		}
 		return batch, index, nil
+	}
+	if c.nativeTestOrder == nil {
+		return nil, 0, errors.New("native process retry test order is unavailable")
+	}
+	tests, indexes, err := nativeScheduledTestsInParentOrder(c.nativeTests, c.nativeTestIndex, c.nativeTestOrder())
+	if err != nil {
+		return nil, 0, err
 	}
 	tempDir, err := os.MkdirTemp("", "dd-process-retry-native-*")
 	if err != nil {
@@ -255,7 +292,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	}
 	batchConfig := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
-		Tests:                  append([]processRetryBatchTestConfig(nil), c.nativeTests...),
+		Tests:                  tests,
 		CollectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
 		PreserveNativeSchedule: true,
 	}
@@ -272,6 +309,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 	batch := &nativeScheduledProcessRetryBatch{
 		rootCfg:    rootCfg,
 		batch:      batchConfig,
+		testIndex:  indexes,
 		resultRoot: filepath.Join(tempDir, "result.json"),
 		done:       make(chan struct{}),
 		cancel:     cancel,
@@ -291,7 +329,7 @@ func (c *processRetryCoordinator) startNativeScheduledBatch(group *deferredProce
 		)
 		close(batch.done)
 	}()
-	return batch, index, nil
+	return batch, indexes[group.identity.FullName], nil
 }
 
 func (c *processRetryCoordinator) waitNativeScheduledFirstAttempt(group *deferredProcessRetryGroup, t *testing.T) processRetryAttemptResult {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch.go
@@ -321,6 +321,18 @@ func preserveProcessRetryBatchFailure(
 	groups []*deferredProcessRetryGroup,
 	completed map[*deferredProcessRetryGroup]processRetryAttemptResult,
 ) {
+	if errors.Is(processAttempt.Err, errProcessRetryTestLogMerge) {
+		for _, group := range groups {
+			attempt, ok := completed[group]
+			if !ok {
+				continue
+			}
+			attempt.SetupFailure = true
+			attempt.Err = errors.Join(attempt.Err, processAttempt.Err)
+			completed[group] = attempt
+			return
+		}
+	}
 	if !processAttempt.ExitStatusObserved || processAttempt.ExitCode == 0 {
 		return
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -67,6 +67,40 @@ func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *test
 	require.Equal(t, processRetryBatchParallelPath(root.ResultPath, 2), child.nativeParallelPath)
 }
 
+func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	batch := &nativeScheduledProcessRetryBatch{
+		batch:      &processRetryBatchConfig{Tests: []processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}}},
+		resultRoot: resultPath,
+		done:       make(chan struct{}),
+		cancel:     func() {},
+	}
+	require.NoError(t, os.WriteFile(processRetryBatchGatePath(resultPath, 0), nil, processRetryBatchManifestMode))
+	run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 0), time.Time{}, false)
+	require.NoError(t, err)
+	require.True(t, run)
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	coordinator.nativeBatches = map[uint64]*nativeScheduledProcessRetryBatch{1: batch}
+	type gateResult struct {
+		run bool
+		err error
+	}
+	gate := make(chan gateResult, 1)
+	go func() {
+		run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 1), time.Time{}, false)
+		gate <- gateResult{run: run, err: err}
+		close(batch.done)
+	}()
+
+	_, ok := coordinator.nativeScheduledBatchResult(1)
+	require.True(t, ok)
+	decision := <-gate
+	require.NoError(t, decision.err)
+	require.False(t, decision.run)
+	require.NoFileExists(t, processRetryBatchSkipPath(resultPath, 0))
+	require.FileExists(t, processRetryBatchSkipPath(resultPath, 1))
+}
+
 func TestProcessRetryNativeScheduledTestsFollowParentOrder(t *testing.T) {
 	tests, indexes, err := nativeScheduledTestsInParentOrder(
 		[]processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}, {TestName: "TestC"}},

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -6,6 +6,7 @@
 package gotesting
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -18,7 +19,8 @@ import (
 func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "batch.json")
 	want := &processRetryBatchConfig{
-		Version: processRetryBatchVersion,
+		Version:                processRetryBatchVersion,
+		CollectPerTestCoverage: true,
 		Tests: []processRetryBatchTestConfig{
 			{TestName: "TestA", InvocationOrdinal: 11},
 			{TestName: "TestB", InvocationOrdinal: 12},
@@ -31,13 +33,14 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 	child := processRetryBatchChildConfig(processRetryChildConfig{
-		ResultPath: path, Attempt: 1, RetryReason: processRetryBatchReason, MRunEpoch: 7,
+		ResultPath: path, Attempt: 1, RetryReason: processRetryBatchReason, MRunEpoch: 7, Batch: got,
 	}, 1, got.Tests[1])
 	require.Equal(t, "TestB", child.TestName)
 	require.Equal(t, 1, child.Attempt)
 	require.Equal(t, processRetryBatchReason, child.RetryReason)
 	require.Equal(t, uint64(7), child.MRunEpoch)
 	require.Equal(t, uint64(12), child.InvocationOrdinal)
+	require.True(t, child.CollectPerTestCoverage)
 }
 
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
@@ -69,6 +72,25 @@ func TestProcessRetryBatchConfigRejectsUnknownAndTrailingData(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
+	snapshot := captureProcessRetryArgsSnapshot([]string{
+		"-test.run=^TestQuarantined$/wanted$",
+		"-test.skip=destructive$",
+	})
+
+	got, ok, reason := buildProcessRetryArgsFromSnapshot(processRetryBatchArgsSnapshot(snapshot), ".", 1, time.Second)
+
+	require.True(t, ok, reason)
+	require.Equal(t, []string{
+		"-test.failfast=false",
+		"-test.run=^TestQuarantined$/wanted$",
+		"-test.skip=destructive$",
+		"-test.count=1",
+		"-test.cpu=1",
+		"-test.timeout=1s",
+	}, got)
 }
 
 func TestProcessRetryBatchRetriesOnlyMissingGroups(t *testing.T) {
@@ -150,6 +172,26 @@ func TestProcessRetryBatchCancellationDoesNotSplitPendingWork(t *testing.T) {
 	require.ErrorIs(t, results[b].Err, context.Canceled)
 }
 
+func TestProcessRetryBatchGlobalStopDoesNotSplitPendingWork(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	calls := 0
+	runOnce := func(_ context.Context, _ []*deferredProcessRetryGroup) (
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+	) {
+		calls++
+		attempt := processRetryAttemptResult{Unreaped: true, Err: errProcessRetryChildUnreaped}
+		return nil, map[*deferredProcessRetryGroup]processRetryAttemptResult{a: attempt, b: attempt}
+	}
+
+	results := runDeferredQuarantinedProcessRetryBatchWithRunner(context.Background(), []*deferredProcessRetryGroup{a, b}, runOnce)
+
+	require.Equal(t, 1, calls)
+	require.True(t, results[a].Unreaped)
+	require.True(t, results[b].Unreaped)
+}
+
 func TestCompletedProcessRetryAttemptPreservesPanicSemantics(t *testing.T) {
 	attempt := completedProcessRetryAttempt(processRetryResult{
 		Status: processRetryStatusControlledPanicReady,
@@ -178,6 +220,15 @@ func TestProcessRetryBatchKeepsOutputPerTest(t *testing.T) {
 	require.Contains(t, b.OutputTail, processRetryOutputTruncationMarker)
 	require.Contains(t, b.OutputTail, "test-b-output-sentinel")
 	require.NotContains(t, b.OutputTail, "test-a-output-sentinel")
+}
+
+func TestProcessRetryBatchReplaysNativeOutputOnce(t *testing.T) {
+	var output bytes.Buffer
+	attempt := processRetryAttemptResult{OutputTail: "native stdout and stderr sentinel"}
+
+	replayDeferredProcessRetryBatchOutput(&output, attempt)
+
+	require.Equal(t, attempt.OutputTail, output.String())
 }
 
 func deferredProcessRetryBatchGroup(name string, ordinal uint64) *deferredProcessRetryGroup {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -6,7 +6,6 @@
 package gotesting
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -220,15 +219,6 @@ func TestProcessRetryBatchKeepsOutputPerTest(t *testing.T) {
 	require.Contains(t, b.OutputTail, processRetryOutputTruncationMarker)
 	require.Contains(t, b.OutputTail, "test-b-output-sentinel")
 	require.NotContains(t, b.OutputTail, "test-a-output-sentinel")
-}
-
-func TestProcessRetryBatchReplaysNativeOutputOnce(t *testing.T) {
-	var output bytes.Buffer
-	attempt := processRetryAttemptResult{OutputTail: "native stdout and stderr sentinel"}
-
-	replayDeferredProcessRetryBatchOutput(&output, attempt)
-
-	require.Equal(t, attempt.OutputTail, output.String())
 }
 
 func deferredProcessRetryBatchGroup(name string, ordinal uint64) *deferredProcessRetryGroup {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,6 +115,40 @@ func TestCurrentProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
 	require.Contains(t, state.Environment, "DD_TEST_BATCH_PARENT_STATE=post-enumeration")
 }
 
+func TestApplyProcessRetryBatchFinalStatePreservesCoverageDirectory(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		apply        func(processRetryBatchInvocationState) error
+		wantCoverage bool
+	}{
+		{name: "child invocation", apply: applyProcessRetryBatchInvocationState},
+		{name: "parent final state", apply: applyProcessRetryBatchFinalState, wantCoverage: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workingDirectory, err := os.Getwd()
+			require.NoError(t, err)
+			t.Setenv(processRetryCoverageDirectoryEnvironmentVariable, filepath.Join(t.TempDir(), "coverage"))
+			t.Setenv("DD_TEST_BATCH_REMOVED_STATE", "remove-me")
+			environment := slices.DeleteFunc(os.Environ(), func(entry string) bool {
+				key, _, _ := strings.Cut(entry, "=")
+				return key == "DD_TEST_BATCH_REMOVED_STATE" ||
+					strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable) ||
+					isProcessRetryInternalEnvKey(key)
+			})
+
+			require.NoError(t, test.apply(processRetryBatchInvocationState{
+				Version:          processRetryBatchGateVersion,
+				WorkingDirectory: workingDirectory,
+				Environment:      environment,
+			}))
+			_, coveragePresent := os.LookupEnv(processRetryCoverageDirectoryEnvironmentVariable)
+			require.Equal(t, test.wantCoverage, coveragePresent)
+			_, removedPresent := os.LookupEnv("DD_TEST_BATCH_REMOVED_STATE")
+			require.False(t, removedPresent)
+		})
+	}
+}
+
 func TestTransitionNativeScheduledTestToParallelUsesCapturedParentBarrier(t *testing.T) {
 	result := make(chan error, 1)
 	t.Run("parent", func(parent *testing.T) {
@@ -126,6 +162,99 @@ func TestTransitionNativeScheduledTestToParallelUsesCapturedParentBarrier(t *tes
 		*fields.barrier = barrier
 	})
 	require.NoError(t, <-result)
+}
+
+func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(t *testing.T) {
+	resetProcessRetryLimiterForTesting(t)
+	limiter := getProcessRetryLimiter()
+	initialSlot := limiter.acquireWithShutdownLimit(context.Background(), nil, nil, 1)
+	require.Equal(t, processRetryLimiterAcquired, initialSlot.Cause)
+	processSlotRelease := make(chan processRetryLimiterRelease, 1)
+	processSlotRelease <- initialSlot.Release
+	dir := t.TempDir()
+	resultRoot := filepath.Join(dir, "result.json")
+	testConfig := processRetryBatchTestConfig{TestName: "TestParallel"}
+	acquireEntered := make(chan struct{})
+	signalCalled := make(chan struct{})
+	activeAtSignal := make(chan int, 1)
+	batchConfig := &processRetryBatchConfig{
+		Version:                processRetryBatchVersion,
+		Tests:                  []processRetryBatchTestConfig{testConfig},
+		PreserveNativeSchedule: true,
+	}
+	batch := &nativeScheduledProcessRetryBatch{
+		rootCfg: processRetryChildConfig{
+			TestName:    processRetryBatchTestName,
+			Attempt:     1,
+			RetryReason: processRetryBatchReason,
+			Batch:       batchConfig,
+		},
+		batch:              batchConfig,
+		resultRoot:         resultRoot,
+		ctx:                &processRetryObservedDoneContext{Context: t.Context(), entered: acquireEntered},
+		done:               make(chan struct{}),
+		cancel:             func() {},
+		processSlotRelease: processSlotRelease,
+	}
+	batch.signal = func() error {
+		limiter.mu.Lock()
+		activeAtSignal <- limiter.active
+		limiter.mu.Unlock()
+		close(signalCalled)
+		now := time.Now()
+		err := writeProcessRetryResultAtomically(processRetryBatchResultPath(resultRoot, 0), processRetryResult{
+			Version:        1,
+			TestName:       testConfig.TestName,
+			Attempt:        1,
+			RetryReason:    processRetryBatchReason,
+			Status:         processRetryStatusPass,
+			RootParallel:   true,
+			StartUnixNano:  now.UnixNano(),
+			FinishUnixNano: now.Add(time.Millisecond).UnixNano(),
+			DurationNanos:  int64(time.Millisecond),
+		})
+		close(batch.done)
+		return err
+	}
+	require.NoError(t, os.WriteFile(processRetryBatchParallelPath(resultRoot, 0), nil, processRetryBatchManifestMode))
+	coordinator := &processRetryCoordinator{
+		nativeTestIndex: map[string]int{testConfig.TestName: 0},
+		nativeTests:     []processRetryBatchTestConfig{testConfig},
+		nativeBatches:   map[uint64]*nativeScheduledProcessRetryBatch{1: batch},
+		shutdown:        make(chan struct{}),
+	}
+	group := &deferredProcessRetryGroup{
+		identity:          *newTestIdentity("module", "suite", testConfig.TestName),
+		invocationOrdinal: 1,
+		launchBaseline: &processRetryLaunchBaseline{
+			workingDirectory:  dir,
+			maxConcurrency:    1,
+			maxConcurrencySet: true,
+		},
+	}
+	result := make(chan processRetryAttemptResult, 1)
+	signalBeforeAdmission := make(chan bool, 1)
+	t.Run("parent", func(parent *testing.T) {
+		parent.Run("parallel", func(child *testing.T) {
+			result <- coordinator.waitNativeScheduledFirstAttempt(group, child)
+		})
+		blockingSlot := limiter.acquireWithShutdownLimit(t.Context(), nil, nil, 1)
+		require.Equal(parent, processRetryLimiterAcquired, blockingSlot.Cause)
+		go func() {
+			select {
+			case <-acquireEntered:
+				signalBeforeAdmission <- false
+			case <-signalCalled:
+				signalBeforeAdmission <- true
+			}
+			blockingSlot.Release()
+		}()
+	})
+
+	require.False(t, <-signalBeforeAdmission)
+	require.Equal(t, 1, <-activeAtSignal)
+	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(<-result, false).Status)
+	require.Zero(t, processRetryLimiterActiveForTesting(t, limiter))
 }
 
 func TestProcessRetryBatchInvocationStateRejectsInvalidPayloads(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -46,6 +46,27 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.Equal(t, []string{"TestA/disabled"}, child.batchTest.DisabledSubtests)
 }
 
+func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *testing.T) {
+	root := processRetryChildConfig{
+		ResultPath:        filepath.Join(t.TempDir(), "result.json"),
+		Attempt:           1,
+		RetryReason:       processRetryBatchReason,
+		MRunEpoch:         7,
+		InvocationOrdinal: 11,
+		Batch: &processRetryBatchConfig{
+			Version:                processRetryBatchVersion,
+			PreserveNativeSchedule: true,
+		},
+	}
+
+	child := processRetryBatchChildConfig(root, 2, processRetryBatchTestConfig{TestName: "TestA"})
+
+	require.Zero(t, child.MRunEpoch)
+	require.Zero(t, child.InvocationOrdinal)
+	require.Equal(t, processRetryBatchGatePath(root.ResultPath, 2), child.nativeGatePath)
+	require.Equal(t, processRetryBatchParallelPath(root.ResultPath, 2), child.nativeParallelPath)
+}
+
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 	validTest := processRetryBatchTestConfig{TestName: "TestA"}
 	tests := map[string]*processRetryBatchConfig{
@@ -198,7 +219,6 @@ func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 	require.True(t, ok, reason)
 	require.Equal(t, []string{
 		"-test.failfast=false",
-		"-test.parallel=1",
 		"-test.testlogfile=child-testlog.txt",
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -527,16 +527,25 @@ func TestProcessRetryBatchOutputOmitsChildRunnerProtocol(t *testing.T) {
 		"\x16=== RUN   TestSelected",
 		"direct stdout",
 		"    selected_test.go:10: test log",
-		"--- FAIL: TestSelected (0.01s)",
-		"WARNING: DATA RACE",
-		"coverage: 42.0% of statements",
+		"PASS",
 		"FAIL",
+		"coverage: custom metric",
+		"=== application state",
+		"--- FAIL: application state",
+		"\x16--- FAIL: TestSelected (0.01s)",
+		"WARNING: DATA RACE",
 		"direct stderr",
+		"\x16FAIL",
 	}, "\n") + "\n"
 
 	require.Equal(t, strings.Join([]string{
 		"direct stdout",
 		"    selected_test.go:10: test log",
+		"PASS",
+		"FAIL",
+		"coverage: custom metric",
+		"=== application state",
+		"--- FAIL: application state",
 		"WARNING: DATA RACE",
 		"direct stderr",
 	}, "\n")+"\n", filterProcessRetryBatchOutput(output))
@@ -623,13 +632,28 @@ func TestRelaunchedNativeScheduledBatchMergesTestLog(t *testing.T) {
 func TestProcessRetryBatchTimeoutUsesPackageBudget(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	deadline := now.Add(30 * time.Minute)
+	disabled := captureProcessRetryArgsSnapshot([]string{"-test.timeout=0"})
 
+	require.True(t, disabled.timeoutSet)
+	require.Zero(t, disabled.timeout)
+	require.Zero(t, selectedProcessRetryTimeout(
+		true, disabled.timeout, disabled.timeoutSet, 0, false, time.Time{}, false, now,
+	))
+	require.Equal(t, 5*time.Minute, selectedProcessRetryTimeout(
+		true, disabled.timeout, disabled.timeoutSet, 5*time.Minute, true, time.Time{}, false, now,
+	))
+	require.Equal(t, 30*time.Minute-processRetryParentDeadlineReserve(), selectedProcessRetryTimeout(
+		true, disabled.timeout, disabled.timeoutSet, 0, false, deadline, true, now,
+	))
 	require.Equal(t, 30*time.Minute-processRetryParentDeadlineReserve(), selectedProcessRetryTimeout(
 		true, 30*time.Minute, true, 0, false, deadline, true, now,
 	))
 	require.Equal(t, 5*time.Minute, selectedProcessRetryTimeout(
 		true, 30*time.Minute, true, 5*time.Minute, true, deadline, true, now,
 	))
+	args, ok, reason := buildProcessRetryArgsFromSnapshot(disabled, ".", 1, 0)
+	require.True(t, ok, reason)
+	require.Contains(t, args, "-test.timeout=0s")
 }
 
 func TestProcessRetryBatchCoverageFlushBeforeTerminalReplay(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -77,6 +77,7 @@ func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *test
 	require.Zero(t, child.InvocationOrdinal)
 	require.Equal(t, processRetryBatchGatePath(root.ResultPath, 2), child.nativeGatePath)
 	require.Equal(t, processRetryBatchParallelPath(root.ResultPath, 2), child.nativeParallelPath)
+	require.Equal(t, processRetryBatchEnumerationPath(root.ResultPath), child.nativeEnumerationPath)
 }
 
 func TestProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -157,6 +157,20 @@ func TestPreserveProcessRetryBatchFailureKeepsDecodedFailure(t *testing.T) {
 	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(completed[b], false).Status)
 }
 
+func TestPreserveProcessRetryBatchFailureKeepsTestLogMergeFailure(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	completed := map[*deferredProcessRetryGroup]processRetryAttemptResult{
+		a: completedProcessRetryAttempt(processRetryResult{Status: processRetryStatusFail, Failed: true}),
+	}
+
+	preserveProcessRetryBatchFailure(processRetryAttemptResult{
+		Err: errors.Join(errProcessRetryTestLogMerge, errors.New("malformed child log")),
+	}, []*deferredProcessRetryGroup{a}, completed)
+
+	require.True(t, completed[a].SetupFailure)
+	require.ErrorIs(t, completed[a].Err, errProcessRetryTestLogMerge)
+}
+
 func TestProcessRetryBatchConfigRejectsUnknownAndTrailingData(t *testing.T) {
 	for name, payload := range map[string]string{
 		"unknown field": `{"version":1,"tests":[{"test_name":"TestA"}],"unknown":true}`,
@@ -175,19 +189,69 @@ func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 	snapshot := captureProcessRetryArgsSnapshot([]string{
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",
+		"-test.testlogfile=parent-testlog.txt",
 	})
 
-	got, ok, reason := buildProcessRetryArgsFromSnapshot(processRetryBatchArgsSnapshot(snapshot), ".", 1, time.Second)
+	require.Equal(t, "parent-testlog.txt", snapshot.testLogFile)
+	got, ok, reason := buildProcessRetryArgsFromSnapshot(processRetryBatchArgsSnapshot(snapshot, "child-testlog.txt"), ".", 1, time.Second)
 
 	require.True(t, ok, reason)
 	require.Equal(t, []string{
 		"-test.failfast=false",
+		"-test.parallel=1",
+		"-test.testlogfile=child-testlog.txt",
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",
 		"-test.count=1",
 		"-test.cpu=1",
 		"-test.timeout=1s",
 	}, got)
+}
+
+func TestMergeProcessRetryTestLog(t *testing.T) {
+	parentPath := filepath.Join(t.TempDir(), "parent-testlog.txt")
+	childPath := filepath.Join(t.TempDir(), "child-testlog.txt")
+	require.NoError(t, os.WriteFile(parentPath, []byte(processRetryTestLogMagic+"getenv PARENT\n"), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte(processRetryTestLogMagic+"getenv CHILD\nopen /tmp/input\n"), 0o600))
+
+	require.NoError(t, mergeProcessRetryTestLog(parentPath, childPath, "/workspace/package"))
+	got, err := os.ReadFile(parentPath)
+	require.NoError(t, err)
+	require.Equal(t, processRetryTestLogMagic+"getenv PARENT\nchdir /workspace/package\ngetenv CHILD\nopen /tmp/input\n", string(got))
+
+	require.NoError(t, os.WriteFile(childPath, []byte("getenv MISSING_HEADER\n"), 0o600))
+	require.Error(t, mergeProcessRetryTestLog(parentPath, childPath, "/workspace/package"))
+}
+
+func TestProcessRetryBatchTimeoutUsesPackageBudget(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	deadline := now.Add(30 * time.Minute)
+
+	require.Equal(t, 30*time.Minute-processRetryParentDeadlineReserve(), selectedProcessRetryTimeout(
+		true, 30*time.Minute, true, 0, false, deadline, true, now,
+	))
+	require.Equal(t, 5*time.Minute, selectedProcessRetryTimeout(
+		true, 30*time.Minute, true, 5*time.Minute, true, deadline, true, now,
+	))
+}
+
+func TestProcessRetryBatchCoverageFlushBeforeTerminalReplay(t *testing.T) {
+	tests := []struct {
+		name   string
+		result retryAttemptResult
+		want   bool
+	}{
+		{name: "pass"},
+		{name: "ordinary failure", result: retryAttemptResult{failed: true}},
+		{name: "native fatal", result: retryAttemptResult{nativeFatalTraceReplay: true}, want: true},
+		{name: "panic", result: retryAttemptResult{panicData: "panic"}, want: true},
+		{name: "cleanup panic", result: retryAttemptResult{cleanupPanicData: "panic"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, requiresProcessRetryBatchCoverageFlush(tt.result))
+		})
+	}
 }
 
 func TestProcessRetryBatchRetriesOnlyMissingGroups(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -23,8 +23,19 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	want := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
 		CollectPerTestCoverage: true,
+		ITRCoverageActive:      true,
+		ImpactedTestsEnabled:   true,
 		Tests: []processRetryBatchTestConfig{
-			{TestName: "TestA", InvocationOrdinal: 11, DisabledSubtests: []string{"TestA/disabled"}},
+			{
+				TestName:          "TestA",
+				InvocationOrdinal: 11,
+				DisabledSubtests:  []string{"TestA/disabled"},
+				ITRSubtests: []processRetrySubtestITRConfig{{
+					TestName:                "TestA/skipped",
+					MissingLineCodeCoverage: true,
+					AttemptToFix:            true,
+				}},
+			},
 			{TestName: "TestB", InvocationOrdinal: 12},
 		},
 	}
@@ -43,6 +54,7 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.Equal(t, uint64(7), child.MRunEpoch)
 	require.Equal(t, uint64(11), child.InvocationOrdinal)
 	require.True(t, child.CollectPerTestCoverage)
+	require.True(t, child.itrCoverageActive)
 	require.Equal(t, []string{"TestA/disabled"}, child.batchTest.DisabledSubtests)
 }
 
@@ -67,6 +79,44 @@ func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *test
 	require.Equal(t, processRetryBatchParallelPath(root.ResultPath, 2), child.nativeParallelPath)
 }
 
+func TestProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
+	path := processRetryBatchGatePath(filepath.Join(t.TempDir(), "result.json"), 0)
+	workingDirectory := t.TempDir()
+	baseline := &processRetryLaunchBaseline{
+		workingDirectory: workingDirectory,
+		environment:      []string{"FIRST=one", "SECOND=two=three"},
+	}
+
+	require.NoError(t, writeProcessRetryBatchInvocationState(path, baseline))
+	requireProcessRetryFileMode(t, path, processRetryBatchManifestMode)
+	state, run, err := waitForProcessRetryBatchGate(path, time.Time{}, false)
+	require.NoError(t, err)
+	require.True(t, run)
+	require.Equal(t, processRetryBatchInvocationState{
+		Version:          processRetryBatchGateVersion,
+		WorkingDirectory: workingDirectory,
+		Environment:      baseline.environment,
+	}, state)
+}
+
+func TestProcessRetryBatchInvocationStateRejectsInvalidPayloads(t *testing.T) {
+	for name, payload := range map[string]string{
+		"unknown field":         `{"version":1,"working_directory":"/tmp","environment":[],"unknown":true}`,
+		"trailing data":         `{"version":1,"working_directory":"/tmp","environment":[]} {}`,
+		"relative directory":    `{"version":1,"working_directory":"relative","environment":[]}`,
+		"private transport":     `{"version":1,"working_directory":"/tmp","environment":["DD_CIVISIBILITY_INTERNAL_RETRY_PROCESS_CHILD=true"]}`,
+		"coverage environment":  `{"version":1,"working_directory":"/tmp","environment":["GOCOVERDIR=/tmp/cov"]}`,
+		"duplicate environment": `{"version":1,"working_directory":"/tmp","environment":["PATH=one","PATH=two"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "gate.json")
+			require.NoError(t, os.WriteFile(path, []byte(payload), processRetryBatchManifestMode))
+			_, err := readProcessRetryBatchInvocationState(path)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	batch := &nativeScheduledProcessRetryBatch{
@@ -75,8 +125,8 @@ func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T
 		done:       make(chan struct{}),
 		cancel:     func() {},
 	}
-	require.NoError(t, os.WriteFile(processRetryBatchGatePath(resultPath, 0), nil, processRetryBatchManifestMode))
-	run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 0), time.Time{}, false)
+	require.NoError(t, writeProcessRetryBatchInvocationState(processRetryBatchGatePath(resultPath, 0), &processRetryLaunchBaseline{workingDirectory: t.TempDir()}))
+	_, run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 0), time.Time{}, false)
 	require.NoError(t, err)
 	require.True(t, run)
 	coordinator := newProcessRetryCoordinatorForTesting(false)
@@ -87,7 +137,7 @@ func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T
 	}
 	gate := make(chan gateResult, 1)
 	go func() {
-		run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 1), time.Time{}, false)
+		_, run, err := waitForProcessRetryBatchGate(processRetryBatchGatePath(resultPath, 1), time.Time{}, false)
 		gate <- gateResult{run: run, err: err}
 		close(batch.done)
 	}()
@@ -132,6 +182,8 @@ func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 		"empty":               {Version: processRetryBatchVersion},
 		"missing name":        {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{InvocationOrdinal: 1}}},
 		"duplicate test name": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{validTest, validTest}},
+		"ITR outside test":    {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestB/child"}}}}},
+		"duplicate ITR":       {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestA/child"}, {TestName: "TestA/child"}}}}},
 	}
 
 	for name, cfg := range tests {
@@ -155,6 +207,39 @@ func TestDisabledProcessRetrySubtests(t *testing.T) {
 	}}
 
 	require.Equal(t, []string{"TestA/disabled"}, disabledProcessRetrySubtests(*identity, modules))
+}
+
+func TestProcessRetryITRSubtests(t *testing.T) {
+	identity := newTestIdentity("module", "suite", "TestA")
+	state := &itrState{
+		settings: &net.SettingsResponseData{ItrEnabled: true, TestsSkipping: true},
+		response: &net.SkippableTestsResponse{Skippables: map[string]map[string][]net.SkippableResponseDataAttributes{
+			"suite": {
+				"TestA/safe": {
+					{Name: "TestA/safe"},
+					{Name: "TestA/safe", MissingLineCodeCoverage: true},
+				},
+				"TestA/parameterized": {{Name: "TestA/parameterized", Parameters: `{"case":"one"}`}},
+				"TestB/other":         {{Name: "TestB/other"}},
+			},
+		}},
+	}
+	modules := &net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
+		"module": {Suites: map[string]net.TestManagementTestsResponseDataTests{
+			"suite": {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+				"TestA/safe": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true}},
+			}},
+		}},
+	}}
+
+	require.Equal(t, []processRetrySubtestITRConfig{{
+		TestName:                "TestA/safe",
+		MissingLineCodeCoverage: true,
+		AttemptToFix:            true,
+	}}, processRetryITRSubtests(*identity, state, modules))
+
+	state.settings.TestsSkipping = false
+	require.Empty(t, processRetryITRSubtests(*identity, state, modules))
 }
 
 func TestPreserveProcessRetryBatchFailure(t *testing.T) {
@@ -298,6 +383,41 @@ func TestMergeProcessRetryTestLog(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(childPath, []byte("getenv MISSING_HEADER\n"), 0o600))
 	require.Error(t, mergeProcessRetryTestLog(parentPath, childPath, "/workspace/package"))
+}
+
+func TestNativeScheduledBatchMergesTestLogAfterParentFlush(t *testing.T) {
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent-testlog.txt")
+	childPath := filepath.Join(dir, "child-testlog.txt")
+	require.NoError(t, os.WriteFile(parentPath, []byte(processRetryTestLogMagic), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte(processRetryTestLogMagic+"getenv CHILD\n"), 0o600))
+
+	done := make(chan struct{})
+	close(done)
+	batch := &nativeScheduledProcessRetryBatch{
+		batch:      &processRetryBatchConfig{},
+		resultRoot: filepath.Join(dir, "result.json"),
+		done:       done,
+		cancel:     func() {},
+		attempt: processRetryAttemptResult{testLogMerge: &processRetryTestLogMerge{
+			parentPath:            parentPath,
+			childPath:             childPath,
+			childWorkingDirectory: "/workspace/package",
+		}},
+	}
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	coordinator.nativeBatches = map[uint64]*nativeScheduledProcessRetryBatch{1: batch}
+
+	// Simulate testing.StopTestLog flushing its buffered parent records after
+	// the native-scheduled child has already completed.
+	require.NoError(t, os.WriteFile(parentPath, []byte(processRetryTestLogMagic+"getenv PARENT\n"), 0o600))
+	attempt, ok := coordinator.nativeScheduledBatchResult(1)
+	require.True(t, ok)
+	require.NoError(t, attempt.Err)
+
+	got, err := os.ReadFile(parentPath)
+	require.NoError(t, err)
+	require.Equal(t, processRetryTestLogMagic+"getenv PARENT\nchdir /workspace/package\ngetenv CHILD\n", string(got))
 }
 
 func TestProcessRetryBatchTimeoutUsesPackageBudget(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
 )
 
@@ -24,18 +25,19 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "batch.json")
 	want := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
+		AttemptToFixRetries:    3,
 		CollectPerTestCoverage: true,
 		ITRCoverageActive:      true,
 		ImpactedTestsEnabled:   true,
 		Tests: []processRetryBatchTestConfig{
 			{
-				TestName:          "TestA",
-				InvocationOrdinal: 11,
-				DisabledSubtests:  []string{"TestA/disabled"},
+				TestName:             "TestA",
+				InvocationOrdinal:    11,
+				DisabledSubtests:     []string{"TestA/disabled"},
+				AttemptToFixSubtests: []string{"TestA/atf"},
 				ITRSubtests: []processRetrySubtestITRConfig{{
 					TestName:                "TestA/skipped",
 					MissingLineCodeCoverage: true,
-					AttemptToFix:            true,
 				}},
 			},
 			{TestName: "TestB", InvocationOrdinal: 12},
@@ -57,7 +59,9 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.Equal(t, uint64(11), child.InvocationOrdinal)
 	require.True(t, child.CollectPerTestCoverage)
 	require.True(t, child.itrCoverageActive)
+	require.Equal(t, 3, child.attemptToFixRetries)
 	require.Equal(t, []string{"TestA/disabled"}, child.batchTest.DisabledSubtests)
+	require.Equal(t, []string{"TestA/atf"}, child.batchTest.AttemptToFixSubtests)
 }
 
 func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *testing.T) {
@@ -117,23 +121,23 @@ func TestCurrentProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
 
 func TestApplyProcessRetryBatchFinalStatePreservesCoverageDirectory(t *testing.T) {
 	for _, test := range []struct {
-		name         string
-		apply        func(processRetryBatchInvocationState) error
-		wantCoverage bool
+		name             string
+		apply            func(processRetryBatchInvocationState) error
+		wantCoverage     bool
+		wantCIVisibility string
 	}{
-		{name: "child invocation", apply: applyProcessRetryBatchInvocationState},
-		{name: "parent final state", apply: applyProcessRetryBatchFinalState, wantCoverage: true},
+		{name: "child invocation", apply: applyProcessRetryBatchInvocationState, wantCIVisibility: "false"},
+		{name: "parent final state", apply: applyProcessRetryBatchFinalState, wantCoverage: true, wantCIVisibility: "parent"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			workingDirectory, err := os.Getwd()
 			require.NoError(t, err)
 			t.Setenv(processRetryCoverageDirectoryEnvironmentVariable, filepath.Join(t.TempDir(), "coverage"))
+			t.Setenv(constants.CIVisibilityEnabledEnvironmentVariable, "parent")
 			t.Setenv("DD_TEST_BATCH_REMOVED_STATE", "remove-me")
-			environment := slices.DeleteFunc(os.Environ(), func(entry string) bool {
+			environment := slices.DeleteFunc(sanitizeProcessRetryBaseEnv(os.Environ()), func(entry string) bool {
 				key, _, _ := strings.Cut(entry, "=")
-				return key == "DD_TEST_BATCH_REMOVED_STATE" ||
-					strings.EqualFold(key, processRetryCoverageDirectoryEnvironmentVariable) ||
-					isProcessRetryInternalEnvKey(key)
+				return key == "DD_TEST_BATCH_REMOVED_STATE"
 			})
 
 			require.NoError(t, test.apply(processRetryBatchInvocationState{
@@ -143,6 +147,7 @@ func TestApplyProcessRetryBatchFinalStatePreservesCoverageDirectory(t *testing.T
 			}))
 			_, coveragePresent := os.LookupEnv(processRetryCoverageDirectoryEnvironmentVariable)
 			require.Equal(t, test.wantCoverage, coveragePresent)
+			require.Equal(t, test.wantCIVisibility, os.Getenv(constants.CIVisibilityEnabledEnvironmentVariable))
 			_, removedPresent := os.LookupEnv("DD_TEST_BATCH_REMOVED_STATE")
 			require.False(t, removedPresent)
 		})
@@ -312,13 +317,17 @@ func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 	validTest := processRetryBatchTestConfig{TestName: "TestA"}
 	tests := map[string]*processRetryBatchConfig{
-		"nil":                 nil,
-		"wrong version":       {Version: processRetryBatchVersion + 1, Tests: []processRetryBatchTestConfig{validTest}},
-		"empty":               {Version: processRetryBatchVersion},
-		"missing name":        {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{InvocationOrdinal: 1}}},
-		"duplicate test name": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{validTest, validTest}},
-		"ITR outside test":    {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestB/child"}}}}},
-		"duplicate ITR":       {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestA/child"}, {TestName: "TestA/child"}}}}},
+		"nil":                  nil,
+		"wrong version":        {Version: processRetryBatchVersion + 1, Tests: []processRetryBatchTestConfig{validTest}},
+		"empty":                {Version: processRetryBatchVersion},
+		"missing name":         {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{InvocationOrdinal: 1}}},
+		"duplicate test name":  {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{validTest, validTest}},
+		"negative retries":     {Version: processRetryBatchVersion, AttemptToFixRetries: -1, Tests: []processRetryBatchTestConfig{validTest}},
+		"too many retries":     {Version: processRetryBatchVersion, AttemptToFixRetries: processRetryBatchMaxTests + 1, Tests: []processRetryBatchTestConfig{validTest}},
+		"managed outside test": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", AttemptToFixSubtests: []string{"TestB/child"}}}},
+		"duplicate managed":    {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", DisabledSubtests: []string{"TestA/child"}, AttemptToFixSubtests: []string{"TestA/child"}}}},
+		"ITR outside test":     {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestB/child"}}}}},
+		"duplicate ITR":        {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestA/child"}, {TestName: "TestA/child"}}}}},
 	}
 
 	for name, cfg := range tests {
@@ -328,7 +337,7 @@ func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 	}
 }
 
-func TestDisabledProcessRetrySubtests(t *testing.T) {
+func TestProcessRetryTestManagementSubtests(t *testing.T) {
 	identity := newTestIdentity("module", "suite", "TestA")
 	modules := &net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
 		"module": {Suites: map[string]net.TestManagementTestsResponseDataTests{
@@ -341,7 +350,9 @@ func TestDisabledProcessRetrySubtests(t *testing.T) {
 		}},
 	}}
 
-	require.Equal(t, []string{"TestA/disabled"}, disabledProcessRetrySubtests(*identity, modules))
+	disabled, attemptToFix := processRetryTestManagementSubtests(*identity, modules)
+	require.Equal(t, []string{"TestA/disabled"}, disabled)
+	require.Equal(t, []string{"TestA/atf"}, attemptToFix)
 }
 
 func TestProcessRetryITRSubtests(t *testing.T) {
@@ -359,22 +370,13 @@ func TestProcessRetryITRSubtests(t *testing.T) {
 			},
 		}},
 	}
-	modules := &net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
-		"module": {Suites: map[string]net.TestManagementTestsResponseDataTests{
-			"suite": {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
-				"TestA/safe": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true}},
-			}},
-		}},
-	}}
-
 	require.Equal(t, []processRetrySubtestITRConfig{{
 		TestName:                "TestA/safe",
 		MissingLineCodeCoverage: true,
-		AttemptToFix:            true,
-	}}, processRetryITRSubtests(*identity, state, modules))
+	}}, processRetryITRSubtests(*identity, state))
 
 	state.settings.TestsSkipping = false
-	require.Empty(t, processRetryITRSubtests(*identity, state, modules))
+	require.Empty(t, processRetryITRSubtests(*identity, state))
 }
 
 func TestPreserveProcessRetryBatchFailure(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -499,6 +499,7 @@ func TestProcessRetryBatchConfigRejectsUnknownAndTrailingData(t *testing.T) {
 
 func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 	snapshot := captureProcessRetryArgsSnapshot([]string{
+		"-test.v=true",
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",
 		"-test.testlogfile=parent-testlog.txt",
@@ -510,6 +511,7 @@ func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 
 	require.True(t, ok, reason)
 	require.Equal(t, []string{
+		"-test.v=test2json",
 		"-test.failfast=false",
 		"-test.testlogfile=child-testlog.txt",
 		"-test.gocoverdir=parent-coverage",
@@ -519,6 +521,7 @@ func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 		"-test.cpu=1",
 		"-test.timeout=1s",
 	}, got)
+	require.Contains(t, processRetryBatchArgsSnapshot(captureProcessRetryArgsSnapshot([]string{"-test.v=false"}), "", false).preserved, "-test.v=false")
 	require.NotContains(t, processRetryBatchArgsSnapshot(snapshot, "", false).preserved, "-test.gocoverdir=parent-coverage")
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -34,6 +34,7 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 				TestName:             "TestA",
 				InvocationOrdinal:    11,
 				DisabledSubtests:     []string{"TestA/disabled"},
+				QuarantinedSubtests:  []string{"TestA/atf", "TestA/quarantined"},
 				AttemptToFixSubtests: []string{"TestA/atf"},
 				ITRSubtests: []processRetrySubtestITRConfig{{
 					TestName:                "TestA/skipped",
@@ -61,6 +62,7 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.True(t, child.itrCoverageActive)
 	require.Equal(t, 3, child.attemptToFixRetries)
 	require.Equal(t, []string{"TestA/disabled"}, child.batchTest.DisabledSubtests)
+	require.Equal(t, []string{"TestA/atf", "TestA/quarantined"}, child.batchTest.QuarantinedSubtests)
 	require.Equal(t, []string{"TestA/atf"}, child.batchTest.AttemptToFixSubtests)
 }
 
@@ -338,6 +340,8 @@ func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 		"too many retries":     {Version: processRetryBatchVersion, AttemptToFixRetries: processRetryBatchMaxTests + 1, Tests: []processRetryBatchTestConfig{validTest}},
 		"managed outside test": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", AttemptToFixSubtests: []string{"TestB/child"}}}},
 		"duplicate managed":    {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", DisabledSubtests: []string{"TestA/child"}, AttemptToFixSubtests: []string{"TestA/child"}}}},
+		"quarantine outside":   {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", QuarantinedSubtests: []string{"TestB/child"}}}},
+		"duplicate quarantine": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", QuarantinedSubtests: []string{"TestA/child", "TestA/child"}}}},
 		"ITR outside test":     {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestB/child"}}}}},
 		"duplicate ITR":        {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{TestName: "TestA", ITRSubtests: []processRetrySubtestITRConfig{{TestName: "TestA/child"}, {TestName: "TestA/child"}}}}},
 	}
@@ -354,16 +358,18 @@ func TestProcessRetryTestManagementSubtests(t *testing.T) {
 	modules := &net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
 		"module": {Suites: map[string]net.TestManagementTestsResponseDataTests{
 			"suite": {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
-				"TestA/disabled": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
-				"TestA/enabled":  {},
-				"TestA/atf":      {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true, AttemptToFix: true}},
-				"TestB/disabled": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
+				"TestA/disabled":   {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
+				"TestA/enabled":    {},
+				"TestA/atf":        {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true, Quarantined: true, AttemptToFix: true}},
+				"TestA/quarantine": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true}},
+				"TestB/disabled":   {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
 			}},
 		}},
 	}}
 
-	disabled, attemptToFix := processRetryTestManagementSubtests(*identity, modules)
+	disabled, quarantined, attemptToFix := processRetryTestManagementSubtests(*identity, modules)
 	require.Equal(t, []string{"TestA/disabled"}, disabled)
+	require.Equal(t, []string{"TestA/atf", "TestA/quarantine"}, quarantined)
 	require.Equal(t, []string{"TestA/atf"}, attemptToFix)
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -434,6 +434,34 @@ func TestNativeScheduledBatchMergesTestLogAfterParentFlush(t *testing.T) {
 	require.Equal(t, processRetryTestLogMagic+"getenv PARENT\nchdir /workspace/package\ngetenv CHILD\n", string(got))
 }
 
+func TestRelaunchedNativeScheduledBatchMergesTestLog(t *testing.T) {
+	requireProcessRetryContainmentForTesting(t)
+	resetProcessRetryLimiterForTesting(t)
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent-testlog.txt")
+	counterPath := filepath.Join(dir, "cleanup-counter")
+	require.NoError(t, os.WriteFile(parentPath, []byte(processRetryTestLogMagic), 0o600))
+	t.Setenv(processRetryNativeLifecycleFixtureEnv, "true")
+	t.Setenv(processRetryChildResultScenarioEnv, "cleanup_once")
+	t.Setenv(processRetryChildCleanupCounterPathEnv, counterPath)
+
+	baseline := captureProcessRetryLaunchBaselineForTesting()
+	require.NoError(t, baseline.err)
+	baseline.args = []string{"-test.testlogfile=" + parentPath}
+	baseline.argsSnapshot = captureProcessRetryArgsSnapshot(baseline.args)
+	group := deferredProcessRetryBatchGroup("TestProcessRetryChildResultFixture", 1)
+	group.launchBaseline = baseline
+
+	completed, missing := runDeferredNativeScheduledProcessRetryBatchOnce(context.Background(), []*deferredProcessRetryGroup{group})
+	require.Empty(t, missing)
+	require.NoError(t, completed[group].Err)
+	got, err := os.ReadFile(parentPath)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "chdir "+baseline.workingDirectory+"\n")
+	require.Contains(t, string(got), "getenv "+processRetryChildResultScenarioEnv+"\n")
+	require.Contains(t, string(got), "open "+counterPath+"\n")
+}
+
 func TestProcessRetryBatchTimeoutUsesPackageBudget(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	deadline := now.Add(30 * time.Minute)

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -113,6 +113,21 @@ func TestCurrentProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
 	require.Contains(t, state.Environment, "DD_TEST_BATCH_PARENT_STATE=post-enumeration")
 }
 
+func TestTransitionNativeScheduledTestToParallelUsesCapturedParentBarrier(t *testing.T) {
+	result := make(chan error, 1)
+	t.Run("parent", func(parent *testing.T) {
+		parent.Run("parallel", func(child *testing.T) {
+			result <- transitionNativeScheduledTestToParallel(child)
+		})
+		fields := getTestPrivateFields(parent)
+		require.NotNil(parent, fields)
+		barrier := *fields.barrier
+		*fields.barrier = nil
+		*fields.barrier = barrier
+	})
+	require.NoError(t, <-result)
+}
+
 func TestProcessRetryBatchInvocationStateRejectsInvalidPayloads(t *testing.T) {
 	for name, payload := range map[string]string{
 		"unknown field":         `{"version":1,"working_directory":"/tmp","environment":[],"unknown":true}`,
@@ -163,29 +178,6 @@ func TestNativeScheduledBatchResultSkipsUninvokedTestsBeforeWaiting(t *testing.T
 	require.False(t, decision.run)
 	require.NoFileExists(t, processRetryBatchSkipPath(resultPath, 0))
 	require.FileExists(t, processRetryBatchSkipPath(resultPath, 1))
-}
-
-func TestProcessRetryNativeScheduledTestsFollowParentOrder(t *testing.T) {
-	tests, indexes, err := nativeScheduledTestsInParentOrder(
-		[]processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}, {TestName: "TestC"}},
-		map[string]int{"TestA": 0, "TestB": 1, "TestC": 2},
-		[]string{"TestC", "TestOther", "TestA", "TestB"},
-	)
-
-	require.NoError(t, err)
-	require.Equal(t, []processRetryBatchTestConfig{
-		{TestName: "TestC"},
-		{TestName: "TestA"},
-		{TestName: "TestB"},
-	}, tests)
-	require.Equal(t, map[string]int{"TestC": 0, "TestA": 1, "TestB": 2}, indexes)
-
-	_, _, err = nativeScheduledTestsInParentOrder(
-		[]processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}},
-		map[string]int{"TestA": 0, "TestB": 1},
-		[]string{"TestA"},
-	)
-	require.Error(t, err)
 }
 
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
@@ -590,6 +582,20 @@ func TestProcessRetryBatchGlobalStopDoesNotSplitPendingWork(t *testing.T) {
 	require.Equal(t, 1, calls)
 	require.True(t, results[a].Unreaped)
 	require.True(t, results[b].Unreaped)
+}
+
+func TestNativeProcessRetryBatchRequiresOneTest(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+
+	completed, missing := runDeferredProcessRetryBatchOnce(context.Background(), []*deferredProcessRetryGroup{a, b}, true)
+
+	require.Empty(t, completed)
+	require.Len(t, missing, 2)
+	for _, group := range []*deferredProcessRetryGroup{a, b} {
+		require.True(t, missing[group].SetupFailure)
+		require.EqualError(t, missing[group].Err, "native process retry batch must contain one test")
+	}
 }
 
 func TestCompletedProcessRetryAttemptPreservesPanicSemantics(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -170,6 +170,8 @@ func TestTransitionNativeScheduledTestToParallelUsesCapturedParentBarrier(t *tes
 }
 
 func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(t *testing.T) {
+	const stateKey = "DD_TEST_BATCH_CHILD_PRE_PARALLEL_STATE"
+	t.Setenv(stateKey, "parent")
 	resetProcessRetryLimiterForTesting(t)
 	limiter := getProcessRetryLimiter()
 	initialSlot := limiter.acquireWithShutdownLimit(context.Background(), nil, nil, 1)
@@ -182,6 +184,7 @@ func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(
 	acquireEntered := make(chan struct{})
 	signalCalled := make(chan struct{})
 	activeAtSignal := make(chan int, 1)
+	stateAtSignal := make(chan string, 1)
 	batchConfig := &processRetryBatchConfig{
 		Version:                processRetryBatchVersion,
 		Tests:                  []processRetryBatchTestConfig{testConfig},
@@ -205,6 +208,7 @@ func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(
 		limiter.mu.Lock()
 		activeAtSignal <- limiter.active
 		limiter.mu.Unlock()
+		stateAtSignal <- os.Getenv(stateKey)
 		close(signalCalled)
 		now := time.Now()
 		err := writeProcessRetryResultAtomically(processRetryBatchResultPath(resultRoot, 0), processRetryResult{
@@ -221,7 +225,14 @@ func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(
 		close(batch.done)
 		return err
 	}
-	require.NoError(t, os.WriteFile(processRetryBatchParallelPath(resultRoot, 0), nil, processRetryBatchManifestMode))
+	environment := slices.DeleteFunc(sanitizeProcessRetryBaseEnv(os.Environ()), func(entry string) bool {
+		key, _, _ := strings.Cut(entry, "=")
+		return key == stateKey
+	})
+	require.NoError(t, writeProcessRetryBatchInvocationState(processRetryBatchParallelPath(resultRoot, 0), &processRetryLaunchBaseline{
+		workingDirectory: dir,
+		environment:      append(environment, stateKey+"=child"),
+	}))
 	coordinator := &processRetryCoordinator{
 		nativeTestIndex: map[string]int{testConfig.TestName: 0},
 		nativeTests:     []processRetryBatchTestConfig{testConfig},
@@ -258,6 +269,7 @@ func TestWaitNativeScheduledFirstAttemptReacquiresProcessSlotBeforeParallelBody(
 
 	require.False(t, <-signalBeforeAdmission)
 	require.Equal(t, 1, <-activeAtSignal)
+	require.Equal(t, "child", <-stateAtSignal)
 	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(<-result, false).Status)
 	require.Zero(t, processRetryLimiterActiveForTesting(t, limiter))
 }
@@ -490,21 +502,44 @@ func TestProcessRetryBatchArgsPreserveSegmentedSelectors(t *testing.T) {
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",
 		"-test.testlogfile=parent-testlog.txt",
+		"-test.gocoverdir=parent-coverage",
 	})
 
 	require.Equal(t, "parent-testlog.txt", snapshot.testLogFile)
-	got, ok, reason := buildProcessRetryArgsFromSnapshot(processRetryBatchArgsSnapshot(snapshot, "child-testlog.txt"), ".", 1, time.Second)
+	got, ok, reason := buildProcessRetryArgsFromSnapshot(processRetryBatchArgsSnapshot(snapshot, "child-testlog.txt", true), ".", 1, time.Second)
 
 	require.True(t, ok, reason)
 	require.Equal(t, []string{
 		"-test.failfast=false",
 		"-test.testlogfile=child-testlog.txt",
+		"-test.gocoverdir=parent-coverage",
 		"-test.run=^TestQuarantined$/wanted$",
 		"-test.skip=destructive$",
 		"-test.count=1",
 		"-test.cpu=1",
 		"-test.timeout=1s",
 	}, got)
+	require.NotContains(t, processRetryBatchArgsSnapshot(snapshot, "", false).preserved, "-test.gocoverdir=parent-coverage")
+}
+
+func TestProcessRetryBatchOutputOmitsChildRunnerProtocol(t *testing.T) {
+	output := strings.Join([]string{
+		"\x16=== RUN   TestSelected",
+		"direct stdout",
+		"    selected_test.go:10: test log",
+		"--- FAIL: TestSelected (0.01s)",
+		"WARNING: DATA RACE",
+		"coverage: 42.0% of statements",
+		"FAIL",
+		"direct stderr",
+	}, "\n") + "\n"
+
+	require.Equal(t, strings.Join([]string{
+		"direct stdout",
+		"    selected_test.go:10: test log",
+		"WARNING: DATA RACE",
+		"direct stderr",
+	}, "\n")+"\n", filterProcessRetryBatchOutput(output))
 }
 
 func TestMergeProcessRetryTestLog(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -100,6 +100,19 @@ func TestProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
 	}, state)
 }
 
+func TestCurrentProcessRetryBatchInvocationStateRoundTrip(t *testing.T) {
+	t.Setenv("DD_TEST_BATCH_PARENT_STATE", "post-enumeration")
+	path := filepath.Join(t.TempDir(), "parent-state.json")
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, writeCurrentProcessRetryBatchInvocationState(path))
+	state, err := readProcessRetryBatchInvocationState(path)
+	require.NoError(t, err)
+	require.Equal(t, workingDirectory, state.WorkingDirectory)
+	require.Contains(t, state.Environment, "DD_TEST_BATCH_PARENT_STATE=post-enumeration")
+}
+
 func TestProcessRetryBatchInvocationStateRejectsInvalidPayloads(t *testing.T) {
 	for name, payload := range map[string]string{
 		"unknown field":         `{"version":1,"working_directory":"/tmp","environment":[],"unknown":true}`,

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -7,12 +7,15 @@ package gotesting
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
 )
 
 func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
@@ -21,7 +24,7 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 		Version:                processRetryBatchVersion,
 		CollectPerTestCoverage: true,
 		Tests: []processRetryBatchTestConfig{
-			{TestName: "TestA", InvocationOrdinal: 11},
+			{TestName: "TestA", InvocationOrdinal: 11, DisabledSubtests: []string{"TestA/disabled"}},
 			{TestName: "TestB", InvocationOrdinal: 12},
 		},
 	}
@@ -33,13 +36,14 @@ func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
 	require.Equal(t, want, got)
 	child := processRetryBatchChildConfig(processRetryChildConfig{
 		ResultPath: path, Attempt: 1, RetryReason: processRetryBatchReason, MRunEpoch: 7, Batch: got,
-	}, 1, got.Tests[1])
-	require.Equal(t, "TestB", child.TestName)
+	}, 0, got.Tests[0])
+	require.Equal(t, "TestA", child.TestName)
 	require.Equal(t, 1, child.Attempt)
 	require.Equal(t, processRetryBatchReason, child.RetryReason)
 	require.Equal(t, uint64(7), child.MRunEpoch)
-	require.Equal(t, uint64(12), child.InvocationOrdinal)
+	require.Equal(t, uint64(11), child.InvocationOrdinal)
 	require.True(t, child.CollectPerTestCoverage)
+	require.Equal(t, []string{"TestA/disabled"}, child.batchTest.DisabledSubtests)
 }
 
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
@@ -57,6 +61,73 @@ func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 			require.Error(t, validateProcessRetryBatchConfig(cfg))
 		})
 	}
+}
+
+func TestDisabledProcessRetrySubtests(t *testing.T) {
+	identity := newTestIdentity("module", "suite", "TestA")
+	modules := &net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
+		"module": {Suites: map[string]net.TestManagementTestsResponseDataTests{
+			"suite": {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+				"TestA/disabled": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
+				"TestA/enabled":  {},
+				"TestA/atf":      {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true, AttemptToFix: true}},
+				"TestB/disabled": {Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true}},
+			}},
+		}},
+	}}
+
+	require.Equal(t, []string{"TestA/disabled"}, disabledProcessRetrySubtests(*identity, modules))
+}
+
+func TestPreserveProcessRetryBatchFailure(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	processErr := errors.New("testmain teardown")
+	completed := map[*deferredProcessRetryGroup]processRetryAttemptResult{
+		a: deferredProcessRetryPassingAttempt(1),
+		b: deferredProcessRetryPassingAttempt(2),
+	}
+
+	preserveProcessRetryBatchFailure(processRetryAttemptResult{ExitCode: 3, ExitStatusObserved: true, Err: processErr}, []*deferredProcessRetryGroup{a, b}, completed)
+
+	require.Equal(t, "process_exit", effectiveProcessRetryStatus(completed[a], false).FailureKind)
+	require.ErrorIs(t, completed[a].Err, processErr)
+	require.ErrorIs(t, completed[a].Err, errProcessRetryBatchFailed)
+	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(completed[b], false).Status)
+}
+
+func TestProcessRetryBatchFailureFailsPackage(t *testing.T) {
+	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
+	require.True(t, coordinator.beginAdmission().commit(group))
+	coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		attempt := deferredProcessRetryPassingAttempt(1)
+		attempt.ExitCode = 1
+		attempt.Err = errProcessRetryBatchFailed
+		return map[*deferredProcessRetryGroup]processRetryAttemptResult{group: attempt}
+	}
+
+	summary := coordinator.drain(0)
+
+	require.True(t, summary.packageFailed)
+	require.True(t, summary.deferredFailed)
+	require.Equal(t, processRetryFailureExitCode, summary.exitCode)
+}
+
+func TestPreserveProcessRetryBatchFailureKeepsDecodedFailure(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	completed := map[*deferredProcessRetryGroup]processRetryAttemptResult{
+		a: completedProcessRetryAttempt(processRetryResult{Status: processRetryStatusFail, Failed: true}),
+		b: deferredProcessRetryPassingAttempt(2),
+	}
+
+	preserveProcessRetryBatchFailure(processRetryAttemptResult{ExitCode: 1, ExitStatusObserved: true}, []*deferredProcessRetryGroup{a, b}, completed)
+
+	require.Equal(t, "test_fail", effectiveProcessRetryStatus(completed[a], false).FailureKind)
+	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(completed[b], false).Status)
 }
 
 func TestProcessRetryBatchConfigRejectsUnknownAndTrailingData(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessRetryBatchConfigRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "batch.json")
+	want := &processRetryBatchConfig{
+		Version: processRetryBatchVersion,
+		Tests: []processRetryBatchTestConfig{
+			{TestName: "TestA", InvocationOrdinal: 11},
+			{TestName: "TestB", InvocationOrdinal: 12},
+		},
+	}
+
+	require.NoError(t, writeProcessRetryBatchConfig(path, want))
+	requireProcessRetryFileMode(t, path, processRetryBatchManifestMode)
+	got, err := readProcessRetryBatchConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	child := processRetryBatchChildConfig(processRetryChildConfig{
+		ResultPath: path, Attempt: 1, RetryReason: processRetryBatchReason, MRunEpoch: 7,
+	}, 1, got.Tests[1])
+	require.Equal(t, "TestB", child.TestName)
+	require.Equal(t, 1, child.Attempt)
+	require.Equal(t, processRetryBatchReason, child.RetryReason)
+	require.Equal(t, uint64(7), child.MRunEpoch)
+	require.Equal(t, uint64(12), child.InvocationOrdinal)
+}
+
+func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
+	validTest := processRetryBatchTestConfig{TestName: "TestA"}
+	tests := map[string]*processRetryBatchConfig{
+		"nil":                 nil,
+		"wrong version":       {Version: processRetryBatchVersion + 1, Tests: []processRetryBatchTestConfig{validTest}},
+		"empty":               {Version: processRetryBatchVersion},
+		"missing name":        {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{{InvocationOrdinal: 1}}},
+		"duplicate test name": {Version: processRetryBatchVersion, Tests: []processRetryBatchTestConfig{validTest, validTest}},
+	}
+
+	for name, cfg := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, validateProcessRetryBatchConfig(cfg))
+		})
+	}
+}
+
+func TestProcessRetryBatchConfigRejectsUnknownAndTrailingData(t *testing.T) {
+	for name, payload := range map[string]string{
+		"unknown field": `{"version":1,"tests":[{"test_name":"TestA"}],"unknown":true}`,
+		"trailing data": `{"version":1,"tests":[{"test_name":"TestA"}]} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "batch.json")
+			require.NoError(t, os.WriteFile(path, []byte(payload), processRetryBatchManifestMode))
+			_, err := readProcessRetryBatchConfig(path)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestProcessRetryBatchRetriesOnlyMissingGroups(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	c := deferredProcessRetryBatchGroup("TestC", 3)
+	var calls [][]*deferredProcessRetryGroup
+	runOnce := func(_ context.Context, groups []*deferredProcessRetryGroup) (
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+	) {
+		calls = append(calls, append([]*deferredProcessRetryGroup(nil), groups...))
+		if len(calls) == 1 {
+			return map[*deferredProcessRetryGroup]processRetryAttemptResult{a: deferredProcessRetryPassingAttempt(1)}, map[*deferredProcessRetryGroup]processRetryAttemptResult{
+				b: {Err: errProcessRetryResultMissing},
+				c: {Err: errProcessRetryResultMissing},
+			}
+		}
+		return map[*deferredProcessRetryGroup]processRetryAttemptResult{
+			b: deferredProcessRetryPassingAttempt(2),
+			c: deferredProcessRetryPassingAttempt(3),
+		}, nil
+	}
+
+	results := runDeferredQuarantinedProcessRetryBatchWithRunner(context.Background(), []*deferredProcessRetryGroup{a, b, c}, runOnce)
+
+	require.Equal(t, [][]*deferredProcessRetryGroup{{a, b, c}, {b, c}}, calls)
+	require.Equal(t, processRetryStatusPass, results[a].Result.Status)
+	require.Equal(t, processRetryStatusPass, results[b].Result.Status)
+	require.Equal(t, processRetryStatusPass, results[c].Result.Status)
+}
+
+func TestProcessRetryBatchNoProgressFallsBackToSingletons(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	var calls [][]*deferredProcessRetryGroup
+	runOnce := func(_ context.Context, groups []*deferredProcessRetryGroup) (
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+	) {
+		calls = append(calls, append([]*deferredProcessRetryGroup(nil), groups...))
+		if len(groups) > 1 {
+			return nil, map[*deferredProcessRetryGroup]processRetryAttemptResult{
+				a: {Err: errProcessRetryResultMissing},
+				b: {Err: errProcessRetryResultMissing},
+			}
+		}
+		return map[*deferredProcessRetryGroup]processRetryAttemptResult{groups[0]: deferredProcessRetryPassingAttempt(len(calls))}, nil
+	}
+
+	results := runDeferredQuarantinedProcessRetryBatchWithRunner(context.Background(), []*deferredProcessRetryGroup{a, b}, runOnce)
+
+	require.Equal(t, [][]*deferredProcessRetryGroup{{a, b}, {a}, {b}}, calls)
+	require.Equal(t, processRetryStatusPass, results[a].Result.Status)
+	require.Equal(t, processRetryStatusPass, results[b].Result.Status)
+}
+
+func TestProcessRetryBatchCancellationDoesNotSplitPendingWork(t *testing.T) {
+	a := deferredProcessRetryBatchGroup("TestA", 1)
+	b := deferredProcessRetryBatchGroup("TestB", 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	runOnce := func(_ context.Context, _ []*deferredProcessRetryGroup) (
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+		map[*deferredProcessRetryGroup]processRetryAttemptResult,
+	) {
+		calls++
+		cancel()
+		return nil, map[*deferredProcessRetryGroup]processRetryAttemptResult{
+			a: {Err: context.Canceled},
+			b: {Err: context.Canceled},
+		}
+	}
+
+	results := runDeferredQuarantinedProcessRetryBatchWithRunner(ctx, []*deferredProcessRetryGroup{a, b}, runOnce)
+
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, results[a].Err, context.Canceled)
+	require.ErrorIs(t, results[b].Err, context.Canceled)
+}
+
+func TestCompletedProcessRetryAttemptPreservesPanicSemantics(t *testing.T) {
+	attempt := completedProcessRetryAttempt(processRetryResult{
+		Status: processRetryStatusControlledPanicReady,
+		Failed: true,
+		Panic:  true,
+	})
+
+	require.Equal(t, processRetryControlledPanicExitCode, attempt.ExitCode)
+	require.True(t, attempt.ControlledTerminalCommitted)
+	require.Equal(t, "test_panic", effectiveProcessRetryStatus(attempt, false).FailureKind)
+}
+
+func TestProcessRetryBatchKeepsOutputPerTest(t *testing.T) {
+	a := completedProcessRetryAttempt(processRetryResult{
+		Status:     processRetryStatusPass,
+		OutputTail: "test-a-output-sentinel",
+	})
+	b := completedProcessRetryAttempt(processRetryResult{
+		Status:          processRetryStatusPass,
+		OutputTail:      "test-b-output-sentinel",
+		OutputTruncated: true,
+	})
+
+	require.Equal(t, "test-a-output-sentinel", a.OutputTail)
+	require.NotContains(t, a.OutputTail, "test-b-output-sentinel")
+	require.Contains(t, b.OutputTail, processRetryOutputTruncationMarker)
+	require.Contains(t, b.OutputTail, "test-b-output-sentinel")
+	require.NotContains(t, b.OutputTail, "test-a-output-sentinel")
+}
+
+func deferredProcessRetryBatchGroup(name string, ordinal uint64) *deferredProcessRetryGroup {
+	identity := newTestIdentity("module", "suite", name)
+	return &deferredProcessRetryGroup{
+		identity:          *identity,
+		mRunEpoch:         1,
+		phaseID:           1,
+		invocationOrdinal: ordinal,
+	}
+}
+
+func fixedProcessRetryAttempt(status processRetryStatus, timestamp int64) processRetryAttemptResult {
+	start := time.Unix(0, timestamp)
+	return processRetryAttemptResult{
+		Result:             processRetryResult{Status: status},
+		ExitCode:           0,
+		ExitStatusObserved: true,
+		StartTime:          start,
+		FinishTime:         start.Add(time.Nanosecond),
+	}
+}

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -96,24 +96,51 @@ func TestPreserveProcessRetryBatchFailure(t *testing.T) {
 	require.Equal(t, processRetryStatusPass, effectiveProcessRetryStatus(completed[b], false).Status)
 }
 
-func TestProcessRetryBatchFailureFailsPackage(t *testing.T) {
+func TestProcessRetryBatchFailureClassification(t *testing.T) {
 	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
 	defer restoreSession()
-	coordinator := newProcessRetryCoordinatorForTesting(false)
-	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
-	require.True(t, coordinator.beginAdmission().commit(group))
-	coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
-		attempt := deferredProcessRetryPassingAttempt(1)
-		attempt.ExitCode = 1
-		attempt.Err = errProcessRetryBatchFailed
-		return map[*deferredProcessRetryGroup]processRetryAttemptResult{group: attempt}
+	batchFailure := deferredProcessRetryPassingAttempt(1)
+	batchFailure.ExitCode = 1
+	batchFailure.Err = errProcessRetryBatchFailed
+	testFailure := completedProcessRetryAttempt(processRetryResult{Status: processRetryStatusFail, Failed: true})
+	testPanic := completedProcessRetryAttempt(processRetryResult{Status: processRetryStatusFail, Failed: true, Panic: true})
+	testRace := completedProcessRetryAttempt(processRetryResult{Status: processRetryStatusFail, Failed: true, RaceDetected: true})
+	tests := []struct {
+		name              string
+		attempt           processRetryAttemptResult
+		wantPackageFailed bool
+	}{
+		{name: "unexplained batch exit", attempt: batchFailure, wantPackageFailed: true},
+		{name: "timeout", attempt: processRetryAttemptResult{TimedOut: true}, wantPackageFailed: true},
+		{name: "unreaped", attempt: processRetryAttemptResult{Unreaped: true}, wantPackageFailed: true},
+		{name: "setup", attempt: processRetryAttemptResult{SetupFailure: true}, wantPackageFailed: true},
+		{name: "missing result", attempt: processRetryAttemptResult{Err: errProcessRetryResultMissing}, wantPackageFailed: true},
+		{name: "invalid result", attempt: processRetryAttemptResult{Err: errProcessRetryResultInvalid}, wantPackageFailed: true},
+		{name: "launch error", attempt: processRetryAttemptResult{Err: errors.New("launch failed")}, wantPackageFailed: true},
+		{name: "test failure", attempt: testFailure},
+		{name: "test panic", attempt: testPanic},
+		{name: "test race", attempt: testRace},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coordinator := newProcessRetryCoordinatorForTesting(false)
+			group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
+			require.True(t, coordinator.beginAdmission().commit(group))
+			coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+				return map[*deferredProcessRetryGroup]processRetryAttemptResult{group: tt.attempt}
+			}
 
-	summary := coordinator.drain(0)
+			summary := coordinator.drain(0)
 
-	require.True(t, summary.packageFailed)
-	require.True(t, summary.deferredFailed)
-	require.Equal(t, processRetryFailureExitCode, summary.exitCode)
+			require.Equal(t, tt.wantPackageFailed, summary.packageFailed)
+			require.Equal(t, tt.wantPackageFailed, summary.deferredFailed)
+			if tt.wantPackageFailed {
+				require.Equal(t, processRetryFailureExitCode, summary.exitCode)
+			} else {
+				require.Zero(t, summary.exitCode)
+			}
+		})
+	}
 }
 
 func TestPreserveProcessRetryBatchFailureKeepsDecodedFailure(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_batch_test.go
@@ -67,6 +67,29 @@ func TestProcessRetryNativeScheduledChildConfigUsesBatchIdentityAndGates(t *test
 	require.Equal(t, processRetryBatchParallelPath(root.ResultPath, 2), child.nativeParallelPath)
 }
 
+func TestProcessRetryNativeScheduledTestsFollowParentOrder(t *testing.T) {
+	tests, indexes, err := nativeScheduledTestsInParentOrder(
+		[]processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}, {TestName: "TestC"}},
+		map[string]int{"TestA": 0, "TestB": 1, "TestC": 2},
+		[]string{"TestC", "TestOther", "TestA", "TestB"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []processRetryBatchTestConfig{
+		{TestName: "TestC"},
+		{TestName: "TestA"},
+		{TestName: "TestB"},
+	}, tests)
+	require.Equal(t, map[string]int{"TestC": 0, "TestA": 1, "TestB": 2}, indexes)
+
+	_, _, err = nativeScheduledTestsInParentOrder(
+		[]processRetryBatchTestConfig{{TestName: "TestA"}, {TestName: "TestB"}},
+		map[string]int{"TestA": 0, "TestB": 1},
+		[]string{"TestA"},
+	)
+	require.Error(t, err)
+}
+
 func TestProcessRetryBatchConfigRejectsInvalidManifests(t *testing.T) {
 	validTest := processRetryBatchTestConfig{TestName: "TestA"}
 	tests := map[string]*processRetryBatchConfig{

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -130,22 +130,36 @@ type processRetryCoordinatorSummary struct {
 }
 
 type processRetryCoordinator struct {
-	mu               locking.Mutex
-	state            processRetryCoordinatorState
-	nextID           uint64
-	inFlight         int
-	queue            []*deferredProcessRetryGroup
-	changed          chan struct{}
-	shutdown         chan struct{}
-	shutdownSignaled bool
-	completed        chan struct{}
-	completionOwner  atomic.Uint32
-	summary          processRetryCoordinatorSummary
-	invocationPhase  uint64
-	phaseByTestName  map[string]uint64
-	failfastEnabled  func() bool
-	attemptRunner    deferredProcessRetryAttemptRunner
-	batchRunner      deferredProcessRetryBatchRunner
+	mu                    locking.Mutex
+	state                 processRetryCoordinatorState
+	nextID                uint64
+	inFlight              int
+	queue                 []*deferredProcessRetryGroup
+	changed               chan struct{}
+	shutdown              chan struct{}
+	shutdownSignaled      bool
+	completed             chan struct{}
+	completionOwner       atomic.Uint32
+	summary               processRetryCoordinatorSummary
+	invocationPhase       uint64
+	phaseByTestName       map[string]uint64
+	nativeFailureOrdinal  uint64
+	nativeFailureObserved bool
+	failfastEnabled       func() bool
+	attemptRunner         deferredProcessRetryAttemptRunner
+	batchRunner           deferredProcessRetryBatchRunner
+}
+
+func (c *processRetryCoordinator) observeNativeFailure(invocationOrdinal uint64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if !c.nativeFailureObserved {
+		c.nativeFailureObserved = true
+		c.nativeFailureOrdinal = invocationOrdinal
+	}
+	c.mu.Unlock()
 }
 
 type deferredProcessRetryPreparedAttempt struct {
@@ -370,7 +384,24 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 			failfastLatched = outcome.failfast
 			terminalPanic = outcome.terminalPanic
 		} else {
-			cancelDeferredProcessRetryGroups(queue, "failfast", false)
+			c.mu.Lock()
+			failureOrdinal, failureObserved := c.nativeFailureOrdinal, c.nativeFailureObserved
+			c.mu.Unlock()
+			if failureObserved {
+				beforeFailure := make([]*deferredProcessRetryGroup, 0, len(queue))
+				afterFailure := make([]*deferredProcessRetryGroup, 0, len(queue))
+				for _, group := range queue {
+					if group.deferredFirstAttempt && group.invocationOrdinal <= failureOrdinal {
+						beforeFailure = append(beforeFailure, group)
+					} else {
+						afterFailure = append(afterFailure, group)
+					}
+				}
+				cancelDeferredProcessRetryGroups(c.drainDeferredFirstAttempts(beforeFailure), "failfast", false)
+				cancelDeferredProcessRetryGroups(afterFailure, "failfast", false)
+			} else {
+				cancelDeferredProcessRetryGroups(queue, "failfast", false)
+			}
 		}
 		packageFailed = deferredFailed || packageFailed
 	} else {
@@ -480,6 +511,9 @@ func (g *deferredProcessRetryGroup) applyDeferredFirstAttempt(attempt processRet
 	effective, tail := deferProcessRetryTestEventWithAdmission(&g.testInfo, execMeta, attempt, func(effective processRetryEffectiveStatus) {
 		g.outcomes.observe(effective.Failed, effective.Skipped)
 		continueGroup = !terminal && deferredProcessRetryShouldContinue(execMeta, effective.Failed, effective.Skipped, g.retryCount)
+		if continueGroup {
+			continueGroup = g.admitDeferredFirstAttemptContinuation(execMeta, effective)
+		}
 		execMeta.retryContinuationDecided = true
 		execMeta.retryContinuationAdmitted = continueGroup
 		execMeta.isLastRetry = !continueGroup
@@ -506,6 +540,38 @@ func (g *deferredProcessRetryGroup) applyDeferredFirstAttempt(attempt processRet
 		g.tailEvent = tail
 	}
 	return continueGroup
+}
+
+func (g *deferredProcessRetryGroup) admitDeferredFirstAttemptContinuation(execMeta *testExecutionMetadata, effective processRetryEffectiveStatus) bool {
+	if g == nil || execMeta == nil {
+		return false
+	}
+	if usesEfdRetrySemantics(execMeta) && g.efdFaultySessionGuard != nil {
+		admission := earlyFlakeDetectionAdmissionAllowed
+		switch {
+		case execMeta.isANewTest:
+			admission = g.efdFaultySessionGuard.admitNewTest(execMeta.identity)
+		case execMeta.isAModifiedTest:
+			admission = g.efdFaultySessionGuard.retryState()
+		}
+		if admission != earlyFlakeDetectionAdmissionAllowed {
+			retryCount, ok := transitionSuppressedEFDToFlakyRetries(execMeta, effective.Failed, g.outcomes.anyPassed())
+			if !ok {
+				return false
+			}
+			g.metadata.efdFellBackToFlakyRetries = execMeta.efdFellBackToFlakyRetries
+			g.retryCount = retryCount
+			execMeta.remainingRetries = retryCount
+			execMeta.initialRetryCount = retryCount
+		}
+	}
+	if !usesFlakyRetryBudget(execMeta) {
+		return true
+	}
+	if g.reservation == nil {
+		g.reservation = &flakyRetryBudgetReservation{}
+	}
+	return g.reservation.reserve()
 }
 
 func cancelDeferredProcessRetryGroups(groups []*deferredProcessRetryGroup, reason string, failed bool) {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -506,7 +506,7 @@ func (g *deferredProcessRetryGroup) applyDeferredFirstAttempt(attempt processRet
 	execMeta.initialRetryCount = g.retryCount
 	execMeta.initialRetryCountSet = true
 	execMeta.isLastRetry = g.retryCount <= 0
-	terminal := deferredProcessRetryAttemptTerminal(attempt)
+	terminal := deferredProcessRetryAttemptTerminal(&g.metadata, attempt)
 	continueGroup := false
 	effective, tail := deferProcessRetryTestEventWithAdmission(&g.testInfo, execMeta, attempt, func(effective processRetryEffectiveStatus) {
 		g.outcomes.observe(effective.Failed, effective.Skipped)
@@ -837,7 +837,7 @@ func (c *processRetryCoordinator) drainScheduledBatch(
 
 		if state.group.parallelEFD {
 			state.completed = append(state.completed, scheduled.completed)
-			if deferredProcessRetryAttemptTerminal(scheduled.completed.result) {
+			if deferredProcessRetryAttemptTerminal(&state.group.metadata, scheduled.completed.result) {
 				state.stopPending = true
 				state.terminalAttempt = true
 				state.remaining = 0
@@ -1302,7 +1302,7 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 	// Queue admission commits this continuation to the process backend. By the
 	// time a late setup failure is observable, native M.Run and the original
 	// testing.T have completed, so represent the admitted continuation exactly once.
-	terminal := deferredProcessRetryAttemptTerminal(attempt)
+	terminal := deferredProcessRetryAttemptTerminal(&g.metadata, attempt)
 	continueGroup := continuationAdmitted && !terminal
 	effective, nextTail := deferProcessRetryTestEventWithAdmission(&g.testInfo, execMeta, attempt, func(effective processRetryEffectiveStatus) {
 		g.retryCount--
@@ -1387,8 +1387,13 @@ func (g *deferredProcessRetryGroup) shutdown() <-chan struct{} {
 	return g.lease.shutdown
 }
 
-func deferredProcessRetryAttemptTerminal(attempt processRetryAttemptResult) bool {
+func deferredProcessRetryAttemptTerminal(metadata *processRetryMetadataSnapshot, attempt processRetryAttemptResult) bool {
 	effective := effectiveProcessRetryStatus(attempt, false)
+	// Attempt-to-fix owns a fixed execution count, so a test race is an outcome
+	// rather than an infrastructure failure that truncates its continuations.
+	if effective.FailureKind == "test_race" && metadata != nil && metadata.isAttemptToFix && metadata.shouldOrchestrateAttemptToFix {
+		return false
+	}
 	return attempt.TimedOut || attempt.Unreaped || attempt.ContainmentLost || attempt.Result.RaceDetected ||
 		errorsIsDeferredTerminal(attempt.Err) || processRetryFailureStopsContinuation(effective.FailureKind)
 }

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -130,36 +130,22 @@ type processRetryCoordinatorSummary struct {
 }
 
 type processRetryCoordinator struct {
-	mu                    locking.Mutex
-	state                 processRetryCoordinatorState
-	nextID                uint64
-	inFlight              int
-	queue                 []*deferredProcessRetryGroup
-	changed               chan struct{}
-	shutdown              chan struct{}
-	shutdownSignaled      bool
-	completed             chan struct{}
-	completionOwner       atomic.Uint32
-	summary               processRetryCoordinatorSummary
-	invocationPhase       uint64
-	phaseByTestName       map[string]uint64
-	nativeFailureOrdinal  uint64
-	nativeFailureObserved bool
-	failfastEnabled       func() bool
-	attemptRunner         deferredProcessRetryAttemptRunner
-	batchRunner           deferredProcessRetryBatchRunner
-}
-
-func (c *processRetryCoordinator) observeNativeFailure(invocationOrdinal uint64) {
-	if c == nil {
-		return
-	}
-	c.mu.Lock()
-	if !c.nativeFailureObserved {
-		c.nativeFailureObserved = true
-		c.nativeFailureOrdinal = invocationOrdinal
-	}
-	c.mu.Unlock()
+	mu               locking.Mutex
+	state            processRetryCoordinatorState
+	nextID           uint64
+	inFlight         int
+	queue            []*deferredProcessRetryGroup
+	changed          chan struct{}
+	shutdown         chan struct{}
+	shutdownSignaled bool
+	completed        chan struct{}
+	completionOwner  atomic.Uint32
+	summary          processRetryCoordinatorSummary
+	invocationPhase  uint64
+	phaseByTestName  map[string]uint64
+	failfastEnabled  func() bool
+	attemptRunner    deferredProcessRetryAttemptRunner
+	batchRunner      deferredProcessRetryBatchRunner
 }
 
 type deferredProcessRetryPreparedAttempt struct {
@@ -384,24 +370,7 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 			failfastLatched = outcome.failfast
 			terminalPanic = outcome.terminalPanic
 		} else {
-			c.mu.Lock()
-			failureOrdinal, failureObserved := c.nativeFailureOrdinal, c.nativeFailureObserved
-			c.mu.Unlock()
-			if failureObserved {
-				beforeFailure := make([]*deferredProcessRetryGroup, 0, len(queue))
-				afterFailure := make([]*deferredProcessRetryGroup, 0, len(queue))
-				for _, group := range queue {
-					if group.deferredFirstAttempt && group.invocationOrdinal <= failureOrdinal {
-						beforeFailure = append(beforeFailure, group)
-					} else {
-						afterFailure = append(afterFailure, group)
-					}
-				}
-				cancelDeferredProcessRetryGroups(c.drainDeferredFirstAttempts(beforeFailure), "failfast", false)
-				cancelDeferredProcessRetryGroups(afterFailure, "failfast", false)
-			} else {
-				cancelDeferredProcessRetryGroups(queue, "failfast", false)
-			}
+			cancelDeferredProcessRetryGroups(c.drainDeferredFirstAttempts(queue), "failfast", false)
 		}
 		packageFailed = deferredFailed || packageFailed
 	} else {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"sync"
@@ -106,6 +107,7 @@ type deferredProcessRetryGroup struct {
 	nativeMaxParallel     int
 	efdFaultySessionGuard earlyFlakeDetectionFaultySession
 	deferredFirstAttempt  bool
+	firstAttemptResult    *processRetryAttemptResult
 }
 
 type deferredProcessRetryEvent struct {
@@ -146,6 +148,9 @@ type processRetryCoordinator struct {
 	failfastEnabled  func() bool
 	attemptRunner    deferredProcessRetryAttemptRunner
 	batchRunner      deferredProcessRetryBatchRunner
+	nativeTests      []processRetryBatchTestConfig
+	nativeTestIndex  map[string]int
+	nativeBatches    map[uint64]*nativeScheduledProcessRetryBatch
 }
 
 type deferredProcessRetryPreparedAttempt struct {
@@ -436,7 +441,23 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 	}
 	for _, phaseID := range phaseOrder {
 		groups := groupsByPhase[phaseID]
-		results := c.batchRunner(context.Background(), groups)
+		results := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+		pending := make([]*deferredProcessRetryGroup, 0, len(groups))
+		native := make([]*deferredProcessRetryGroup, 0, len(groups))
+		for _, group := range groups {
+			if group.firstAttemptResult == nil {
+				pending = append(pending, group)
+				continue
+			}
+			results[group] = *group.firstAttemptResult
+			native = append(native, group)
+		}
+		if len(pending) > 0 {
+			maps.Copy(results, c.batchRunner(context.Background(), pending))
+		}
+		if processAttempt, ok := c.nativeScheduledBatchResult(phaseID); ok {
+			preserveProcessRetryBatchFailure(processAttempt, native, results)
+		}
 		for _, group := range groups {
 			attempt, ok := results[group]
 			if !ok {
@@ -460,6 +481,7 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 			group.finish()
 			group.printSummary()
 		}
+		c.cleanupNativeScheduledBatch(phaseID)
 	}
 	slices.SortStableFunc(remaining, func(a, b *deferredProcessRetryGroup) int {
 		return cmp.Compare(a.invocationOrdinal, b.invocationOrdinal)
@@ -1109,6 +1131,10 @@ func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
 	}
 	group.metadata.identity = &group.identity
 	group.testInfo.identity = &group.identity
+	if options.quarantinedRaceNativeOrder {
+		firstAttempt := options.processRetryCoordinator.waitNativeScheduledFirstAttempt(group, options.t)
+		group.firstAttemptResult = &firstAttempt
+	}
 	if !admission.commit(group) {
 		lease.release()
 		runTestWithRetry(options)

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -447,7 +447,11 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 					FinishTime: time.Now(),
 				}
 			}
-			batchFailed = batchFailed || errors.Is(attempt.Err, errProcessRetryBatchFailed)
+			switch effectiveProcessRetryStatus(attempt, false).FailureKind {
+			case "", "test_fail", "test_panic", "test_race":
+			default:
+				batchFailed = true
+			}
 			if group.applyDeferredFirstAttempt(attempt) {
 				group.deferredFirstAttempt = false
 				remaining = append(remaining, group)

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -148,6 +148,7 @@ type processRetryCoordinator struct {
 	failfastEnabled  func() bool
 	attemptRunner    deferredProcessRetryAttemptRunner
 	batchRunner      deferredProcessRetryBatchRunner
+	nativeRunner     deferredProcessRetryBatchRunner
 	nativeTests      []processRetryBatchTestConfig
 	nativeTestIndex  map[string]int
 	nativeTestOrder  func() []string
@@ -219,6 +220,7 @@ func newProcessRetryCoordinator(failfastEnabled func() bool, attemptRunner defer
 		failfastEnabled: failfastEnabled,
 		attemptRunner:   attemptRunner,
 		batchRunner:     runDeferredQuarantinedProcessRetryBatch,
+		nativeRunner:    runDeferredNativeScheduledProcessRetryBatch,
 	}
 }
 
@@ -445,16 +447,24 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 		results := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
 		pending := make([]*deferredProcessRetryGroup, 0, len(groups))
 		native := make([]*deferredProcessRetryGroup, 0, len(groups))
+		missingNative := make([]*deferredProcessRetryGroup, 0, len(groups))
 		for _, group := range groups {
 			if group.firstAttemptResult == nil {
 				pending = append(pending, group)
 				continue
 			}
-			results[group] = *group.firstAttemptResult
 			native = append(native, group)
+			if errors.Is(group.firstAttemptResult.Err, errProcessRetryResultMissing) {
+				missingNative = append(missingNative, group)
+				continue
+			}
+			results[group] = *group.firstAttemptResult
 		}
 		if len(pending) > 0 {
 			maps.Copy(results, c.batchRunner(context.Background(), pending))
+		}
+		if len(missingNative) > 0 {
+			maps.Copy(results, c.nativeRunner(context.Background(), missingNative))
 		}
 		if processAttempt, ok := c.nativeScheduledBatchResult(phaseID); ok {
 			preserveProcessRetryBatchFailure(processAttempt, native, results)

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1082,6 +1082,7 @@ func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
 		return
 	}
 	parentDeadline, parentDeadlineOK := options.t.Deadline()
+	nativeMaxParallel, _ := retryAttemptNativeMaxParallel(options.t)
 	module := session.GetOrCreateModule(options.testInfo.moduleName)
 	suite := module.GetOrCreateSuite(options.testInfo.suiteName)
 	group := &deferredProcessRetryGroup{
@@ -1092,6 +1093,7 @@ func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
 		lease:                 lease,
 		parentDeadline:        parentDeadline,
 		parentDeadlineOK:      parentDeadlineOK,
+		nativeMaxParallel:     nativeMaxParallel,
 		mRunEpoch:             options.processRetryMRunEpoch,
 		phaseID:               options.processRetryPhaseID,
 		invocationOrdinal:     ensureProcessRetryInvocationOrdinal(options),

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -151,7 +151,6 @@ type processRetryCoordinator struct {
 	nativeRunner     deferredProcessRetryBatchRunner
 	nativeTests      []processRetryBatchTestConfig
 	nativeTestIndex  map[string]int
-	nativeTestOrder  func() []string
 	nativeBatches    map[uint64]*nativeScheduledProcessRetryBatch
 }
 
@@ -466,8 +465,10 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 		if len(missingNative) > 0 {
 			maps.Copy(results, c.nativeRunner(context.Background(), missingNative))
 		}
-		if processAttempt, ok := c.nativeScheduledBatchResult(phaseID); ok {
-			preserveProcessRetryBatchFailure(processAttempt, native, results)
+		for _, group := range native {
+			if processAttempt, ok := c.nativeScheduledBatchResult(group.invocationOrdinal); ok {
+				preserveProcessRetryBatchFailure(processAttempt, []*deferredProcessRetryGroup{group}, results)
+			}
 		}
 		for _, group := range groups {
 			attempt, ok := results[group]
@@ -492,7 +493,9 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 			group.finish()
 			group.printSummary()
 		}
-		c.cleanupNativeScheduledBatch(phaseID)
+		for _, group := range native {
+			c.cleanupNativeScheduledBatch(group.invocationOrdinal)
+		}
 	}
 	slices.SortStableFunc(remaining, func(a, b *deferredProcessRetryGroup) int {
 		return cmp.Compare(a.invocationOrdinal, b.invocationOrdinal)

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1052,7 +1052,7 @@ func prepareDeferredProcessRetryInvocation(execOpts *executionOptions) {
 		return
 	}
 	execOpts.processRetryLaunchBaseline = captureProcessRetryLaunchBaselineFromTemplate(options.processRetryLaunchTemplate)
-	if ok, _ := processRetryParallelBaselineReady(execOpts.processRetryLaunchBaseline); !ok {
+	if ok, _ := processRetryFirstAttemptIsolationReady(execOpts.processRetryLaunchBaseline); !ok {
 		return
 	}
 	options.processRetryPhaseID = options.processRetryCoordinator.observeInvocationPhase(options.processRetryIdentity)
@@ -1099,7 +1099,7 @@ func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
 	execMeta.hasAdditionalFeatureWrapper = true
 	execOpts := &executionOptions{options: options, executionMetadata: execMeta}
 	prepareDeferredProcessRetryInvocation(execOpts)
-	if ok, _ := processRetryParallelBaselineReady(execOpts.processRetryLaunchBaseline); !ok || options.processRetryPhaseID == 0 {
+	if ok, _ := processRetryFirstAttemptIsolationReady(execOpts.processRetryLaunchBaseline); !ok || options.processRetryPhaseID == 0 {
 		runTestWithRetry(options)
 		return
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -150,6 +150,7 @@ type processRetryCoordinator struct {
 	batchRunner      deferredProcessRetryBatchRunner
 	nativeTests      []processRetryBatchTestConfig
 	nativeTestIndex  map[string]int
+	nativeTestOrder  func() []string
 	nativeBatches    map[uint64]*nativeScheduledProcessRetryBatch
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -105,6 +105,7 @@ type deferredProcessRetryGroup struct {
 	rootParallel          bool
 	nativeMaxParallel     int
 	efdFaultySessionGuard earlyFlakeDetectionFaultySession
+	deferredFirstAttempt  bool
 }
 
 type deferredProcessRetryEvent struct {
@@ -144,6 +145,7 @@ type processRetryCoordinator struct {
 	phaseByTestName  map[string]uint64
 	failfastEnabled  func() bool
 	attemptRunner    deferredProcessRetryAttemptRunner
+	batchRunner      deferredProcessRetryBatchRunner
 }
 
 type deferredProcessRetryPreparedAttempt struct {
@@ -210,6 +212,7 @@ func newProcessRetryCoordinator(failfastEnabled func() bool, attemptRunner defer
 		completed:       make(chan struct{}),
 		failfastEnabled: failfastEnabled,
 		attemptRunner:   attemptRunner,
+		batchRunner:     runDeferredQuarantinedProcessRetryBatch,
 	}
 }
 
@@ -361,6 +364,7 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 	var terminalPanic any
 	if !shuttingDown && !c.shutdownRequested() {
 		if !failfastLatched {
+			queue = c.drainDeferredFirstAttempts(queue)
 			outcome := c.drainScheduledGroups(queue)
 			deferredFailed = outcome.deferredFailed
 			failfastLatched = outcome.failfast
@@ -398,6 +402,110 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 	close(c.completed)
 	c.mu.Unlock()
 	unregisterProcessRetryCoordinator(c)
+}
+
+func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredProcessRetryGroup) []*deferredProcessRetryGroup {
+	if len(queue) == 0 {
+		return nil
+	}
+	hasDeferredFirstAttempt := false
+	for _, group := range queue {
+		if group.deferredFirstAttempt {
+			hasDeferredFirstAttempt = true
+			break
+		}
+	}
+	if !hasDeferredFirstAttempt {
+		return queue
+	}
+	remaining := make([]*deferredProcessRetryGroup, 0, len(queue))
+	groupsByPhase := make(map[uint64][]*deferredProcessRetryGroup)
+	phaseOrder := make([]uint64, 0)
+	for _, group := range queue {
+		if !group.deferredFirstAttempt {
+			remaining = append(remaining, group)
+			continue
+		}
+		if _, exists := groupsByPhase[group.phaseID]; !exists {
+			phaseOrder = append(phaseOrder, group.phaseID)
+		}
+		groupsByPhase[group.phaseID] = append(groupsByPhase[group.phaseID], group)
+	}
+	for _, phaseID := range phaseOrder {
+		groups := groupsByPhase[phaseID]
+		results := c.batchRunner(context.Background(), groups)
+		for _, group := range groups {
+			attempt, ok := results[group]
+			if !ok {
+				attempt = processRetryAttemptResult{
+					Err:        errProcessRetryResultMissing,
+					ExitCode:   processRetryExitCodeUnset,
+					StartTime:  time.Now(),
+					FinishTime: time.Now(),
+				}
+			}
+			if group.applyDeferredFirstAttempt(attempt) {
+				group.deferredFirstAttempt = false
+				remaining = append(remaining, group)
+				continue
+			}
+			group.finish()
+			group.printSummary()
+		}
+	}
+	slices.SortStableFunc(remaining, func(a, b *deferredProcessRetryGroup) int {
+		return cmp.Compare(a.invocationOrdinal, b.invocationOrdinal)
+	})
+	return remaining
+}
+
+func (g *deferredProcessRetryGroup) applyDeferredFirstAttempt(attempt processRetryAttemptResult) bool {
+	execMeta := &testExecutionMetadata{}
+	if !applyProcessRetryMetadataSnapshot(execMeta, &g.metadata) {
+		g.cancel("missing_metadata_snapshot", true)
+		return false
+	}
+	execMeta.hasAdditionalFeatureWrapper = true
+	execMeta.isARetry = false
+	duration := max(attempt.FinishTime.Sub(attempt.StartTime), 0)
+	// Match the inline runner: the configured count is sampled from the first
+	// execution, then that completed execution consumes the initial slot.
+	g.retryCount = computeAdjustedRetryCount(execMeta, duration) - 1
+	execMeta.remainingRetries = g.retryCount
+	execMeta.initialRetryCount = g.retryCount
+	execMeta.initialRetryCountSet = true
+	execMeta.isLastRetry = g.retryCount <= 0
+	terminal := deferredProcessRetryAttemptTerminal(attempt)
+	continueGroup := false
+	effective, tail := deferProcessRetryTestEventWithAdmission(&g.testInfo, execMeta, attempt, func(effective processRetryEffectiveStatus) {
+		g.outcomes.observe(effective.Failed, effective.Skipped)
+		continueGroup = !terminal && deferredProcessRetryShouldContinue(execMeta, effective.Failed, effective.Skipped, g.retryCount)
+		execMeta.retryContinuationDecided = true
+		execMeta.retryContinuationAdmitted = continueGroup
+		execMeta.isLastRetry = !continueGroup
+		execMeta.anyExecutionPassed = g.outcomes.anyPassed()
+		execMeta.anyExecutionFailed = g.outcomes.anyFailed()
+		execMeta.allAttemptsPassed = g.outcomes.allAttemptsPassed()
+		execMeta.allRetriesFailed = g.executionIndex > 0 && g.outcomes.allRetriesFailed()
+	})
+	g.latest = retryAttemptObservation{
+		executionIndex: 0,
+		failed:         effective.Failed,
+		skipped:        effective.Skipped,
+		duration:       duration,
+		raceDetected:   attempt.Result.RaceDetected,
+		rootParallel:   attempt.Result.RootParallel,
+	}
+	g.rootParallel = attempt.Result.RootParallel
+	if attempt.Result.Panic {
+		g.panicPresent = true
+		g.panicMessage = attempt.Result.ErrorMessage
+		g.panicStack = attempt.Result.ErrorStack
+	}
+	if tail != nil {
+		g.tailEvent = tail
+	}
+	return continueGroup
 }
 
 func cancelDeferredProcessRetryGroups(groups []*deferredProcessRetryGroup, reason string, failed bool) {
@@ -876,6 +984,94 @@ func prepareDeferredProcessRetryInvocation(execOpts *executionOptions) {
 	}
 }
 
+func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
+	if options == nil {
+		return
+	}
+	if options.t == nil || options.testInfo == nil || options.processRetryCoordinator == nil {
+		runTestWithRetry(options)
+		return
+	}
+	identity, ok := cloneDeferredTestIdentity(options.processRetryIdentity)
+	if !ok {
+		runTestWithRetry(options)
+		return
+	}
+	execMeta := &testExecutionMetadata{}
+	if options.preExecMetaAdjust != nil {
+		options.preExecMetaAdjust(execMeta, 0)
+	}
+	testInfo := &testingTInfo{commonInfo: *options.testInfo}
+	itrDecision := currentITRState().decisionFor(testInfo, execMeta, integrations.IsTestFuncUnskippable(options.testInfo.sourceFunc))
+	if itrDecision.skip {
+		originalExecMeta := getTestMetadata(options.t)
+		if originalExecMeta == nil {
+			originalExecMeta = createTestMetadata(options.t, nil)
+			defer deleteTestMetadata(options.t)
+		}
+		if options.preExecMetaAdjust != nil {
+			options.preExecMetaAdjust(originalExecMeta, 0)
+		}
+		options.targetFunc(options.t)
+		return
+	}
+	if itrDecision.forcedRun {
+		execMeta.isItrForcedRun = true
+	}
+	execMeta.identity = &identity
+	execMeta.hasAdditionalFeatureWrapper = true
+	execOpts := &executionOptions{options: options, executionMetadata: execMeta}
+	prepareDeferredProcessRetryInvocation(execOpts)
+	if ok, _ := processRetryParallelBaselineReady(execOpts.processRetryLaunchBaseline); !ok || options.processRetryPhaseID == 0 {
+		runTestWithRetry(options)
+		return
+	}
+	metadata := snapshotProcessRetryExecutionMetadata(execMeta)
+	if metadata == nil {
+		runTestWithRetry(options)
+		return
+	}
+	admission := options.processRetryCoordinator.beginAdmission()
+	if admission == nil {
+		runTestWithRetry(options)
+		return
+	}
+	lease, err := acquireProcessRetryGroupLease()
+	if err != nil {
+		admission.abort()
+		runTestWithRetry(options)
+		return
+	}
+	parentDeadline, parentDeadlineOK := options.t.Deadline()
+	module := session.GetOrCreateModule(options.testInfo.moduleName)
+	suite := module.GetOrCreateSuite(options.testInfo.suiteName)
+	group := &deferredProcessRetryGroup{
+		identity:              identity,
+		testInfo:              *options.testInfo,
+		metadata:              *metadata,
+		launchBaseline:        execOpts.processRetryLaunchBaseline,
+		lease:                 lease,
+		parentDeadline:        parentDeadline,
+		parentDeadlineOK:      parentDeadlineOK,
+		mRunEpoch:             options.processRetryMRunEpoch,
+		phaseID:               options.processRetryPhaseID,
+		invocationOrdinal:     ensureProcessRetryInvocationOrdinal(options),
+		executionIndex:        0,
+		module:                module,
+		suite:                 suite,
+		efdFaultySessionGuard: options.efdFaultySessionGuard,
+		deferredFirstAttempt:  true,
+	}
+	group.metadata.identity = &group.identity
+	group.testInfo.identity = &group.identity
+	if !admission.commit(group) {
+		lease.release()
+		runTestWithRetry(options)
+		return
+	}
+	options.t.SkipNow()
+}
+
 func enqueueDeferredProcessRetryGroup(execOpts *executionOptions) bool {
 	if execOpts == nil || execOpts.options == nil || execOpts.executionMetadata == nil {
 		return false
@@ -1222,7 +1418,7 @@ func (g *deferredProcessRetryGroup) closeTailEvent(final bool) {
 			attemptToFixPassed := g.outcomes.allAttemptsPassed() && !g.truncated && !g.terminalFailure
 			g.tailEvent.event.SetTag(constants.TestAttemptToFixPassed, strconv.FormatBool(attemptToFixPassed))
 		}
-		if g.tailEvent.failed && g.outcomes.allRetriesFailed() {
+		if g.executionIndex > 0 && g.tailEvent.failed && g.outcomes.allRetriesFailed() {
 			g.tailEvent.event.SetTag(constants.TestHasFailedAllRetries, "true")
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -480,9 +480,7 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 					FinishTime: time.Now(),
 				}
 			}
-			switch effectiveProcessRetryStatus(attempt, false).FailureKind {
-			case "", "test_fail", "test_panic", "test_race":
-			default:
+			if deferredProcessRetryInfrastructureFailure(attempt) {
 				batchFailed = true
 			}
 			if group.applyDeferredFirstAttempt(attempt) {
@@ -1145,14 +1143,32 @@ func deferQuarantinedRaceFirstAttempt(options *runTestWithRetryOptions) {
 	}
 	group.metadata.identity = &group.identity
 	group.testInfo.identity = &group.identity
+	infrastructureFailure := false
 	if options.quarantinedRaceNativeOrder {
 		firstAttempt := options.processRetryCoordinator.waitNativeScheduledFirstAttempt(group, options.t)
 		group.firstAttemptResult = &firstAttempt
+		infrastructureFailure = deferredProcessRetryInfrastructureFailure(firstAttempt)
 	}
 	if !admission.commit(group) {
 		lease.release()
 		runTestWithRetry(options)
 		return
+	}
+	finishDeferredProcessRetryFirstAttempt(options, infrastructureFailure)
+}
+
+func deferredProcessRetryInfrastructureFailure(attempt processRetryAttemptResult) bool {
+	switch effectiveProcessRetryStatus(attempt, false).FailureKind {
+	case "", "test_fail", "test_panic", "test_race":
+		return false
+	default:
+		return true
+	}
+}
+
+func finishDeferredProcessRetryFirstAttempt(options *runTestWithRetryOptions, infrastructureFailure bool) {
+	if infrastructureFailure && retryAttemptFailfastEnabled() {
+		options.t.FailNow()
 	}
 	options.t.SkipNow()
 }

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -364,13 +364,15 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 	var terminalPanic any
 	if !shuttingDown && !c.shutdownRequested() {
 		if !failfastLatched {
-			queue = c.drainDeferredFirstAttempts(queue)
+			var batchFailed bool
+			queue, batchFailed = c.drainDeferredFirstAttempts(queue)
 			outcome := c.drainScheduledGroups(queue)
-			deferredFailed = outcome.deferredFailed
+			deferredFailed = batchFailed || outcome.deferredFailed
 			failfastLatched = outcome.failfast
 			terminalPanic = outcome.terminalPanic
 		} else {
-			cancelDeferredProcessRetryGroups(c.drainDeferredFirstAttempts(queue), "failfast", false)
+			remaining, _ := c.drainDeferredFirstAttempts(queue)
+			cancelDeferredProcessRetryGroups(remaining, "failfast", false)
 		}
 		packageFailed = deferredFailed || packageFailed
 	} else {
@@ -404,9 +406,9 @@ func (c *processRetryCoordinator) complete(nativeExitCode int, shuttingDown bool
 	unregisterProcessRetryCoordinator(c)
 }
 
-func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredProcessRetryGroup) []*deferredProcessRetryGroup {
+func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredProcessRetryGroup) ([]*deferredProcessRetryGroup, bool) {
 	if len(queue) == 0 {
-		return nil
+		return nil, false
 	}
 	hasDeferredFirstAttempt := false
 	for _, group := range queue {
@@ -416,8 +418,9 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 		}
 	}
 	if !hasDeferredFirstAttempt {
-		return queue
+		return queue, false
 	}
+	batchFailed := false
 	remaining := make([]*deferredProcessRetryGroup, 0, len(queue))
 	groupsByPhase := make(map[uint64][]*deferredProcessRetryGroup)
 	phaseOrder := make([]uint64, 0)
@@ -444,6 +447,7 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 					FinishTime: time.Now(),
 				}
 			}
+			batchFailed = batchFailed || errors.Is(attempt.Err, errProcessRetryBatchFailed)
 			if group.applyDeferredFirstAttempt(attempt) {
 				group.deferredFirstAttempt = false
 				remaining = append(remaining, group)
@@ -456,7 +460,7 @@ func (c *processRetryCoordinator) drainDeferredFirstAttempts(queue []*deferredPr
 	slices.SortStableFunc(remaining, func(a, b *deferredProcessRetryGroup) int {
 		return cmp.Compare(a.invocationOrdinal, b.invocationOrdinal)
 	})
-	return remaining
+	return remaining, batchFailed
 }
 
 func (g *deferredProcessRetryGroup) applyDeferredFirstAttempt(attempt processRetryAttemptResult) bool {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -1223,8 +1223,9 @@ func TestDeferredProcessRetryBatchesFirstAttemptsByPhase(t *testing.T) {
 		return results
 	}
 
-	remaining := coordinator.drainDeferredFirstAttempts([]*deferredProcessRetryGroup{a, ordinary, b, c})
+	remaining, batchFailed := coordinator.drainDeferredFirstAttempts([]*deferredProcessRetryGroup{a, ordinary, b, c})
 
+	require.False(t, batchFailed)
 	require.Equal(t, [][]*deferredProcessRetryGroup{{a, b}, {c}}, batches)
 	require.Equal(t, []*deferredProcessRetryGroup{ordinary}, remaining)
 	require.Len(t, recorder.tests, 3)
@@ -1243,8 +1244,9 @@ func TestDeferredProcessRetryFirstAttemptDrainReturnsOriginalQueueWhenUnused(t *
 		return nil
 	}
 
-	got := coordinator.drainDeferredFirstAttempts(queue)
+	got, batchFailed := coordinator.drainDeferredFirstAttempts(queue)
 
+	require.False(t, batchFailed)
 	require.Equal(t, queue, got)
 	require.Same(t, &queue[0], &got[0])
 }

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -625,6 +625,7 @@ func TestDeferredProcessRetryInfrastructureFailfastStopsFollowingTest(t *testing
 		os.Args[1:],
 		"^(TestDeferredProcessRetryInfrastructureFailfastFailure|TestDeferredProcessRetryInfrastructureFailfastFollowing)$",
 		"-test.failfast=true",
+		"-test.shuffle=off", // The failfast assertion requires the failure fixture to run first.
 	)...)
 	cmd.Env = append(os.Environ(), deferredProcessRetryInfrastructureFailfastFixtureEnv+"=true", "Bypass=true")
 	output, err := cmd.CombinedOutput()

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -549,45 +549,27 @@ func TestDeferredProcessRetryCoordinatorFailfastStopsLaterGroups(t *testing.T) {
 	require.False(t, second.terminalFailure, "failfast cancellation keeps the latest real observation authoritative")
 }
 
-func TestDeferredProcessRetryCoordinatorNativeFailfastLaunchesNoGroups(t *testing.T) {
-	runner := func(context.Context, *deferredProcessRetryGroup, deferredProcessRetryPreparedAttempt) processRetryAttemptResult {
-		t.Fatal("native package failure must latch failfast before deferred launch")
-		return processRetryAttemptResult{}
-	}
-	coordinator := newProcessRetryCoordinatorForTesting(true, runner)
-	group := &deferredProcessRetryGroup{}
-	require.True(t, coordinator.beginAdmission().commit(group))
-
-	summary := coordinator.drain(3)
-	require.Equal(t, 3, summary.exitCode)
-	require.True(t, summary.packageFailed)
-	require.False(t, summary.deferredFailed)
-	require.True(t, summary.failfast)
-	require.Equal(t, "failfast", group.terminalFailureReason)
-}
-
-func TestDeferredProcessRetryCoordinatorNativeFailfastRunsEarlierFirstAttempts(t *testing.T) {
+func TestDeferredProcessRetryCoordinatorNativeFailfastRunsAdmittedFirstAttempts(t *testing.T) {
 	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
 	defer restoreSession()
 	coordinator := newProcessRetryCoordinatorForTesting(true)
-	before := newDeferredQuarantinedFirstAttemptGroupForTesting("TestBeforeFailure", 1, 1)
-	after := newDeferredQuarantinedFirstAttemptGroupForTesting("TestAfterFailure", 1, 2)
-	require.True(t, coordinator.beginAdmission().commit(before))
-	require.True(t, coordinator.beginAdmission().commit(after))
+	first := newDeferredQuarantinedFirstAttemptGroupForTesting("TestFirst", 1, 1)
+	second := newDeferredQuarantinedFirstAttemptGroupForTesting("TestSecond", 1, 2)
+	require.True(t, coordinator.beginAdmission().commit(first))
+	require.True(t, coordinator.beginAdmission().commit(second))
 	var batches [][]*deferredProcessRetryGroup
 	coordinator.batchRunner = func(_ context.Context, groups []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
 		batches = append(batches, append([]*deferredProcessRetryGroup(nil), groups...))
 		return map[*deferredProcessRetryGroup]processRetryAttemptResult{
-			before: fixedProcessRetryAttempt(processRetryStatusPass, 1),
+			first:  fixedProcessRetryAttempt(processRetryStatusPass, 1),
+			second: fixedProcessRetryAttempt(processRetryStatusPass, 1),
 		}
 	}
-	coordinator.observeNativeFailure(1)
 
 	summary := coordinator.drain(3)
 
-	require.Equal(t, [][]*deferredProcessRetryGroup{{before}}, batches)
-	require.Len(t, recorder.tests, 1)
-	require.Equal(t, "failfast", after.terminalFailureReason)
+	require.Equal(t, [][]*deferredProcessRetryGroup{{first, second}}, batches)
+	require.Len(t, recorder.tests, 2)
 	require.Equal(t, 3, summary.exitCode)
 	require.True(t, summary.failfast)
 }

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -1287,6 +1287,54 @@ func TestDeferredProcessRetryFirstAttemptConsumesInitialRetrySlot(t *testing.T) 
 	require.Equal(t, int64(9), group.retryCount)
 }
 
+func TestDeferredProcessRetryAttemptToFixContinuesAfterEveryRace(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	settings := integrations.GetSettings()
+	oldSettings := *settings
+	defer func() { *settings = oldSettings }()
+	settings.TestManagement.AttemptToFixRetries = 3
+
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestAttemptToFixRace", 1, 1)
+	group.metadata.isAttemptToFix = true
+	group.metadata.shouldOrchestrateAttemptToFix = true
+	raceAttempt := fixedProcessRetryAttempt(processRetryStatusFail, 1)
+	raceAttempt.Result.Failed = true
+	raceAttempt.Result.RaceDetected = true
+	require.True(t, group.applyDeferredFirstAttempt(raceAttempt))
+
+	for index, wantContinue := range []bool{true, false} {
+		prepared, ok, _ := group.prepareAttempt(true)
+		require.True(t, ok)
+		attempt := raceAttempt
+		attempt.StartTime = time.Unix(0, int64(index+2))
+		attempt.FinishTime = attempt.StartTime.Add(time.Nanosecond)
+		require.Equal(t, wantContinue, group.applyCompletedAttempt(deferredProcessRetryCompletedAttempt{
+			prepared: prepared,
+			result:   attempt,
+		}, true, false))
+	}
+	require.Zero(t, group.retryCount)
+	group.finish()
+	require.Len(t, recorder.tests, 3)
+}
+
+func TestDeferredProcessRetryAttemptToFixRaceTerminalPolicy(t *testing.T) {
+	raceAttempt := fixedProcessRetryAttempt(processRetryStatusFail, 1)
+	raceAttempt.Result.Failed = true
+	raceAttempt.Result.RaceDetected = true
+	ownedAttemptToFix := &processRetryMetadataSnapshot{isAttemptToFix: true, shouldOrchestrateAttemptToFix: true}
+	unownedAttemptToFix := &processRetryMetadataSnapshot{isAttemptToFix: true}
+
+	require.False(t, deferredProcessRetryAttemptTerminal(ownedAttemptToFix, raceAttempt))
+	require.True(t, deferredProcessRetryAttemptTerminal(unownedAttemptToFix, raceAttempt))
+	require.True(t, deferredProcessRetryAttemptTerminal(nil, raceAttempt))
+
+	infrastructureFailure := raceAttempt
+	infrastructureFailure.ContainmentLost = true
+	require.True(t, deferredProcessRetryAttemptTerminal(ownedAttemptToFix, infrastructureFailure))
+}
+
 func TestDeferredProcessRetryFirstAttemptReservesFTRBudget(t *testing.T) {
 	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
 	defer restoreSession()

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -1236,6 +1236,26 @@ func TestDeferredProcessRetryBatchesFirstAttemptsByPhase(t *testing.T) {
 	}
 }
 
+func TestDeferredProcessRetryUsesNativeScheduledFirstAttemptResult(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
+	result := fixedProcessRetryAttempt(processRetryStatusPass, 1)
+	group.firstAttemptResult = &result
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		t.Fatal("native-scheduled first attempt was executed twice")
+		return nil
+	}
+
+	remaining, batchFailed := coordinator.drainDeferredFirstAttempts([]*deferredProcessRetryGroup{group})
+
+	require.False(t, batchFailed)
+	require.Empty(t, remaining)
+	require.Len(t, recorder.tests, 1)
+	require.Equal(t, processRetryStatusPass, recorder.tests[0].status)
+}
+
 func TestDeferredProcessRetryFirstAttemptDrainReturnsOriginalQueueWhenUnused(t *testing.T) {
 	coordinator := newProcessRetryCoordinatorForTesting(false)
 	queue := []*deferredProcessRetryGroup{{invocationOrdinal: 1}, {invocationOrdinal: 2}}

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -24,6 +26,11 @@ import (
 type deferredProcessRetryMutablePanic struct {
 	message string
 }
+
+const (
+	deferredProcessRetryInfrastructureFailfastFixtureEnv = "DD_TEST_DEFERRED_PROCESS_RETRY_INFRASTRUCTURE_FAILFAST"
+	deferredProcessRetryFailfastFollowingSentinel        = "deferred-process-retry-failfast-following-ran"
+)
 
 func processRetryCoordinatorRegisteredForTesting(c *processRetryCoordinator) bool {
 	processRetryCoordinatorRegistry.mu.Lock()
@@ -572,6 +579,57 @@ func TestDeferredProcessRetryCoordinatorNativeFailfastRunsAdmittedFirstAttempts(
 	require.Len(t, recorder.tests, 2)
 	require.Equal(t, 3, summary.exitCode)
 	require.True(t, summary.failfast)
+}
+
+func TestDeferredProcessRetryInfrastructureFailureClassification(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		attempt processRetryAttemptResult
+		want    bool
+	}{
+		{name: "pass", attempt: fixedProcessRetryAttempt(processRetryStatusPass, 1)},
+		{name: "test failure", attempt: fixedProcessRetryAttempt(processRetryStatusFail, 1)},
+		{name: "test race", attempt: processRetryAttemptResult{Result: processRetryResult{Status: processRetryStatusFail, Failed: true, RaceDetected: true}, ExitCode: 1}},
+		{name: "setup failure", attempt: failedNativeScheduledAttempt(errors.New("launch failed")), want: true},
+		{name: "timeout", attempt: processRetryAttemptResult{TimedOut: true}, want: true},
+		{name: "invalid result", attempt: processRetryAttemptResult{Err: errProcessRetryResultInvalid}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, deferredProcessRetryInfrastructureFailure(test.attempt))
+		})
+	}
+}
+
+func TestDeferredProcessRetryInfrastructureFailfastFailure(t *testing.T) {
+	if os.Getenv(deferredProcessRetryInfrastructureFailfastFixtureEnv) != "true" {
+		t.Skip("failfast fixture runs only in its controller subprocess")
+	}
+	finishDeferredProcessRetryFirstAttempt(
+		&runTestWithRetryOptions{t: t},
+		deferredProcessRetryInfrastructureFailure(failedNativeScheduledAttempt(errors.New("launch failed"))),
+	)
+}
+
+func TestDeferredProcessRetryInfrastructureFailfastFollowing(t *testing.T) {
+	if os.Getenv(deferredProcessRetryInfrastructureFailfastFixtureEnv) != "true" {
+		t.Skip("failfast fixture runs only in its controller subprocess")
+	}
+	fmt.Fprint(os.Stdout, deferredProcessRetryFailfastFollowingSentinel)
+}
+
+func TestDeferredProcessRetryInfrastructureFailfastStopsFollowingTest(t *testing.T) {
+	if os.Getenv(deferredProcessRetryInfrastructureFailfastFixtureEnv) == "true" {
+		t.Skip("controller does not run inside its fixture subprocess")
+	}
+	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(
+		os.Args[1:],
+		"^(TestDeferredProcessRetryInfrastructureFailfastFailure|TestDeferredProcessRetryInfrastructureFailfastFollowing)$",
+		"-test.failfast=true",
+	)...)
+	cmd.Env = append(os.Environ(), deferredProcessRetryInfrastructureFailfastFixtureEnv+"=true", "Bypass=true")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.NotContains(t, string(output), deferredProcessRetryFailfastFollowingSentinel)
 }
 
 func TestDeferredProcessRetryFailfastRefundsUnconsumedFTRReservation(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -566,6 +566,32 @@ func TestDeferredProcessRetryCoordinatorNativeFailfastLaunchesNoGroups(t *testin
 	require.Equal(t, "failfast", group.terminalFailureReason)
 }
 
+func TestDeferredProcessRetryCoordinatorNativeFailfastRunsEarlierFirstAttempts(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	coordinator := newProcessRetryCoordinatorForTesting(true)
+	before := newDeferredQuarantinedFirstAttemptGroupForTesting("TestBeforeFailure", 1, 1)
+	after := newDeferredQuarantinedFirstAttemptGroupForTesting("TestAfterFailure", 1, 2)
+	require.True(t, coordinator.beginAdmission().commit(before))
+	require.True(t, coordinator.beginAdmission().commit(after))
+	var batches [][]*deferredProcessRetryGroup
+	coordinator.batchRunner = func(_ context.Context, groups []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		batches = append(batches, append([]*deferredProcessRetryGroup(nil), groups...))
+		return map[*deferredProcessRetryGroup]processRetryAttemptResult{
+			before: fixedProcessRetryAttempt(processRetryStatusPass, 1),
+		}
+	}
+	coordinator.observeNativeFailure(1)
+
+	summary := coordinator.drain(3)
+
+	require.Equal(t, [][]*deferredProcessRetryGroup{{before}}, batches)
+	require.Len(t, recorder.tests, 1)
+	require.Equal(t, "failfast", after.terminalFailureReason)
+	require.Equal(t, 3, summary.exitCode)
+	require.True(t, summary.failfast)
+}
+
 func TestDeferredProcessRetryFailfastRefundsUnconsumedFTRReservation(t *testing.T) {
 	restoreBudget := setProcessRetryBudgetForTesting(1, 1)
 	defer restoreBudget()
@@ -1255,6 +1281,42 @@ func TestDeferredProcessRetryFirstAttemptConsumesInitialRetrySlot(t *testing.T) 
 
 	require.True(t, group.applyDeferredFirstAttempt(fixedProcessRetryAttempt(processRetryStatusPass, 1)))
 	require.Equal(t, int64(9), group.retryCount)
+}
+
+func TestDeferredProcessRetryFirstAttemptReservesFTRBudget(t *testing.T) {
+	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	restoreBudget := setProcessRetryBudgetForTesting(1, 1)
+	defer restoreBudget()
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestFTR", 1, 1)
+	group.metadata.isFlakyTestRetriesEnabled = true
+	attempt := fixedProcessRetryAttempt(processRetryStatusFail, 1)
+	attempt.Result.Failed = true
+
+	require.True(t, group.applyDeferredFirstAttempt(attempt))
+	require.NotNil(t, group.reservation)
+	require.True(t, group.reservation.reserved())
+	require.Zero(t, flakyRetryBudgetRemaining(integrations.GetFlakyRetriesSettings()))
+}
+
+func TestDeferredProcessRetryFirstAttemptAdmitsNewEFDTest(t *testing.T) {
+	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	settings := integrations.GetSettings()
+	oldSettings := *settings
+	defer func() { *settings = oldSettings }()
+	settings.EarlyFlakeDetection.SlowTestRetries.FiveS = 2
+	guard := &recordingEFDFaultySessionGuard{}
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestEFD", 1, 1)
+	group.metadata.isEarlyFlakeDetectionEnabled = true
+	group.metadata.isANewTest = true
+	group.efdFaultySessionGuard = guard
+	attempt := fixedProcessRetryAttempt(processRetryStatusFail, 1)
+	attempt.Result.Failed = true
+
+	require.True(t, group.applyDeferredFirstAttempt(attempt))
+	require.Equal(t, 1, guard.admitCalls)
+	require.Zero(t, guard.retryCalls)
 }
 
 func TestDeferredProcessRetryFirstAttemptDoesNotMarkAllRetriesFailed(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -1196,6 +1196,93 @@ func BenchmarkDeferredProcessRetryQueueAdmission(b *testing.B) {
 	}
 }
 
+func TestDeferredProcessRetryBatchesFirstAttemptsByPhase(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+
+	a := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
+	b := newDeferredQuarantinedFirstAttemptGroupForTesting("TestB", 1, 2)
+	c := newDeferredQuarantinedFirstAttemptGroupForTesting("TestC", 2, 3)
+	ordinary := &deferredProcessRetryGroup{invocationOrdinal: 4}
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	var batches [][]*deferredProcessRetryGroup
+	coordinator.batchRunner = func(_ context.Context, groups []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		batches = append(batches, append([]*deferredProcessRetryGroup(nil), groups...))
+		results := make(map[*deferredProcessRetryGroup]processRetryAttemptResult, len(groups))
+		for index, group := range groups {
+			results[group] = fixedProcessRetryAttempt(processRetryStatusPass, int64(index+1))
+		}
+		return results
+	}
+
+	remaining := coordinator.drainDeferredFirstAttempts([]*deferredProcessRetryGroup{a, ordinary, b, c})
+
+	require.Equal(t, [][]*deferredProcessRetryGroup{{a, b}, {c}}, batches)
+	require.Equal(t, []*deferredProcessRetryGroup{ordinary}, remaining)
+	require.Len(t, recorder.tests, 3)
+	for _, event := range recorder.tests {
+		require.Equal(t, processRetryStatusPass, event.status)
+		require.Equal(t, 1, event.closeCount)
+		require.Equal(t, constants.TestStatusSkip, event.tags[constants.TestFinalStatus])
+	}
+}
+
+func TestDeferredProcessRetryFirstAttemptDrainReturnsOriginalQueueWhenUnused(t *testing.T) {
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	queue := []*deferredProcessRetryGroup{{invocationOrdinal: 1}, {invocationOrdinal: 2}}
+	coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		t.Fatal("batch runner called without a deferred first attempt")
+		return nil
+	}
+
+	got := coordinator.drainDeferredFirstAttempts(queue)
+
+	require.Equal(t, queue, got)
+	require.Same(t, &queue[0], &got[0])
+}
+
+func TestDeferredProcessRetryFirstAttemptConsumesInitialRetrySlot(t *testing.T) {
+	_, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	settings := integrations.GetSettings()
+	oldSettings := *settings
+	defer func() { *settings = oldSettings }()
+	settings.TestManagement.AttemptToFixRetries = 10
+
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestAttemptToFix", 1, 1)
+	group.metadata.isAttemptToFix = true
+	group.metadata.shouldOrchestrateAttemptToFix = true
+
+	require.True(t, group.applyDeferredFirstAttempt(fixedProcessRetryAttempt(processRetryStatusPass, 1)))
+	require.Equal(t, int64(9), group.retryCount)
+}
+
+func TestDeferredProcessRetryFirstAttemptDoesNotMarkAllRetriesFailed(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	group := newDeferredQuarantinedFirstAttemptGroupForTesting("TestQuarantined", 1, 1)
+	attempt := fixedProcessRetryAttempt(processRetryStatusFail, 1)
+	attempt.Result.Failed = true
+
+	require.False(t, group.applyDeferredFirstAttempt(attempt))
+	group.finish()
+	require.Len(t, recorder.tests, 1)
+	_, tagged := recorder.tests[0].tags[constants.TestHasFailedAllRetries]
+	require.False(t, tagged)
+}
+
+func newDeferredQuarantinedFirstAttemptGroupForTesting(name string, phaseID, ordinal uint64) *deferredProcessRetryGroup {
+	identity := newTestIdentity("module", "suite", name)
+	return &deferredProcessRetryGroup{
+		identity:             *identity,
+		testInfo:             commonInfo{moduleName: identity.ModuleName, suiteName: identity.SuiteName, testName: identity.FullName, identity: identity},
+		metadata:             processRetryMetadataSnapshot{identity: identity, isQuarantined: true, hasAdditionalFeatureWrapper: true},
+		phaseID:              phaseID,
+		invocationOrdinal:    ordinal,
+		deferredFirstAttempt: true,
+	}
+}
+
 func newDeferredProcessRetrySchedulerGroup(
 	name string,
 	retryCount int64,

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -1256,6 +1256,34 @@ func TestDeferredProcessRetryUsesNativeScheduledFirstAttemptResult(t *testing.T)
 	require.Equal(t, processRetryStatusPass, recorder.tests[0].status)
 }
 
+func TestDeferredProcessRetryRelaunchesMissingNativeFirstAttemptsTogether(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	a := newDeferredQuarantinedFirstAttemptGroupForTesting("TestA", 1, 1)
+	b := newDeferredQuarantinedFirstAttemptGroupForTesting("TestB", 1, 2)
+	missing := processRetryAttemptResult{Err: errProcessRetryResultMissing, ExitCode: processRetryExitCodeUnset}
+	a.firstAttemptResult = &missing
+	b.firstAttemptResult = &missing
+	coordinator := newProcessRetryCoordinatorForTesting(false)
+	coordinator.batchRunner = func(context.Context, []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		t.Fatal("missing native attempts used the ordinary batch runner")
+		return nil
+	}
+	coordinator.nativeRunner = func(_ context.Context, groups []*deferredProcessRetryGroup) map[*deferredProcessRetryGroup]processRetryAttemptResult {
+		require.Equal(t, []*deferredProcessRetryGroup{a, b}, groups)
+		return map[*deferredProcessRetryGroup]processRetryAttemptResult{
+			a: fixedProcessRetryAttempt(processRetryStatusPass, 1),
+			b: fixedProcessRetryAttempt(processRetryStatusPass, 2),
+		}
+	}
+
+	remaining, batchFailed := coordinator.drainDeferredFirstAttempts([]*deferredProcessRetryGroup{a, b})
+
+	require.False(t, batchFailed)
+	require.Empty(t, remaining)
+	require.Len(t, recorder.tests, 2)
+}
+
 func TestDeferredProcessRetryFirstAttemptDrainReturnsOriginalQueueWhenUnused(t *testing.T) {
 	coordinator := newProcessRetryCoordinatorForTesting(false)
 	queue := []*deferredProcessRetryGroup{{invocationOrdinal: 1}, {invocationOrdinal: 2}}

--- a/internal/civisibility/integrations/gotesting/retry_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_race_test.go
@@ -24,3 +24,14 @@ func TestProcessRetryParityProcessChildRaceIsStructured(t *testing.T) {
 		ExitCode: exitCode,
 	}, false).FailureKind)
 }
+
+func TestProcessRetryParityProcessChildSubtestRaceIsStructured(t *testing.T) {
+	result, exitCode, output := runProcessRetryChildResultFixture(t, "subtest_race")
+	require.NotZero(t, exitCode, output)
+	require.Equal(t, processRetryStatusFail, result.Status)
+	require.True(t, result.Failed)
+	require.Len(t, result.Subtests, 1)
+	require.Equal(t, "TestProcessRetryChildResultFixture/child", result.Subtests[0].TestName)
+	require.Equal(t, processRetryStatusFail, result.Subtests[0].Status)
+	require.True(t, result.Subtests[0].Failed)
+}

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -614,6 +614,9 @@ func TestProcessRetryTimeoutFromEnv(t *testing.T) {
 func TestProcessRetrySelectedTimeoutUsesDefaultUnlessShortened(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	require.Equal(t, processRetryDefaultTimeout, selectedProcessRetryTimeout(
+		false, 0, true, 0, false, time.Time{}, false, now,
+	))
+	require.Equal(t, processRetryDefaultTimeout, selectedProcessRetryTimeout(
 		false, 30*time.Minute, true, 0, false, time.Time{}, false, now,
 	))
 	require.Equal(t, 5*time.Minute, selectedProcessRetryTimeout(
@@ -2967,11 +2970,11 @@ func TestProcessRetryTimeoutFromArgs(t *testing.T) {
 		{name: "test timeout equals", args: []string{"-test.timeout=30s"}, want: 30 * time.Second, ok: true},
 		{name: "timeout space", args: []string{"-timeout", "45s"}, want: 45 * time.Second, ok: true},
 		{name: "last valid wins", args: []string{"-timeout=bad", "-test.timeout", "1m"}, want: time.Minute, ok: true},
-		{name: "later zero clears positive timeout", args: []string{"-timeout=30s", "-test.timeout=0"}},
+		{name: "later zero disables positive timeout", args: []string{"-timeout=30s", "-test.timeout=0"}, ok: true},
 		{name: "later negative clears positive timeout", args: []string{"-timeout=30s", "-test.timeout=-1s"}},
 		{name: "later positive replaces zero timeout", args: []string{"-timeout=0", "-test.timeout=45s"}, want: 45 * time.Second, ok: true},
-		{name: "zero ignored", args: []string{"-timeout=0"}},
-		{name: "test timeout zero ignored", args: []string{"-test.timeout=0"}},
+		{name: "zero disables timeout", args: []string{"-timeout=0"}, ok: true},
+		{name: "test timeout zero disables timeout", args: []string{"-test.timeout=0"}, ok: true},
 		{name: "negative ignored", args: []string{"-timeout=-1s"}},
 		{name: "after boundary ignored", args: []string{"--", "-timeout=30s"}},
 		{name: "test timeout after boundary ignored", args: []string{"user_arg", "-test.timeout=30s"}},
@@ -4277,7 +4280,7 @@ func TestCombineProcessRetryOutputTailsMarksPerStreamTruncation(t *testing.T) {
 	_, err := sink.Write([]byte("prefix-tail"))
 	require.NoError(t, err)
 
-	combined, truncated, err := combineProcessRetryOutputTails(&processRetryOutputCapture{sink: sink}, nil, 16)
+	combined, truncated, err := combineProcessRetryOutputTails(&processRetryOutputCapture{sink: sink}, nil, 16, nil)
 	require.NoError(t, err)
 	require.True(t, truncated)
 	require.Equal(t, 1, strings.Count(combined, processRetryOutputTruncationMarker))
@@ -4298,6 +4301,7 @@ func TestCombineProcessRetryOutputTailsKeepsBoundedCombinedSuffix(t *testing.T) 
 		stdout    string
 		stderr    string
 		maxBytes  int64
+		filter    func(string) string
 		want      string
 		truncated bool
 	}{
@@ -4308,10 +4312,11 @@ func TestCombineProcessRetryOutputTailsKeepsBoundedCombinedSuffix(t *testing.T) 
 		{name: "stdout only", stdout: "abcdef", maxBytes: 3, want: processRetryOutputTruncationMarker + "def", truncated: true},
 		{name: "zero limit", stdout: "stdout", stderr: "stderr", maxBytes: 0, want: processRetryOutputTruncationMarker, truncated: true},
 		{name: "unbounded", stdout: "stdout", stderr: "stderr", maxBytes: -1, want: "stdout\nstderr"},
+		{name: "filter applies only to stdout", stdout: "\x16PASS\nstdout", stderr: "\x16FAIL\nPASS", maxBytes: processRetryOutputMaxBytes, filter: filterProcessRetryBatchOutput, want: "stdout\n\x16FAIL\nPASS"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			combined, truncated, err := combineProcessRetryOutputTails(capture(t, tt.stdout), capture(t, tt.stderr), tt.maxBytes)
+			combined, truncated, err := combineProcessRetryOutputTails(capture(t, tt.stdout), capture(t, tt.stderr), tt.maxBytes, tt.filter)
 			require.NoError(t, err)
 			require.Equal(t, tt.truncated, truncated)
 			require.Equal(t, tt.want, combined)
@@ -4330,7 +4335,7 @@ func BenchmarkCombineProcessRetryOutputTailsSaturated(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		_, _, _ = combineProcessRetryOutputTails(stdout, stderr, processRetryOutputMaxBytes)
+		_, _, _ = combineProcessRetryOutputTails(stdout, stderr, processRetryOutputMaxBytes, nil)
 	}
 }
 
@@ -4410,7 +4415,7 @@ func TestFinalizeProcessRetryOutputCapturesMarksContainmentLossOnDrainTimeout(t 
 		Result:   processRetryResult{Status: processRetryStatusPass},
 		ExitCode: 0,
 	}
-	finalizeProcessRetryOutputCaptures(hooks, &exec.Cmd{}, &attempt, stdoutCapture, stderrCapture)
+	finalizeProcessRetryOutputCaptures(hooks, &exec.Cmd{}, &attempt, stdoutCapture, stderrCapture, nil)
 
 	require.Equal(t, int32(1), killCalls.Load())
 	require.ErrorIs(t, attempt.CaptureErr, errProcessRetryOutputDrainTimedOut)
@@ -4692,11 +4697,18 @@ func TestRunProcessRetryBatchMergesTestLog(t *testing.T) {
 	require.NoError(t, os.WriteFile(parentTestLog, []byte(processRetryTestLogMagic), 0o600))
 	t.Setenv(processRetryNativeLifecycleFixtureEnv, "true")
 	t.Setenv(processRetryChildResultScenarioEnv, "pass")
+	t.Setenv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "")
 
 	baseline := captureProcessRetryLaunchBaselineForTesting()
 	require.NoError(t, baseline.err)
-	baseline.args = []string{"-test.testlogfile=" + parentTestLog}
+	baseline.args = []string{"-test.testlogfile=" + parentTestLog, "-test.timeout=0"}
 	baseline.argsSnapshot = captureProcessRetryArgsSnapshot(baseline.args)
+	timerCalls := atomic.Int32{}
+	newTimer := baseline.hooks.newTimer
+	baseline.hooks.newTimer = func(d time.Duration) processRetryTimer {
+		timerCalls.Add(1)
+		return newTimer(d)
+	}
 	attempt := runProcessRetryAttemptWithBaseline(context.Background(), processRetryChildConfig{
 		TestName:    processRetryBatchTestName,
 		Attempt:     1,
@@ -4713,6 +4725,7 @@ func TestRunProcessRetryBatchMergesTestLog(t *testing.T) {
 	}
 	require.False(t, attempt.SetupFailure)
 	require.NoError(t, attempt.Err)
+	require.Zero(t, timerCalls.Load())
 
 	got, err := os.ReadFile(parentTestLog)
 	require.NoError(t, err)

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -614,13 +614,13 @@ func TestProcessRetryTimeoutFromEnv(t *testing.T) {
 func TestProcessRetrySelectedTimeoutUsesDefaultUnlessShortened(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	require.Equal(t, processRetryDefaultTimeout, selectedProcessRetryTimeout(
-		30*time.Minute, true, 0, false, time.Time{}, false, now,
+		false, 30*time.Minute, true, 0, false, time.Time{}, false, now,
 	))
 	require.Equal(t, 5*time.Minute, selectedProcessRetryTimeout(
-		5*time.Minute, true, 0, false, time.Time{}, false, now,
+		false, 5*time.Minute, true, 0, false, time.Time{}, false, now,
 	))
 	require.Equal(t, 20*time.Minute, selectedProcessRetryTimeout(
-		30*time.Minute, true, 20*time.Minute, true, time.Time{}, false, now,
+		false, 30*time.Minute, true, 20*time.Minute, true, time.Time{}, false, now,
 	))
 }
 
@@ -4498,6 +4498,40 @@ func TestRunProcessRetryAttemptPreservesArtifactPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, "..", relative)
 	require.False(t, strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+func TestRunProcessRetryBatchMergesTestLog(t *testing.T) {
+	requireProcessRetryContainmentForTesting(t)
+	resetProcessRetryLimiterForTesting(t)
+	parentTestLog := filepath.Join(t.TempDir(), "testlog.txt")
+	require.NoError(t, os.WriteFile(parentTestLog, []byte(processRetryTestLogMagic), 0o600))
+	t.Setenv(processRetryNativeLifecycleFixtureEnv, "true")
+	t.Setenv(processRetryChildResultScenarioEnv, "pass")
+
+	baseline := captureProcessRetryLaunchBaselineForTesting()
+	require.NoError(t, baseline.err)
+	baseline.args = []string{"-test.testlogfile=" + parentTestLog}
+	baseline.argsSnapshot = captureProcessRetryArgsSnapshot(baseline.args)
+	attempt := runProcessRetryAttemptWithBaseline(context.Background(), processRetryChildConfig{
+		TestName:    processRetryBatchTestName,
+		Attempt:     1,
+		RetryReason: processRetryBatchReason,
+		Batch: &processRetryBatchConfig{
+			Version: processRetryBatchVersion,
+			Tests: []processRetryBatchTestConfig{{
+				TestName: "TestProcessRetryChildResultFixture",
+			}},
+		},
+	}, time.Time{}, false, baseline)
+	if attempt.Cleanup != nil {
+		defer attempt.Cleanup()
+	}
+	require.False(t, attempt.SetupFailure)
+	require.NoError(t, attempt.Err)
+
+	got, err := os.ReadFile(parentTestLog)
+	require.NoError(t, err)
+	require.Contains(t, string(got), "getenv "+processRetryChildResultScenarioEnv+"\n")
 }
 
 func TestRunProcessRetryAttemptDoesNotInheritStdin(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -6932,6 +6932,23 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 		<-done
 		<-done
 		runtime.KeepAlive(value)
+	case "subtest_race":
+		t.Run("child", instrumentProcessRetryChildSubtest(func(t *testing.T) {
+			var value int
+			start := make(chan struct{})
+			done := make(chan struct{}, 2)
+			for range 2 {
+				go func() {
+					<-start
+					value++
+					done <- struct{}{}
+				}()
+			}
+			close(start)
+			<-done
+			<-done
+			runtime.KeepAlive(value)
+		}))
 	case "stdin_eof":
 		stdin, err := io.ReadAll(os.Stdin)
 		require.NoError(t, err)

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1614,6 +1614,7 @@ func TestProcessRetryChildResultStatuses(t *testing.T) {
 		outputContains   []string
 		skipReason       string
 		subtestError     string
+		subtestNames     []string
 		requireStack     bool
 	}{
 		{name: "pass", scenario: "pass", exitOK: true, status: processRetryStatusPass},
@@ -1625,6 +1626,7 @@ func TestProcessRetryChildResultStatuses(t *testing.T) {
 		{name: "runtime Goexit", scenario: "goexit", status: processRetryStatusControlledUnexpectedGoexitReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
 		{name: "failed runtime Goexit", scenario: "failed_goexit", status: processRetryStatusControlledUnexpectedGoexitReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
 		{name: "subtest panic", scenario: "subtest_panic", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "subtest panic sentinel", subtestError: "subtest panic sentinel", requireStack: true},
+		{name: "nested subtest panic", scenario: "nested_subtest_panic", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "nested subtest panic sentinel", subtestError: "nested subtest panic sentinel", subtestNames: []string{"TestProcessRetryChildResultFixture/parent", "TestProcessRetryChildResultFixture/parent/child"}, requireStack: true},
 		{name: "subtest runtime Goexit", scenario: "subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", subtestError: "runtime.Goexit", requireStack: true},
 		{name: "parallel subtest runtime Goexit", scenario: "parallel_subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", subtestError: "runtime.Goexit", requireStack: true},
 		{name: "subtest parent FailNow", scenario: "subtest_parent_failnow", status: processRetryStatusFail, failed: true},
@@ -1670,11 +1672,19 @@ func TestProcessRetryChildResultStatuses(t *testing.T) {
 				require.NotEmpty(t, result.ErrorStack)
 			}
 			if tt.subtestError != "" {
-				require.Len(t, result.Subtests, 1)
-				require.Equal(t, "TestProcessRetryChildResultFixture/child", result.Subtests[0].TestName)
-				require.Equal(t, processRetryStatusFail, result.Subtests[0].Status)
-				require.True(t, result.Subtests[0].Panic)
-				require.Contains(t, result.Subtests[0].ErrorMessage, tt.subtestError)
+				wantNames := tt.subtestNames
+				if len(wantNames) == 0 {
+					wantNames = []string{"TestProcessRetryChildResultFixture/child"}
+				}
+				require.Len(t, result.Subtests, len(wantNames))
+				for index, wantName := range wantNames {
+					require.Equal(t, wantName, result.Subtests[index].TestName)
+					require.Equal(t, processRetryStatusFail, result.Subtests[index].Status)
+					if len(wantNames) == 1 || strings.HasSuffix(wantName, "/child") {
+						require.True(t, result.Subtests[index].Panic)
+						require.Contains(t, result.Subtests[index].ErrorMessage, tt.subtestError)
+					}
+				}
 			}
 		})
 	}
@@ -6553,6 +6563,12 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 	case "subtest_panic":
 		t.Run("child", instrumentProcessRetryChildSubtest(func(*testing.T) {
 			panic("subtest panic sentinel")
+		}))
+	case "nested_subtest_panic":
+		t.Run("parent", instrumentProcessRetryChildSubtest(func(t *testing.T) {
+			t.Run("child", instrumentProcessRetryChildSubtest(func(*testing.T) {
+				panic("nested subtest panic sentinel")
+			}))
 		}))
 	case "subtest_goexit":
 		t.Run("child", instrumentProcessRetryChildSubtest(func(*testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1258,6 +1258,8 @@ func TestProcessRetryResultErrorValidation(t *testing.T) {
 	}
 	base := processRetryNotRunResult(cfg, "invalid_child_config")
 	require.NoError(t, validateProcessRetryResult(base, cfg))
+	nativeNotRun := processRetryNotRunResult(cfg, "native_parent_not_run")
+	require.NoError(t, validateProcessRetryResult(nativeNotRun, cfg))
 
 	unknown := base
 	unknown.ResultError = "unknown_reason"
@@ -3999,9 +4001,10 @@ func BenchmarkProcessRetryBoundedOutputSaturated(b *testing.B) {
 	}
 }
 
-func TestProcessRetryLaunchBaselineReusesStaticTemplate(t *testing.T) {
+func TestProcessRetryLaunchBaselineRefreshesMutableStateFromStaticTemplate(t *testing.T) {
 	resetProcessRetryLimiterForTesting(t)
 	var executableCalls, lateArgsCalls, startupArgsCalls, workingDirectoryCalls, environCalls atomic.Int32
+	var workingDirectoryErr atomic.Bool
 	resetProcessRetryRunnerHooksForTesting(t, processRetryRunnerHooks{
 		executable: func() (string, error) {
 			executableCalls.Add(1)
@@ -4013,6 +4016,9 @@ func TestProcessRetryLaunchBaselineReusesStaticTemplate(t *testing.T) {
 		},
 		workingDirectory: func() (string, error) {
 			call := workingDirectoryCalls.Add(1)
+			if workingDirectoryErr.Load() {
+				return "", errors.New("working directory unavailable")
+			}
 			return fmt.Sprintf("/tmp/work-%d", call), nil
 		},
 		environ: func() []string {
@@ -4057,12 +4063,22 @@ func TestProcessRetryLaunchBaselineReusesStaticTemplate(t *testing.T) {
 	require.Equal(t, int32(1), executableCalls.Load())
 	require.Zero(t, lateArgsCalls.Load())
 	require.Equal(t, int32(1), startupArgsCalls.Load())
-	require.Equal(t, int32(1), workingDirectoryCalls.Load())
-	require.Equal(t, int32(1), environCalls.Load())
-	require.Equal(t, "/tmp/startup-work", first.workingDirectory)
-	require.Equal(t, "/tmp/startup-work", second.workingDirectory)
-	require.Equal(t, []string{"STARTUP=1"}, first.environment)
-	require.Equal(t, []string{"STARTUP=1"}, second.environment)
+	require.Equal(t, int32(3), workingDirectoryCalls.Load())
+	require.Equal(t, int32(3), environCalls.Load())
+	require.Equal(t, "/tmp/work-2", first.workingDirectory)
+	require.Equal(t, "/tmp/work-3", second.workingDirectory)
+	require.Equal(t, []string{"ATTEMPT=2"}, first.environment)
+	require.Equal(t, []string{"ATTEMPT=3"}, second.environment)
+	require.Equal(t, template.executable, first.executable)
+	require.Equal(t, template.executable, second.executable)
+	require.Equal(t, template.args, first.args)
+	require.Equal(t, template.args, second.args)
+
+	workingDirectoryErr.Store(true)
+	failed := captureProcessRetryLaunchBaselineFromTemplate(template)
+	require.ErrorContains(t, failed.err, "working directory unavailable")
+	require.Equal(t, int32(4), workingDirectoryCalls.Load())
+	require.Equal(t, int32(3), environCalls.Load())
 }
 
 func TestProcessRetryChildControlConfigUsesBootstrapSnapshot(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1613,17 +1613,20 @@ func TestProcessRetryChildResultStatuses(t *testing.T) {
 		errorNotContains string
 		outputContains   []string
 		skipReason       string
+		subtestError     string
 		requireStack     bool
 	}{
 		{name: "pass", scenario: "pass", exitOK: true, status: processRetryStatusPass},
+		{name: "additional feature metadata", scenario: "additional_feature_metadata", exitOK: true, status: processRetryStatusPass},
 		{name: "fail", scenario: "fail", status: processRetryStatusFail, failed: true, errorType: "Error", errorMessage: "fixture failure", requireStack: true},
 		{name: "instrumented error hook", scenario: "instrument_error_only", status: processRetryStatusFail, failed: true, errorType: "assertion", errorMessage: "instrumented error sentinel", requireStack: true},
 		{name: "skip", scenario: "skip", exitOK: true, status: processRetryStatusSkip, skipped: true, skipReason: "fixture skip"},
 		{name: "panic", scenario: "panic", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "body panic sentinel", requireStack: true},
 		{name: "runtime Goexit", scenario: "goexit", status: processRetryStatusControlledUnexpectedGoexitReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
 		{name: "failed runtime Goexit", scenario: "failed_goexit", status: processRetryStatusControlledUnexpectedGoexitReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
-		{name: "subtest runtime Goexit", scenario: "subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
-		{name: "parallel subtest runtime Goexit", scenario: "parallel_subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", requireStack: true},
+		{name: "subtest panic", scenario: "subtest_panic", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "subtest panic sentinel", subtestError: "subtest panic sentinel", requireStack: true},
+		{name: "subtest runtime Goexit", scenario: "subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", subtestError: "runtime.Goexit", requireStack: true},
+		{name: "parallel subtest runtime Goexit", scenario: "parallel_subtest_goexit", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "runtime.Goexit", subtestError: "runtime.Goexit", requireStack: true},
 		{name: "subtest parent FailNow", scenario: "subtest_parent_failnow", status: processRetryStatusFail, failed: true},
 		{name: "cleanup panic", scenario: "cleanup_panic", status: processRetryStatusControlledPanicReady, failed: true, panicked: true, errorType: "panic", errorContains: "cleanup panic sentinel", requireStack: true},
 		{name: "cleanup skip", scenario: "cleanup_skip", exitOK: true, status: processRetryStatusSkip, skipped: true},
@@ -1665,6 +1668,13 @@ func TestProcessRetryChildResultStatuses(t *testing.T) {
 			}
 			if tt.requireStack {
 				require.NotEmpty(t, result.ErrorStack)
+			}
+			if tt.subtestError != "" {
+				require.Len(t, result.Subtests, 1)
+				require.Equal(t, "TestProcessRetryChildResultFixture/child", result.Subtests[0].TestName)
+				require.Equal(t, processRetryStatusFail, result.Subtests[0].Status)
+				require.True(t, result.Subtests[0].Panic)
+				require.Contains(t, result.Subtests[0].ErrorMessage, tt.subtestError)
 			}
 		})
 	}
@@ -1712,6 +1722,50 @@ func TestProcessRetryChildPublicHelpersPreserveNativeState(t *testing.T) {
 	}
 }
 
+func TestProcessRetryChildCapturesInstrumentedSubtestResults(t *testing.T) {
+	result, exitCode, output := runProcessRetryChildResultFixture(t, "subtest_results")
+	require.NotEqual(t, 0, exitCode, output)
+	require.Equal(t, processRetryStatusFail, result.Status)
+	require.Len(t, result.Subtests, 2)
+	require.Equal(t, "TestProcessRetryChildResultFixture/pass", result.Subtests[0].TestName)
+	require.Equal(t, processRetryStatusPass, result.Subtests[0].Status)
+	require.Equal(t, "TestProcessRetryChildResultFixture/fail", result.Subtests[1].TestName)
+	require.Equal(t, processRetryStatusFail, result.Subtests[1].Status)
+	require.True(t, result.Subtests[1].Failed)
+}
+
+func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	identity := newTestIdentity("module", "suite", "TestParent")
+	parentMeta := &testExecutionMetadata{identity: identity}
+	finishProcessRetrySubtestEvents(&commonInfo{
+		moduleName: identity.ModuleName,
+		suiteName:  identity.SuiteName,
+		testName:   identity.FullName,
+		identity:   identity,
+	}, parentMeta, processRetryAttemptResult{Result: processRetryResult{Subtests: []processRetrySubtestResult{{
+		TestName:       "TestParent/child",
+		Status:         processRetryStatusFail,
+		StartUnixNano:  10,
+		FinishUnixNano: 20,
+		DurationNanos:  10,
+		Failed:         true,
+		Panic:          true,
+		ErrorType:      "panic",
+		ErrorMessage:   "subtest panic sentinel",
+		ErrorStack:     "subtest stack sentinel",
+	}}}})
+
+	require.Len(t, recorder.tests, 1)
+	require.Equal(t, "TestParent/child", recorder.tests[0].name)
+	require.Equal(t, processRetryStatusFail, recorder.tests[0].status)
+	require.Equal(t, 1, recorder.tests[0].closeCount)
+	require.Equal(t, "panic", recorder.tests[0].errorType)
+	require.Equal(t, "subtest panic sentinel", recorder.tests[0].errorMessage)
+	require.Equal(t, "subtest stack sentinel", recorder.tests[0].errorStack)
+}
+
 func TestProcessRetryChildCleanupRunsExactlyOnce(t *testing.T) {
 	counterPath := filepath.Join(t.TempDir(), "cleanup-count")
 	result, exitCode, output := runProcessRetryChildResultFixtureWithEnv(t, "cleanup_once", []string{
@@ -1756,6 +1810,16 @@ func TestProcessRetryStructuredMetadataIsTruncated(t *testing.T) {
 			require.NotContains(t, got, tailSentinel)
 		})
 	}
+}
+
+func TestProcessRetryOutputTailKeepsEncodedSuffixWithinLimit(t *testing.T) {
+	const tailSentinel = "per-test-output-tail-sentinel"
+	output, truncated := truncateProcessRetryOutputTail([]byte(strings.Repeat("\x00\n", processRetryResultOutputMaxBytes) + tailSentinel))
+
+	require.True(t, truncated)
+	require.True(t, processRetryJSONStringFits(output, processRetryResultOutputMaxBytes))
+	require.True(t, utf8.ValidString(output))
+	require.Contains(t, output, tailSentinel)
 }
 
 func TestProcessRetryStructuredMetadataFitsEncodedResultLimit(t *testing.T) {
@@ -2219,6 +2283,46 @@ func TestReadProcessRetryResult(t *testing.T) {
 		_, _, err := readProcessRetryResult(cfg.ResultPath, cfg)
 		require.ErrorIs(t, err, errProcessRetryResultInvalid)
 	})
+}
+
+func TestProcessRetrySubtestResultValidation(t *testing.T) {
+	expected := processRetryChildConfig{TestName: "TestSelected", Attempt: 1, RetryReason: constants.AutoTestRetriesRetryReason}
+	validSubtest := processRetrySubtestResult{
+		TestName:       "TestSelected/child",
+		Status:         processRetryStatusPass,
+		StartUnixNano:  10,
+		FinishUnixNano: 20,
+		DurationNanos:  10,
+	}
+	valid := processRetryResult{
+		Version:        1,
+		TestName:       expected.TestName,
+		Attempt:        expected.Attempt,
+		RetryReason:    expected.RetryReason,
+		Status:         processRetryStatusPass,
+		StartUnixNano:  1,
+		FinishUnixNano: 2,
+		DurationNanos:  1,
+		Subtests:       []processRetrySubtestResult{validSubtest},
+	}
+	require.NoError(t, validateProcessRetryResult(valid, expected))
+
+	tests := []struct {
+		name     string
+		subtests []processRetrySubtestResult
+	}{
+		{name: "outside selected test", subtests: []processRetrySubtestResult{{TestName: "TestOther/child", Status: processRetryStatusPass, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+		{name: "duplicate", subtests: []processRetrySubtestResult{validSubtest, validSubtest}},
+		{name: "invalid status mirrors", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, Failed: true, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+		{name: "oversized metadata", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorMessage: strings.Repeat("x", processRetryErrorMessageMaxBytes+1), StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := valid
+			result.Subtests = test.subtests
+			require.ErrorIs(t, validateProcessRetryResult(result, expected), errProcessRetryResultInvalid)
+		})
+	}
 }
 
 func TestProcessRetryValidateResultRejectsEncodedMetadataOverLimit(t *testing.T) {
@@ -6411,6 +6515,10 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 	}
 	switch scenario {
 	case "pass":
+	case "additional_feature_metadata":
+		execMeta := getTestMetadata(t)
+		require.NotNil(t, execMeta)
+		require.True(t, execMeta.hasAdditionalFeatureWrapper)
 	case "fail":
 		(*T)(t).Error("fixture failure")
 	case "instrument_error_only":
@@ -6442,6 +6550,10 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 	case "failed_goexit":
 		t.Fail()
 		runtime.Goexit()
+	case "subtest_panic":
+		t.Run("child", instrumentProcessRetryChildSubtest(func(*testing.T) {
+			panic("subtest panic sentinel")
+		}))
 	case "subtest_goexit":
 		t.Run("child", instrumentProcessRetryChildSubtest(func(*testing.T) {
 			runtime.Goexit()
@@ -6479,6 +6591,11 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 		t.Run("child", func(t *testing.T) {
 			t.Parallel()
 			t.Error("parallel child failure")
+		})
+	case "subtest_results":
+		GetTest(t).Run("pass", func(*testing.T) {})
+		GetTest(t).Run("fail", func(t *testing.T) {
+			GetTest(t).Error("subtest failure")
 		})
 	case "parallel_top_level_subtest_fail":
 		t.Parallel()

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1745,35 +1745,53 @@ func TestProcessRetryChildCapturesInstrumentedSubtestResults(t *testing.T) {
 }
 
 func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
-	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
-	defer restoreSession()
-	identity := newTestIdentity("module", "suite", "TestParent")
-	parentMeta := &testExecutionMetadata{identity: identity}
-	finishProcessRetrySubtestEvents(&commonInfo{
-		moduleName: identity.ModuleName,
-		suiteName:  identity.SuiteName,
-		testName:   identity.FullName,
-		identity:   identity,
-	}, parentMeta, processRetryAttemptResult{Result: processRetryResult{Subtests: []processRetrySubtestResult{{
-		TestName:       "TestParent/child",
-		Status:         processRetryStatusFail,
-		StartUnixNano:  10,
-		FinishUnixNano: 20,
-		DurationNanos:  10,
-		Failed:         true,
-		Panic:          true,
-		ErrorType:      "panic",
-		ErrorMessage:   "subtest panic sentinel",
-		ErrorStack:     "subtest stack sentinel",
-	}}}})
+	for _, tt := range []struct {
+		name             string
+		isRetry          bool
+		allRetriesFailed bool
+		expectTag        bool
+	}{
+		{name: "initial attempt"},
+		{name: "all retries failed", isRetry: true, allRetriesFailed: true, expectTag: true},
+		{name: "a retry passed", isRetry: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+			defer restoreSession()
+			identity := newTestIdentity("module", "suite", "TestParent")
+			parentMeta := &testExecutionMetadata{
+				identity:         identity,
+				isARetry:         tt.isRetry,
+				allRetriesFailed: tt.allRetriesFailed,
+			}
+			finishProcessRetrySubtestEvents(&commonInfo{
+				moduleName: identity.ModuleName,
+				suiteName:  identity.SuiteName,
+				testName:   identity.FullName,
+				identity:   identity,
+			}, parentMeta, processRetryAttemptResult{Result: processRetryResult{Subtests: []processRetrySubtestResult{{
+				TestName:       "TestParent/child",
+				Status:         processRetryStatusFail,
+				StartUnixNano:  10,
+				FinishUnixNano: 20,
+				DurationNanos:  10,
+				Failed:         true,
+				Panic:          true,
+				ErrorType:      "panic",
+				ErrorMessage:   "subtest panic sentinel",
+				ErrorStack:     "subtest stack sentinel",
+			}}}})
 
-	require.Len(t, recorder.tests, 1)
-	require.Equal(t, "TestParent/child", recorder.tests[0].name)
-	require.Equal(t, processRetryStatusFail, recorder.tests[0].status)
-	require.Equal(t, 1, recorder.tests[0].closeCount)
-	require.Equal(t, "panic", recorder.tests[0].errorType)
-	require.Equal(t, "subtest panic sentinel", recorder.tests[0].errorMessage)
-	require.Equal(t, "subtest stack sentinel", recorder.tests[0].errorStack)
+			require.Len(t, recorder.tests, 1)
+			require.Equal(t, "TestParent/child", recorder.tests[0].name)
+			require.Equal(t, processRetryStatusFail, recorder.tests[0].status)
+			require.Equal(t, 1, recorder.tests[0].closeCount)
+			require.Equal(t, "panic", recorder.tests[0].errorType)
+			require.Equal(t, "subtest panic sentinel", recorder.tests[0].errorMessage)
+			require.Equal(t, "subtest stack sentinel", recorder.tests[0].errorStack)
+			require.Equal(t, tt.expectTag, recorder.tests[0].tags[constants.TestHasFailedAllRetries] == "true")
+		})
+	}
 }
 
 func TestProcessRetryChildCleanupRunsExactlyOnce(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1123,6 +1123,36 @@ func TestProcessRetryChildSkipsDisabledSubtestBeforeBody(t *testing.T) {
 	require.Equal(t, constants.TestDisabledSkipReason, result.SkipReason)
 }
 
+func TestProcessRetryChildOrchestratesExactAttemptToFixSubtest(t *testing.T) {
+	owner := createTestMetadata(t, nil)
+	name := t.Name() + "/attempt-to-fix"
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{
+		TestName:            t.Name(),
+		attemptToFixRetries: 3,
+		batchTest: &processRetryBatchTestConfig{
+			AttemptToFixSubtests: []string{name},
+		},
+	}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	runs := 0
+	require.True(t, t.Run("attempt-to-fix", instrumentProcessRetryChildSubtest(func(*testing.T) {
+		runs++
+	})))
+
+	require.Equal(t, 3, runs)
+	results := root.snapshotSubtests()
+	require.Len(t, results, 3)
+	for index, result := range results {
+		require.Equal(t, name, result.TestName)
+		require.True(t, result.AttemptToFix)
+		require.Equal(t, index, result.Attempt)
+		require.Equal(t, index == len(results)-1, result.AttemptToFixLast)
+		require.Equal(t, processRetryStatusPass, result.Status)
+	}
+}
+
 func TestProcessRetryChildSkipsITRSubtestBeforeBody(t *testing.T) {
 	owner := createTestMetadata(t, nil)
 	name := t.Name() + "/skipped"
@@ -1903,6 +1933,47 @@ func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
 	}
 }
 
+func TestFinishProcessRetrySubtestEventsPublishesAttemptToFixExecutions(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	identity := newTestIdentity("module", "suite", "TestParent")
+	results := make([]processRetrySubtestResult, 3)
+	for index := range results {
+		results[index] = processRetrySubtestResult{
+			TestName:         "TestParent/attempt-to-fix",
+			AttemptToFix:     true,
+			Attempt:          index,
+			AttemptToFixLast: index == len(results)-1,
+			Status:           processRetryStatusPass,
+			StartUnixNano:    int64(index*10 + 1),
+			FinishUnixNano:   int64(index*10 + 2),
+			DurationNanos:    1,
+		}
+	}
+	results[1].Status = processRetryStatusFail
+	results[1].Failed = true
+
+	finishProcessRetrySubtestEvents(&commonInfo{
+		moduleName: identity.ModuleName,
+		suiteName:  identity.SuiteName,
+		testName:   identity.FullName,
+		identity:   identity,
+	}, &testExecutionMetadata{identity: identity}, processRetryAttemptResult{Result: processRetryResult{Subtests: results}})
+
+	require.Len(t, recorder.tests, 3)
+	for index, event := range recorder.tests {
+		require.Equal(t, "true", event.tags[constants.TestIsAttempToFix])
+		require.Equal(t, index > 0, event.tags[constants.TestIsRetry] == "true")
+		require.Equal(t, index > 0, event.tags[constants.TestRetryReason] == constants.AttemptToFixRetryReason)
+		if index < len(recorder.tests)-1 {
+			require.Empty(t, event.tags[constants.TestFinalStatus])
+		} else {
+			require.Equal(t, constants.TestStatusFail, event.tags[constants.TestFinalStatus])
+			require.Equal(t, "false", event.tags[constants.TestAttemptToFixPassed])
+		}
+	}
+}
+
 func TestFinishProcessRetryDisabledResultRequiresChildSkip(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
@@ -2500,6 +2571,13 @@ func TestProcessRetrySubtestResultValidation(t *testing.T) {
 		Subtests:       []processRetrySubtestResult{validSubtest},
 	}
 	require.NoError(t, validateProcessRetryResult(valid, expected))
+	validAttemptToFix := validSubtest
+	validAttemptToFix.AttemptToFix = true
+	validAttemptToFixLast := validAttemptToFix
+	validAttemptToFixLast.Attempt = 1
+	validAttemptToFixLast.AttemptToFixLast = true
+	valid.Subtests = []processRetrySubtestResult{validAttemptToFix, validAttemptToFixLast}
+	require.NoError(t, validateProcessRetryResult(valid, expected))
 
 	tests := []struct {
 		name     string
@@ -2507,6 +2585,10 @@ func TestProcessRetrySubtestResultValidation(t *testing.T) {
 	}{
 		{name: "outside selected test", subtests: []processRetrySubtestResult{{TestName: "TestOther/child", Status: processRetryStatusPass, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 		{name: "duplicate", subtests: []processRetrySubtestResult{validSubtest, validSubtest}},
+		{name: "attempt-to-fix starts after zero", subtests: []processRetrySubtestResult{validAttemptToFixLast}},
+		{name: "attempt-to-fix incomplete", subtests: []processRetrySubtestResult{validAttemptToFix}},
+		{name: "attempt-to-fix continues after last", subtests: []processRetrySubtestResult{validAttemptToFix, validAttemptToFixLast, {TestName: validSubtest.TestName, AttemptToFix: true, Attempt: 2, AttemptToFixLast: true, Status: processRetryStatusPass, StartUnixNano: 30, FinishUnixNano: 40, DurationNanos: 10}}},
+		{name: "attempt metadata without directive", subtests: []processRetrySubtestResult{{TestName: validSubtest.TestName, Attempt: 1, Status: processRetryStatusPass, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 		{name: "invalid status mirrors", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, Failed: true, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 		{name: "oversized metadata", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorMessage: strings.Repeat("x", processRetryErrorMessageMaxBytes+1), StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 		{name: "oversized output", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, OutputTail: strings.Repeat("x", processRetryResultOutputMaxBytes+1), StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
@@ -2577,6 +2659,30 @@ func TestProcessRetryValidateResultRejectsEncodedMetadataOverLimit(t *testing.T)
 			require.ErrorIs(t, validateProcessRetryResult(tt.result, cfg), errProcessRetryResultInvalid)
 		})
 	}
+}
+
+func TestProcessRetryFirstAttemptIsolationRejectsProfilingFlags(t *testing.T) {
+	for _, flagName := range []string{
+		"-test.cpuprofile",
+		"-test.memprofile",
+		"-test.blockprofile",
+		"-test.mutexprofile",
+		"-test.trace",
+	} {
+		t.Run(flagName, func(t *testing.T) {
+			baseline := &processRetryLaunchBaseline{argsSnapshot: captureProcessRetryArgsSnapshot([]string{flagName, "profile.out"})}
+
+			ok, reason := processRetryFirstAttemptIsolationReady(baseline)
+
+			require.False(t, ok)
+			require.Equal(t, "test_profiling_enabled", reason)
+		})
+	}
+
+	baseline := &processRetryLaunchBaseline{argsSnapshot: captureProcessRetryArgsSnapshot([]string{"--", "-test.cpuprofile=profile.out"})}
+	ok, reason := processRetryFirstAttemptIsolationReady(baseline)
+	require.True(t, ok)
+	require.Empty(t, reason)
 }
 
 func TestBuildProcessRetryArgs(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1123,6 +1123,60 @@ func TestProcessRetryChildSkipsDisabledSubtestBeforeBody(t *testing.T) {
 	require.Equal(t, constants.TestDisabledSkipReason, result.SkipReason)
 }
 
+func TestProcessRetryChildSkipsITRSubtestBeforeBody(t *testing.T) {
+	owner := createTestMetadata(t, nil)
+	name := t.Name() + "/skipped"
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{
+		TestName: t.Name(),
+		batchTest: &processRetryBatchTestConfig{ITRSubtests: []processRetrySubtestITRConfig{{
+			TestName: name,
+		}}},
+	}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	bodyRan := false
+	require.True(t, t.Run("skipped", instrumentProcessRetryChildSubtest(func(*testing.T) {
+		bodyRan = true
+	})))
+
+	require.False(t, bodyRan)
+	require.Len(t, root.snapshotSubtests(), 1)
+	result := root.snapshotSubtests()[0]
+	require.Equal(t, processRetryStatusSkip, result.Status)
+	require.True(t, result.SkippedByITR)
+	require.Equal(t, constants.SkippedByITRReason, result.SkipReason)
+}
+
+var processRetryUnskippableSubtestRuns atomic.Int32
+
+//dd:test.unskippable
+func processRetryUnskippableSubtestFixture(*testing.T) {
+	processRetryUnskippableSubtestRuns.Add(1)
+}
+
+func TestProcessRetryChildForcesUnskippableITRSubtestToRun(t *testing.T) {
+	processRetryUnskippableSubtestRuns.Store(0)
+	owner := createTestMetadata(t, nil)
+	name := t.Name() + "/forced"
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{
+		TestName: t.Name(),
+		batchTest: &processRetryBatchTestConfig{ITRSubtests: []processRetrySubtestITRConfig{{
+			TestName: name,
+		}}},
+	}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	require.True(t, t.Run("forced", instrumentProcessRetryChildSubtest(processRetryUnskippableSubtestFixture)))
+	require.Equal(t, int32(1), processRetryUnskippableSubtestRuns.Load())
+	require.Len(t, root.snapshotSubtests(), 1)
+	result := root.snapshotSubtests()[0]
+	require.Equal(t, processRetryStatusPass, result.Status)
+	require.True(t, result.ITRForcedRun)
+	require.False(t, result.SkippedByITR)
+}
+
 func TestProcessRetryChildBoundsSubtestOutput(t *testing.T) {
 	owner := createTestMetadata(t, nil)
 	root := newProcessRetryNoopTest(t, processRetryChildConfig{TestName: t.Name()}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
@@ -5585,6 +5639,51 @@ func TestFinishProcessRetryTestEventPropagatesITRForcedRun(t *testing.T) {
 	metric := telemetrytest.MetricKey{
 		Namespace: coretelemetry.NamespaceCIVisibility,
 		Name:      "itr_forced_run",
+		Tags:      "event_type:test",
+		Kind:      "count",
+	}
+	require.Contains(t, telemetryRecorder.Metrics, metric)
+	require.Equal(t, 1.0, telemetryRecorder.Metrics[metric].Get())
+}
+
+func TestFinishProcessRetryTestEventPropagatesITRSkip(t *testing.T) {
+	recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+	defer restoreSession()
+	telemetryRecorder := new(telemetrytest.RecordClient)
+	defer coretelemetry.MockClient(telemetryRecorder)()
+	previousState := activeITRState.Load()
+	activeITRState.Store(&itrState{})
+	t.Cleanup(func() { activeITRState.Store(previousState) })
+	previousSkipped := numOfTestsSkipped.Load()
+	t.Cleanup(func() { numOfTestsSkipped.Store(previousSkipped) })
+
+	identity := newTestIdentity("module", "suite", "TestProcessRetryITRSkip")
+	now := time.Now()
+	effective := finishProcessRetryTestEventForTesting(&commonInfo{
+		moduleName: identity.ModuleName,
+		suiteName:  identity.SuiteName,
+		testName:   identity.FullName,
+		identity:   identity,
+	}, &testExecutionMetadata{identity: identity, isItrSkipped: true}, processRetryAttemptResult{
+		Result: processRetryResult{
+			Status:     processRetryStatusSkip,
+			Skipped:    true,
+			SkipReason: constants.SkippedByITRReason,
+		},
+		ExitCode:   0,
+		StartTime:  now,
+		FinishTime: now.Add(time.Millisecond),
+	})
+
+	require.Equal(t, processRetryStatusSkip, effective.Status)
+	require.Len(t, recorder.tests, 1)
+	require.Equal(t, "true", recorder.tests[0].tags[constants.TestSkippedByITR])
+	require.Equal(t, constants.TestStatusSkip, recorder.tests[0].tags[constants.TestFinalStatus])
+	require.Equal(t, "true", recorder.tags[constants.ITRTestsSkipped])
+	require.Equal(t, previousSkipped+1, numOfTestsSkipped.Load())
+	metric := telemetrytest.MetricKey{
+		Namespace: coretelemetry.NamespaceCIVisibility,
+		Name:      "itr_skipped",
 		Tags:      "event_type:test",
 		Kind:      "count",
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1156,6 +1156,30 @@ func TestProcessRetryChildOrchestratesExactAttemptToFixSubtest(t *testing.T) {
 	}
 }
 
+func TestProcessRetryChildMasksExactQuarantinedSubtest(t *testing.T) {
+	owner := createTestMetadata(t, nil)
+	name := t.Name() + "/quarantined"
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{
+		TestName: t.Name(),
+		batchTest: &processRetryBatchTestConfig{
+			QuarantinedSubtests: []string{name},
+		},
+	}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	require.True(t, t.Run("quarantined", instrumentProcessRetryChildSubtest(func(t *testing.T) {
+		t.Error("quarantined failure")
+	})))
+
+	require.Len(t, root.snapshotSubtests(), 1)
+	result := root.snapshotSubtests()[0]
+	require.Equal(t, name, result.TestName)
+	require.Equal(t, processRetryStatusFail, result.Status)
+	require.True(t, result.Failed)
+	require.False(t, result.Skipped)
+}
+
 func TestProcessRetryChildSkipsITRSubtestBeforeBody(t *testing.T) {
 	owner := createTestMetadata(t, nil)
 	name := t.Name() + "/skipped"
@@ -4287,6 +4311,33 @@ func TestCombineProcessRetryOutputTailsMarksPerStreamTruncation(t *testing.T) {
 	require.Equal(t, processRetryOutputTruncationMarker+"tail", combined)
 }
 
+func TestProcessRetryOutputCaptureStreamsCompleteOutput(t *testing.T) {
+	capture, err := newProcessRetryOutputCapture(4)
+	require.NoError(t, err)
+	var stream strings.Builder
+	capture.StartCopy(&stream)
+
+	_, err = io.WriteString(capture.ChildWriter(), "prefix-tail")
+	require.NoError(t, err)
+	require.NoError(t, capture.CloseParentWriter())
+	require.NoError(t, capture.FinishAfterWait(time.Second))
+	tail, truncated, err := capture.Tail()
+	require.NoError(t, err)
+	require.True(t, truncated)
+	require.Equal(t, "tail", tail)
+	require.Equal(t, "prefix-tail", stream.String())
+}
+
+func TestProcessRetryBatchOutputWriterFiltersSplitProtocolLines(t *testing.T) {
+	var output strings.Builder
+	writer := newProcessRetryBatchOutputWriter(&output)
+	for _, chunk := range []string{"stdout\n\x16PA", "SS\nnext", " line\n\x16partial"} {
+		_, err := io.WriteString(writer, chunk)
+		require.NoError(t, err)
+	}
+	require.Equal(t, "stdout\nnext line\n", output.String())
+}
+
 func TestCombineProcessRetryOutputTailsKeepsBoundedCombinedSuffix(t *testing.T) {
 	capture := func(t *testing.T, value string) *processRetryOutputCapture {
 		t.Helper()
@@ -4342,7 +4393,7 @@ func BenchmarkCombineProcessRetryOutputTailsSaturated(b *testing.B) {
 func TestProcessRetryOutputCaptureAbortIsIdempotent(t *testing.T) {
 	capture, err := newProcessRetryOutputCapture(processRetryStreamMaxBytes)
 	require.NoError(t, err)
-	capture.StartCopy()
+	capture.StartCopy(nil)
 
 	firstErr := capture.AbortAfterReapedChild(time.Second)
 	secondErr := capture.AbortAfterReapedChild(time.Nanosecond)
@@ -4400,8 +4451,8 @@ func TestFinalizeProcessRetryOutputCapturesMarksContainmentLossOnDrainTimeout(t 
 	require.NoError(t, err)
 	stderrCapture, err := newProcessRetryOutputCapture(processRetryStreamMaxBytes)
 	require.NoError(t, err)
-	stdoutCapture.StartCopy()
-	stderrCapture.StartCopy()
+	stdoutCapture.StartCopy(nil)
+	stderrCapture.StartCopy(nil)
 
 	killCalls := atomic.Int32{}
 	hooks := processRetryRunnerHooks{

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1101,6 +1101,28 @@ func TestProcessRetryChildSubtestErrorForwardsWithoutOverwritingTopLevelSkip(t *
 	require.Zero(t, spy.closeCalls.Load())
 }
 
+func TestProcessRetryChildSkipsDisabledSubtestBeforeBody(t *testing.T) {
+	owner := createTestMetadata(t, nil)
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{
+		TestName:  t.Name(),
+		batchTest: &processRetryBatchTestConfig{DisabledSubtests: []string{t.Name() + "/disabled"}},
+	}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	bodyRan := false
+	require.True(t, t.Run("disabled", instrumentProcessRetryChildSubtest(func(*testing.T) {
+		bodyRan = true
+	})))
+
+	require.False(t, bodyRan)
+	require.Len(t, root.snapshotSubtests(), 1)
+	result := root.snapshotSubtests()[0]
+	require.Equal(t, processRetryStatusSkip, result.Status)
+	require.True(t, result.Skipped)
+	require.Equal(t, constants.TestDisabledSkipReason, result.SkipReason)
+}
+
 func TestProcessRetryChildCapturesMetadataWithoutSpanOwnership(t *testing.T) {
 	enableProcessRetryChildForTesting(t)
 

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -4074,6 +4074,15 @@ func TestProcessRetryLaunchBaselineRefreshesMutableStateFromStaticTemplate(t *te
 	require.Equal(t, template.args, first.args)
 	require.Equal(t, template.args, second.args)
 
+	template.preserveStartup = true
+	preserved := captureProcessRetryLaunchBaselineFromTemplate(template)
+	require.NoError(t, preserved.err)
+	require.Equal(t, "/tmp/startup-work", preserved.workingDirectory)
+	require.Equal(t, []string{"STARTUP=1"}, preserved.environment)
+	require.Equal(t, int32(3), workingDirectoryCalls.Load())
+	require.Equal(t, int32(3), environCalls.Load())
+	template.preserveStartup = false
+
 	workingDirectoryErr.Store(true)
 	failed := captureProcessRetryLaunchBaselineFromTemplate(template)
 	require.ErrorContains(t, failed.err, "working directory unavailable")

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1123,6 +1123,23 @@ func TestProcessRetryChildSkipsDisabledSubtestBeforeBody(t *testing.T) {
 	require.Equal(t, constants.TestDisabledSkipReason, result.SkipReason)
 }
 
+func TestProcessRetryChildBoundsSubtestOutput(t *testing.T) {
+	owner := createTestMetadata(t, nil)
+	root := newProcessRetryNoopTest(t, processRetryChildConfig{TestName: t.Name()}, time.Now(), nil, nil, retryAttemptRaceErrors()).(*processRetryNoopTest)
+	owner.test = root
+	defer deleteTestMetadata(t)
+
+	require.True(t, t.Run("output", instrumentProcessRetryChildSubtest(func(t *testing.T) {
+		t.Log(strings.Repeat("x", processRetryResultOutputMaxBytes) + "output tail sentinel")
+	})))
+
+	require.Len(t, root.snapshotSubtests(), 1)
+	result := root.snapshotSubtests()[0]
+	require.True(t, result.OutputTruncated)
+	require.Contains(t, result.OutputTail, "output tail sentinel")
+	require.LessOrEqual(t, len(result.OutputTail), processRetryResultOutputMaxBytes)
+}
+
 func TestProcessRetryChildCapturesMetadataWithoutSpanOwnership(t *testing.T) {
 	enableProcessRetryChildForTesting(t)
 
@@ -1761,9 +1778,21 @@ func TestProcessRetryChildCapturesInstrumentedSubtestResults(t *testing.T) {
 	require.Len(t, result.Subtests, 2)
 	require.Equal(t, "TestProcessRetryChildResultFixture/pass", result.Subtests[0].TestName)
 	require.Equal(t, processRetryStatusPass, result.Subtests[0].Status)
+	require.Contains(t, result.Subtests[0].OutputTail, "passing subtest output sentinel")
+	require.NotContains(t, result.Subtests[0].OutputTail, "failing subtest output sentinel")
+	require.NotNil(t, result.Subtests[0].Source)
+	require.NotEmpty(t, result.Subtests[0].Source.RuntimePath)
+	require.Positive(t, result.Subtests[0].Source.RuntimeStartLine)
+	require.NotEmpty(t, result.Subtests[0].Source.FunctionName)
 	require.Equal(t, "TestProcessRetryChildResultFixture/fail", result.Subtests[1].TestName)
 	require.Equal(t, processRetryStatusFail, result.Subtests[1].Status)
 	require.True(t, result.Subtests[1].Failed)
+	require.Contains(t, result.Subtests[1].OutputTail, "failing subtest output sentinel")
+	require.NotContains(t, result.Subtests[1].OutputTail, "passing subtest output sentinel")
+	require.NotNil(t, result.Subtests[1].Source)
+	require.NotEmpty(t, result.Subtests[1].Source.RuntimePath)
+	require.Positive(t, result.Subtests[1].Source.RuntimeStartLine)
+	require.NotEmpty(t, result.Subtests[1].Source.FunctionName)
 }
 
 func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
@@ -1802,6 +1831,7 @@ func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
 				ErrorType:      "panic",
 				ErrorMessage:   "subtest panic sentinel",
 				ErrorStack:     "subtest stack sentinel",
+				OutputTail:     "subtest output sentinel",
 			}}}})
 
 			require.Len(t, recorder.tests, 1)
@@ -1811,7 +1841,65 @@ func TestFinishProcessRetrySubtestEventsPublishesTerminalSubtest(t *testing.T) {
 			require.Equal(t, "panic", recorder.tests[0].errorType)
 			require.Equal(t, "subtest panic sentinel", recorder.tests[0].errorMessage)
 			require.Equal(t, "subtest stack sentinel", recorder.tests[0].errorStack)
+			require.Contains(t, recorder.tests[0].logs, "subtest output sentinel")
 			require.Equal(t, tt.expectTag, recorder.tests[0].tags[constants.TestHasFailedAllRetries] == "true")
+		})
+	}
+}
+
+func TestFinishProcessRetryDisabledResultRequiresChildSkip(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		result     processRetryResult
+		wantStatus processRetryStatus
+		wantError  bool
+	}{
+		{
+			name: "enforced disabled skip",
+			result: processRetryResult{
+				Status:     processRetryStatusSkip,
+				Skipped:    true,
+				SkipReason: constants.TestDisabledSkipReason,
+			},
+			wantStatus: processRetryStatusSkip,
+		},
+		{
+			name:       "unenforced disabled pass",
+			result:     processRetryResult{Status: processRetryStatusPass},
+			wantStatus: processRetryStatusFail,
+			wantError:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+			defer restoreSession()
+			identity := newTestIdentity("module", "suite", "TestParent/disabled")
+			result := tt.result
+			result.Version = 1
+			result.TestName = identity.FullName
+			result.StartUnixNano = 10
+			result.FinishUnixNano = 20
+			result.DurationNanos = 10
+
+			finishProcessRetryTestEvent(&commonInfo{
+				moduleName: identity.ModuleName,
+				suiteName:  identity.SuiteName,
+				testName:   identity.FullName,
+				identity:   identity,
+			}, &testExecutionMetadata{
+				identity:   identity,
+				isDisabled: true,
+			}, completedProcessRetryAttempt(result), nil, nil)
+
+			require.Len(t, recorder.tests, 1)
+			require.Equal(t, tt.wantStatus, recorder.tests[0].status)
+			require.Equal(t, "true", recorder.tests[0].tags[constants.TestIsDisabled])
+			_, testErrored := recorder.tests[0].tags["error"]
+			require.Equal(t, tt.wantError, testErrored)
+			_, suiteErrored := recorder.modules[identity.ModuleName].suites[identity.SuiteName].tags["error"]
+			_, moduleErrored := recorder.modules[identity.ModuleName].tags["error"]
+			require.Equal(t, tt.wantError, suiteErrored)
+			require.Equal(t, tt.wantError, moduleErrored)
 		})
 	}
 }
@@ -2365,6 +2453,9 @@ func TestProcessRetrySubtestResultValidation(t *testing.T) {
 		{name: "duplicate", subtests: []processRetrySubtestResult{validSubtest, validSubtest}},
 		{name: "invalid status mirrors", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, Failed: true, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 		{name: "oversized metadata", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorMessage: strings.Repeat("x", processRetryErrorMessageMaxBytes+1), StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+		{name: "oversized output", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, OutputTail: strings.Repeat("x", processRetryResultOutputMaxBytes+1), StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+		{name: "truncated empty output", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, OutputTruncated: true, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
+		{name: "partial source", subtests: []processRetrySubtestResult{{TestName: "TestSelected/child", Status: processRetryStatusPass, Source: &processRetryTestSource{RuntimePath: "fixture_test.go"}, StartUnixNano: 10, FinishUnixNano: 20, DurationNanos: 10}}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -6649,8 +6740,11 @@ func TestProcessRetryChildResultFixture(t *testing.T) {
 			t.Error("parallel child failure")
 		})
 	case "subtest_results":
-		GetTest(t).Run("pass", func(*testing.T) {})
+		GetTest(t).Run("pass", func(t *testing.T) {
+			t.Log("passing subtest output sentinel")
+		})
 		GetTest(t).Run("fail", func(t *testing.T) {
+			t.Log("failing subtest output sentinel")
 			GetTest(t).Error("subtest failure")
 		})
 	case "parallel_top_level_subtest_fail":

--- a/internal/civisibility/integrations/gotesting/retryprocess/fixtures_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/fixtures_test.go
@@ -84,6 +84,8 @@ const (
 	processRetryParallelEFDEnv                = "PROCESS_RETRY_PARALLEL_EFD_FIXTURE"
 	processRetryParallelEFDCoordinationDirEnv = "PROCESS_RETRY_PARALLEL_EFD_COORDINATION_DIR"
 	processRetryAttemptToFixEnv               = "PROCESS_RETRY_ATTEMPT_TO_FIX_FIXTURE"
+	processRetryQuarantinedCoverageEnv        = "PROCESS_RETRY_QUARANTINED_COVERAGE_FIXTURE"
+	processRetryQuarantinedCoverageResultEnv  = "PROCESS_RETRY_QUARANTINED_COVERAGE_RESULT"
 	processRetryScenarioEnv                   = "PROCESS_RETRY_FIXTURE_SCENARIO"
 	processRetryControllerProbeEnv            = "PROCESS_RETRY_CONTROLLER_PROBE"
 	processRetryControllerProbePathEnv        = "PROCESS_RETRY_CONTROLLER_PROBE_PATH"

--- a/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
@@ -42,7 +42,7 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 			t.Fatalf("quarantined coverage subprocess failed: %v\n%s", err, output)
 		}
 		if count := bytes.Count(output, []byte("=== RUN   TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt")); count != 1 {
-			t.Fatalf("quarantined test runner header count = %d, want 1\n%s", count, output)
+			t.Errorf("quarantined test runner header count = %d, want 1\n%s", count, output)
 		}
 		if !bytes.Contains(output, []byte(processRetryQuarantinedCoverageOutputSentinel)) {
 			t.Fatalf("quarantined child output was lost:\n%s", output)
@@ -51,9 +51,12 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 		if err != nil {
 			t.Fatal(err)
 		}
+		if !bytes.HasPrefix(profile, []byte("mode: atomic\n")) {
+			t.Errorf("quarantined coverage mode is not atomic:\n%s", profile)
+		}
 		file, line := processRetryCoverageChildMarker()
-		if count, ok := processRetryCoverageCountForLine(profile, file, line); !ok || count == 0 {
-			t.Fatalf("isolated first-attempt coverage count = %d, found = %t; want positive", count, ok)
+		if count, ok := processRetryCoverageCountForLine(profile, file, line); !ok || count != 3 {
+			t.Errorf("isolated first-attempt coverage count = %d, found = %t; want 3", count, ok)
 		}
 		assertProcessRetryAttemptCoverage(t, resultPath)
 		return

--- a/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+//go:build race
+
+package retryprocess
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
+)
+
+const processRetryQuarantinedCoverageOutputSentinel = "quarantined coverage child output sentinel"
+
+func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.T) {
+	if !processRetryFixtureScenarioEnabled() && !processRetryFixtureChild() {
+		skipProcessRetryFixtureChildLaunchIneligible(t, "quarantined coverage")
+		if testing.CoverMode() == "" {
+			t.Skip("quarantined coverage fixture runs only with Go coverage enabled")
+		}
+		coveragePath := filepath.Join(t.TempDir(), "quarantined.out")
+		resultPath := filepath.Join(t.TempDir(), "result.json")
+		cmd := exec.Command(os.Args[0],
+			"-test.run=^TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt$",
+			"-test.coverprofile="+coveragePath,
+			"-test.v",
+		)
+		cmd.Env = processRetryScenarioEnvironment(
+			processRetryQuarantinedCoverageEnv+"=true",
+			processRetryQuarantinedCoverageResultEnv+"="+resultPath,
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("quarantined coverage subprocess failed: %v\n%s", err, output)
+		}
+		if count := bytes.Count(output, []byte("=== RUN   TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt")); count != 1 {
+			t.Fatalf("quarantined test runner header count = %d, want 1\n%s", count, output)
+		}
+		if !bytes.Contains(output, []byte(processRetryQuarantinedCoverageOutputSentinel)) {
+			t.Fatalf("quarantined child output was lost:\n%s", output)
+		}
+		profile, err := os.ReadFile(coveragePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		file, line := processRetryCoverageChildMarker()
+		if count, ok := processRetryCoverageCountForLine(profile, file, line); !ok || count == 0 {
+			t.Fatalf("isolated first-attempt coverage count = %d, found = %t; want positive", count, ok)
+		}
+		assertProcessRetryAttemptCoverage(t, resultPath)
+		return
+	}
+	if !processRetryFixtureChild() {
+		t.Fatal("quarantined first attempt ran in the parent process")
+	}
+
+	processRetryCoverageChildMarker()
+	fmt.Println(processRetryQuarantinedCoverageOutputSentinel)
+	var attempt int
+	gotesting.GetTest(t).Run("attempt-to-fix", func(*testing.T) {
+		attempt++
+		processRetryCoverageParentMarker()
+		if attempt > 1 {
+			processRetryCoverageChildMarker()
+		}
+	})
+}
+
+func assertProcessRetryAttemptCoverage(t *testing.T, resultPath string) {
+	t.Helper()
+	payload, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		Subtests []struct {
+			Attempt  int `json:"attempt"`
+			Coverage []struct {
+				Name   string `json:"name"`
+				Bitmap []byte `json:"bitmap"`
+			} `json:"coverage"`
+		} `json:"subtests"`
+	}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Subtests) != 3 {
+		t.Fatalf("attempt-to-fix result count = %d, want 3", len(result.Subtests))
+	}
+	for attempt, subtest := range result.Subtests {
+		if subtest.Attempt != attempt || len(subtest.Coverage) == 0 {
+			t.Fatalf("attempt %d result = %+v, want matching index and non-empty coverage", attempt, subtest)
+		}
+	}
+}

--- a/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/quarantined_coverage_race_test.go
@@ -13,12 +13,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 )
 
-const processRetryQuarantinedCoverageOutputSentinel = "quarantined coverage child output sentinel"
+const (
+	processRetryQuarantinedCoverageOutputStart = "quarantined coverage child output start"
+	processRetryQuarantinedCoverageOutputEnd   = "quarantined coverage child output end"
+	processRetryQuarantinedCoverageErrorStart  = "quarantined coverage child error start"
+	processRetryQuarantinedCoverageErrorEnd    = "quarantined coverage child error end"
+)
 
 func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.T) {
 	if !processRetryFixtureScenarioEnabled() && !processRetryFixtureChild() {
@@ -44,8 +50,12 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 		if count := bytes.Count(output, []byte("=== RUN   TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt")); count != 1 {
 			t.Errorf("quarantined test runner header count = %d, want 1\n%s", count, output)
 		}
-		if !bytes.Contains(output, []byte(processRetryQuarantinedCoverageOutputSentinel)) {
-			t.Fatalf("quarantined child output was lost:\n%s", output)
+		assertProcessRetryAttemptCoverage(t, resultPath)
+		if !bytes.Contains(output, []byte(processRetryQuarantinedCoverageOutputStart)) ||
+			!bytes.Contains(output, []byte(processRetryQuarantinedCoverageOutputEnd)) ||
+			!bytes.Contains(output, []byte(processRetryQuarantinedCoverageErrorStart)) ||
+			!bytes.Contains(output, []byte(processRetryQuarantinedCoverageErrorEnd)) {
+			t.Fatalf("quarantined child output was truncated (bytes = %d)", len(output))
 		}
 		profile, err := os.ReadFile(coveragePath)
 		if err != nil {
@@ -58,7 +68,6 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 		if count, ok := processRetryCoverageCountForLine(profile, file, line); !ok || count != 3 {
 			t.Errorf("isolated first-attempt coverage count = %d, found = %t; want 3", count, ok)
 		}
-		assertProcessRetryAttemptCoverage(t, resultPath)
 		return
 	}
 	if !processRetryFixtureChild() {
@@ -66,7 +75,12 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 	}
 
 	processRetryCoverageChildMarker()
-	fmt.Println(processRetryQuarantinedCoverageOutputSentinel)
+	fmt.Println(processRetryQuarantinedCoverageOutputStart)
+	fmt.Println(strings.Repeat("x", 40*1024))
+	fmt.Println(processRetryQuarantinedCoverageOutputEnd)
+	fmt.Fprintln(os.Stderr, processRetryQuarantinedCoverageErrorStart)
+	fmt.Fprintln(os.Stderr, strings.Repeat("y", 40*1024))
+	fmt.Fprintln(os.Stderr, processRetryQuarantinedCoverageErrorEnd)
 	var attempt int
 	gotesting.GetTest(t).Run("attempt-to-fix", func(*testing.T) {
 		attempt++
@@ -74,6 +88,9 @@ func TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt(t *testing.
 		if attempt > 1 {
 			processRetryCoverageChildMarker()
 		}
+	})
+	gotesting.GetTest(t).Run("quarantined", func(t *testing.T) {
+		t.Error("quarantined subtest failure")
 	})
 }
 
@@ -85,7 +102,11 @@ func assertProcessRetryAttemptCoverage(t *testing.T, resultPath string) {
 	}
 	var result struct {
 		Subtests []struct {
-			Attempt  int `json:"attempt"`
+			TestName string `json:"test_name"`
+			Attempt  int    `json:"attempt"`
+			Status   string `json:"status"`
+			Failed   bool   `json:"failed"`
+			Skipped  bool   `json:"skipped"`
 			Coverage []struct {
 				Name   string `json:"name"`
 				Bitmap []byte `json:"bitmap"`
@@ -95,12 +116,26 @@ func assertProcessRetryAttemptCoverage(t *testing.T, resultPath string) {
 	if err := json.Unmarshal(payload, &result); err != nil {
 		t.Fatal(err)
 	}
-	if len(result.Subtests) != 3 {
-		t.Fatalf("attempt-to-fix result count = %d, want 3", len(result.Subtests))
+	if len(result.Subtests) != 4 {
+		t.Fatalf("managed subtest result count = %d, want 4", len(result.Subtests))
 	}
-	for attempt, subtest := range result.Subtests {
-		if subtest.Attempt != attempt || len(subtest.Coverage) == 0 {
-			t.Fatalf("attempt %d result = %+v, want matching index and non-empty coverage", attempt, subtest)
+	attempt := 0
+	for _, subtest := range result.Subtests {
+		switch {
+		case strings.HasSuffix(subtest.TestName, "/attempt-to-fix"):
+			if subtest.Attempt != attempt || len(subtest.Coverage) == 0 {
+				t.Fatalf("attempt %d result = %+v, want matching index and non-empty coverage", attempt, subtest)
+			}
+			attempt++
+		case strings.HasSuffix(subtest.TestName, "/quarantined"):
+			if subtest.Status != "fail" || !subtest.Failed || subtest.Skipped || len(subtest.Coverage) == 0 {
+				t.Fatalf("quarantined result = %+v, want raw failure with coverage", subtest)
+			}
+		default:
+			t.Fatalf("unexpected managed subtest result: %+v", subtest)
 		}
+	}
+	if attempt != 3 {
+		t.Fatalf("attempt-to-fix result count = %d, want 3", attempt)
 	}
 }

--- a/internal/civisibility/integrations/gotesting/retryprocess/retryprocess_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/retryprocess_test.go
@@ -124,6 +124,9 @@ func TestMain(m *testing.M) {
 			os.Exit(0)
 		}
 		exitCode := gotesting.RunM(m)
+		if processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) == "true" {
+			copyProcessRetryBatchResultForFixture()
+		}
 		if processRetryFixtureEnv(processRetryProcessExitFixtureEnv) == "true" && exitCode == 0 {
 			os.Exit(1)
 		}
@@ -157,7 +160,15 @@ func TestMain(m *testing.M) {
 
 	tracer := integrations.InitializeCIVisibilityMock()
 	runMStart := time.Now()
-	exitCode := gotesting.RunM(m)
+	var exitCode int
+	if processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) == "true" {
+		// Exercise the woven M.Run call shape; this fixture package otherwise has a custom TestMain frame.
+		done := make(chan int, 1)
+		go func() { done <- gotesting.RunM(m) }()
+		exitCode = <-done
+	} else {
+		exitCode = gotesting.RunM(m)
+	}
 	if exitCode == 0 && processRetryFixtureEnv(processRetryDeferredOrderingEnv) == "true" {
 		assertDeferredProcessRetryOrder()
 	}
@@ -192,7 +203,8 @@ func TestMain(m *testing.M) {
 	}
 	requireLogs := processRetryFixtureEnv(processRetryBenchmarkExecutionModeEnv) == "" &&
 		processRetryFixtureEnv(processRetryParallelEFDEnv) != "true" &&
-		processRetryFixtureEnv(processRetryDeferredFTRFailfastPathEnv) == ""
+		processRetryFixtureEnv(processRetryDeferredFTRFailfastPathEnv) == "" &&
+		processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) != "true"
 	assertProcessRetryFixtureRequests(requireLogs)
 	os.Exit(exitCode)
 }
@@ -369,10 +381,11 @@ func newProcessRetryFixtureServer() *httptest.Server {
 				attributes.EarlyFlakeDetection.Enabled = true
 				attributes.EarlyFlakeDetection.SlowTestRetries.FiveS = retryCount
 			}
-			if processRetryFixtureEnv(processRetryAttemptToFixEnv) == "true" {
+			if processRetryFixtureEnv(processRetryAttemptToFixEnv) == "true" || processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) == "true" {
 				attributes.TestManagement.Enabled = true
 				attributes.TestManagement.AttemptToFixRetries = 3
 			}
+			attributes.CodeCoverage = processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) == "true"
 			writeProcessRetryAPIResponse(w, "process-retry-fixture", "ci_app_libraries_settings", attributes)
 		case "/api/v2/ci/libraries/tests":
 			if processRetryFixtureEnv(processRetryParallelEFDEnv) != "true" {
@@ -384,7 +397,7 @@ func newProcessRetryFixtureServer() *httptest.Server {
 			}}
 			writeProcessRetryAPIResponse(w, "process-retry-fixture", "ci_app_libraries_tests", attributes)
 		case "/api/v2/test/libraries/test-management/tests":
-			if processRetryFixtureEnv(processRetryAttemptToFixEnv) != "true" {
+			if processRetryFixtureEnv(processRetryAttemptToFixEnv) != "true" && processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) != "true" {
 				http.NotFound(w, r)
 				return
 			}
@@ -401,10 +414,23 @@ func newProcessRetryFixtureServer() *httptest.Server {
 								},
 							},
 						},
+						"quarantined_coverage_race_test.go": {
+							Tests: map[string]civisibilitynet.TestManagementTestsResponseDataTestProperties{
+								"TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt": {
+									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
+								},
+								"TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt/attempt-to-fix": {
+									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+								},
+							},
+						},
 					},
 				},
 			}}
 			writeProcessRetryAPIResponse(w, "process-retry-fixture", "ci_app_libraries_tests", attributes)
+		case "/api/v2/citestcov":
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusAccepted)
 		case "/api/v2/ci/tests/skippable":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -553,7 +579,7 @@ func assertProcessRetryFixtureRequests(requireLogs bool) {
 		panic(fmt.Sprintf("expected %d parent known-tests requests, got %d", wantKnownTestsRequests, got))
 	}
 	wantTestManagementRequests := 0
-	if processRetryFixtureEnv(processRetryAttemptToFixEnv) == "true" {
+	if processRetryFixtureEnv(processRetryAttemptToFixEnv) == "true" || processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) == "true" {
 		wantTestManagementRequests = 1
 	}
 	if got := processRetryFixtureRequests.counts["/api/v2/test/libraries/test-management/tests"]; got != wantTestManagementRequests {
@@ -583,9 +609,31 @@ func assertProcessRetryFixtureRequests(requireLogs bool) {
 			if requireLogs && count < 1 {
 				panic("expected at least one request to " + path)
 			}
+		case "/api/v2/citestcov":
+			if processRetryFixtureEnv(processRetryQuarantinedCoverageEnv) != "true" {
+				panic(fmt.Sprintf("unexpected coverage request path %s (%d requests)", path, count))
+			}
 		default:
 			panic(fmt.Sprintf("unexpected CI Visibility request path %s (%d requests)", path, count))
 		}
+	}
+}
+
+func copyProcessRetryBatchResultForFixture() {
+	resultRoot, ok := integrations.LookupProcessRetryChildTransport(constants.CIVisibilityInternalRetryProcessResultPath)
+	if !ok {
+		panic("quarantined coverage child is missing its result root")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(resultRoot), "batch-result-*.json"))
+	if err != nil || len(matches) != 1 {
+		panic(fmt.Sprintf("quarantined coverage child result count = %d, err = %v", len(matches), err))
+	}
+	payload, err := os.ReadFile(matches[0])
+	if err != nil {
+		panic(fmt.Sprintf("read quarantined coverage child result: %v", err))
+	}
+	if err := os.WriteFile(processRetryFixtureEnv(processRetryQuarantinedCoverageResultEnv), payload, 0o600); err != nil {
+		panic(fmt.Sprintf("copy quarantined coverage child result: %v", err))
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/retryprocess/retryprocess_test.go
+++ b/internal/civisibility/integrations/gotesting/retryprocess/retryprocess_test.go
@@ -420,7 +420,10 @@ func newProcessRetryFixtureServer() *httptest.Server {
 									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
 								},
 								"TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt/attempt-to-fix": {
-									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true, AttemptToFix: true},
+								},
+								"TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt/quarantined": {
+									Properties: civisibilitynet.TestManagementTestsResponseDataTestPropertiesAttributes{Quarantined: true},
 								},
 							},
 						},

--- a/internal/civisibility/integrations/gotesting/subtests/subtestcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/subtests/subtestcontroller_test.go
@@ -783,6 +783,9 @@ func runMatrixScenario(m *testing.M, scenario string) int {
 			s.restore()
 		}
 	}()
+	if integrations.IsProcessRetryChild() {
+		return gotesting.RunM(m)
+	}
 
 	_, restore := startSubtestServer(subtestServerConfig{
 		managementData:      ctx.data,

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -203,7 +203,9 @@ func TestMain(m *testing.M) {
 						}
 					}
 					previousProcessMax, hadProcessMax := os.LookupEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable)
-					if err := os.Setenv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1"); err != nil {
+					// The two parallel race fixtures coordinate with each other, so both
+					// bodies must be admitted just as they are under -test.parallel=2.
+					if err := os.Setenv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "2"); err != nil {
 						panic(err)
 					}
 					shuffleSeed := testControllerShuffleSeedWithOrder(*tests, orderedTests...)

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -75,6 +75,8 @@ var mockCoverageRequests atomic.Int32
 
 // TestMain is the entry point for testing and runs before any test.
 func TestMain(m *testing.M) {
+	releaseQuarantinedRaceTestMainResource := acquireQuarantinedRaceCustomTestMainResource()
+	defer releaseQuarantinedRaceTestMainResource()
 	// Enable logs collection for all test scenarios (propagates to spawned child processes).
 	_ = os.Setenv("DD_CIVISIBILITY_LOGS_ENABLED", "true")
 
@@ -82,7 +84,7 @@ func TestMain(m *testing.M) {
 	// We need to spawn separated test process for each scenario
 	scenarios := []string{"TestFlakyTestRetries", "TestEarlyFlakeDetection", "TestFlakyTestRetriesAndEarlyFlakeDetection", "TestIntelligentTestRunner", "TestManagementTests", "TestImpactedTests", "TestParallelEarlyFlakeDetection", "TestFlakyTestRetriesWithTransientSettingsFailure"}
 	if quarantinedRaceScenarioAvailable() {
-		scenarios = append(scenarios, "TestQuarantinedRace")
+		scenarios = append(scenarios, "TestQuarantinedRace", "TestQuarantinedRaceCustomTestMain")
 	}
 	if coverageModeSupportsITRBackfill() {
 		scenarios = append(scenarios, "TestIntelligentTestRunnerWithCoverageBackfill")
@@ -124,6 +126,9 @@ func TestMain(m *testing.M) {
 	} else if internal.BoolEnv("TestQuarantinedRace", false) {
 		fmt.Printf(scenarioStarted, "TestQuarantinedRace")
 		runQuarantinedRaceTests(m, "process")
+	} else if internal.BoolEnv("TestQuarantinedRaceCustomTestMain", false) {
+		fmt.Printf(scenarioStarted, "TestQuarantinedRaceCustomTestMain")
+		runQuarantinedRaceCustomTestMainTests(m)
 	} else if internal.BoolEnv(processRetryNativeLifecycleFixtureEnv, false) &&
 		os.Getenv(processRetryChildResultScenarioEnv) != processRetryOrdinaryDescendantHelperScenario {
 		os.Exit(runProcessRetryChild(m))
@@ -146,6 +151,20 @@ func TestMain(m *testing.M) {
 			runTestControllerSubprocess("RetryNativeParallelUnitTest", "^TestRetryAttemptNativeMaxParallelMatchesTestingFlag$", "Bypass=true", "-test.parallel=3")
 			for _, v := range scenarios {
 				runFilter := legacyScenarioRunFilter
+				if v == "TestQuarantinedRaceCustomTestMain" {
+					pidDir, err := os.MkdirTemp("", "dd-quarantined-custom-testmain-*")
+					if err != nil {
+						panic(err)
+					}
+					pidPath := filepath.Join(pidDir, "pid")
+					_ = os.Setenv(quarantinedRaceCustomTestMainEnv, "127.0.0.1:0")
+					_ = os.Setenv(quarantinedRaceCustomTestMainPIDEnv, pidPath)
+					runTestControllerSubprocess(v, "^TestQuarantinedRaceCustomTestMain$", v+"=true", "-test.parallel=1")
+					_ = os.Unsetenv(quarantinedRaceCustomTestMainEnv)
+					_ = os.Unsetenv(quarantinedRaceCustomTestMainPIDEnv)
+					_ = os.RemoveAll(pidDir)
+					continue
+				}
 				if v == "TestQuarantinedRace" {
 					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|Test_Foo)$"
 					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -170,8 +170,8 @@ func TestMain(m *testing.M) {
 					continue
 				}
 				if v == "TestQuarantinedRace" || v == "TestQuarantinedCleanupPanic" {
-					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedInvocationStateMutator|TestQuarantinedInvocationStateSecondMutator|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
-					orderedTests := []string{"TestQuarantinedSerialOrderProducer", "Test_Foo", "TestQuarantinedInvocationStateMutator", "TestQuarantinedRace", "TestQuarantinedInvocationStateSecondMutator", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer"}
+					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedSerialStateProducer|TestQuarantinedSerialStateConsumer|TestQuarantinedInvocationStateMutator|TestQuarantinedInvocationStateSecondMutator|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
+					orderedTests := []string{"TestQuarantinedSerialOrderProducer", "TestQuarantinedInvocationStateMutator", "TestQuarantinedRace", "TestQuarantinedInvocationStateSecondMutator", "TestQuarantinedRaceSecond", "TestQuarantinedSerialStateProducer", "TestQuarantinedSerialStateConsumer", "TestQuarantinedSerialOrderConsumer"}
 					if v == "TestQuarantinedCleanupPanic" {
 						runFilter = "^(TestQuarantinedCleanupPanic|TestQuarantinedAfterCleanupPanic)$"
 						orderedTests = []string{"TestQuarantinedCleanupPanic", "TestQuarantinedAfterCleanupPanic"}
@@ -188,7 +188,7 @@ func TestMain(m *testing.M) {
 					if err := os.Mkdir(stateDir, 0o700); err != nil {
 						panic(err)
 					}
-					for _, state := range []string{"first", "second", "post-enumeration"} {
+					for _, state := range []string{"first", "second", "child-final", "post-enumeration"} {
 						if err := os.Mkdir(filepath.Join(stateDir, state), 0o700); err != nil {
 							panic(err)
 						}
@@ -202,8 +202,17 @@ func TestMain(m *testing.M) {
 							panic(err)
 						}
 					}
+					previousProcessMax, hadProcessMax := os.LookupEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable)
+					if err := os.Setenv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1"); err != nil {
+						panic(err)
+					}
 					shuffleSeed := testControllerShuffleSeedWithOrder(*tests, orderedTests...)
 					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.failfast=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
+					if hadProcessMax {
+						_ = os.Setenv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, previousProcessMax)
+					} else {
+						_ = os.Unsetenv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable)
+					}
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
 					} else {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -188,7 +188,7 @@ func TestMain(m *testing.M) {
 					if err := os.Mkdir(stateDir, 0o700); err != nil {
 						panic(err)
 					}
-					for _, state := range []string{"first", "second"} {
+					for _, state := range []string{"first", "second", "post-enumeration"} {
 						if err := os.Mkdir(filepath.Join(stateDir, state), 0o700); err != nil {
 							panic(err)
 						}

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -184,7 +184,7 @@ func TestMain(m *testing.M) {
 					}
 					shuffleSeed := testControllerShuffleSeedWithFirst(*tests, "TestQuarantinedSerialOrderProducer",
 						"Test_Foo", "TestQuarantinedRace", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer")
-					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
+					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.failfast=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
 					} else {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -167,7 +167,7 @@ func TestMain(m *testing.M) {
 					continue
 				}
 				if v == "TestQuarantinedRace" {
-					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
+					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedInvocationStateMutator|TestQuarantinedInvocationStateSecondMutator|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
 					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")
 					if err != nil {
 						panic(err)
@@ -176,14 +176,26 @@ func TestMain(m *testing.M) {
 					if err := os.Setenv(quarantinedRacePIDDirEnv, pidDir); err != nil {
 						panic(err)
 					}
+					stateDir := filepath.Join(pidDir, "invocation-state")
+					if err := os.Mkdir(stateDir, 0o700); err != nil {
+						panic(err)
+					}
+					for _, state := range []string{"first", "second"} {
+						if err := os.Mkdir(filepath.Join(stateDir, state), 0o700); err != nil {
+							panic(err)
+						}
+					}
+					if err := os.Setenv(quarantinedRaceStateDirEnv, stateDir); err != nil {
+						panic(err)
+					}
 					previousCoverageEnabled, hadCoverageEnabled := os.LookupEnv(quarantinedRaceCoverageEnabledEnv)
 					if testing.CoverMode() != "" {
 						if err := os.Setenv(quarantinedRaceCoverageEnabledEnv, "true"); err != nil {
 							panic(err)
 						}
 					}
-					shuffleSeed := testControllerShuffleSeedWithFirst(*tests, "TestQuarantinedSerialOrderProducer",
-						"Test_Foo", "TestQuarantinedRace", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer")
+					shuffleSeed := testControllerShuffleSeedWithOrder(*tests, "TestQuarantinedSerialOrderProducer",
+						"Test_Foo", "TestQuarantinedInvocationStateMutator", "TestQuarantinedRace", "TestQuarantinedInvocationStateSecondMutator", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer")
 					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.failfast=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
@@ -195,6 +207,7 @@ func TestMain(m *testing.M) {
 					} else {
 						_ = os.Unsetenv(quarantinedRacePIDDirEnv)
 					}
+					_ = os.Unsetenv(quarantinedRaceStateDirEnv)
 					if err := os.RemoveAll(pidDir); err != nil {
 						panic(err)
 					}
@@ -593,29 +606,26 @@ func buildTestControllerSubprocessArgs(originalArgs []string, runFilter string, 
 	return args
 }
 
-func testControllerShuffleSeedWithFirst(tests []testing.InternalTest, first string, later ...string) int64 {
+func testControllerShuffleSeedWithOrder(tests []testing.InternalTest, ordered ...string) int64 {
 	for seed := int64(1); seed < 1_000_000; seed++ {
 		shuffled := append([]testing.InternalTest(nil), tests...)
 		rand.New(rand.NewSource(seed)).Shuffle(len(shuffled), func(i, j int) {
 			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 		})
-		positions := make(map[string]int, len(later)+1)
+		positions := make(map[string]int, len(ordered))
 		for i, test := range shuffled {
-			if test.Name == first {
-				positions[first] = i
-			}
-			for _, name := range later {
+			for _, name := range ordered {
 				if test.Name == name {
 					positions[name] = i
 				}
 			}
 		}
-		if len(positions) != len(later)+1 {
+		if len(positions) != len(ordered) {
 			break
 		}
 		valid := true
-		for _, name := range later {
-			if positions[first] >= positions[name] {
+		for i := 1; i < len(ordered); i++ {
+			if positions[ordered[i-1]] >= positions[ordered[i]] {
 				valid = false
 				break
 			}

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -146,7 +147,7 @@ func TestMain(m *testing.M) {
 			for _, v := range scenarios {
 				runFilter := legacyScenarioRunFilter
 				if v == "TestQuarantinedRace" {
-					runFilter = "^TestQuarantinedRace"
+					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|Test_Foo)$"
 					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")
 					if err != nil {
 						panic(err)
@@ -211,6 +212,17 @@ func runTestControllerSubprocess(name, runFilter, environment string, extraArgs 
 	}
 	fmt.Printf("cmd.Run: %v\n", err)
 	os.Exit(1)
+}
+
+func writeQuarantinedRacePID(t *testing.T) {
+	t.Helper()
+	dir := os.Getenv(quarantinedRacePIDDirEnv)
+	if dir == "" {
+		t.Fatal("missing quarantined race PID directory")
+	}
+	if err := os.WriteFile(filepath.Join(dir, t.Name()), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func buildProcessRetryUnitRunFilter(tests []testing.InternalTest, layoutAvailable bool) string {
@@ -923,19 +935,7 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 
 	// set impacted tests variables
 	if impactedTests {
-		// set the commit sha to a known value to always have the same git diff
-		base := "b97e7cbb464aef26da8cb5c07a225f7a144f26a4"
-		head := "3808532bc719ca418b938afb680246109768f343"
-		// 3808532bc719ca418b938afb680246109768f343 (feat) internal/civisibility: impacted tests (#3389)
-		// ...
-		// b97e7cbb464aef26da8cb5c07a225f7a144f26a4 v2.0.0 (#2427)
-
-		// let's make sure we have both shas available
-		_ = exec.Command("git", "fetch", "origin", base).Run()
-		_ = exec.Command("git", "fetch", "origin", head).Run()
-
-		utils.AddCITags(constants.GitPrBaseCommit, base)
-		utils.AddCITags(constants.GitHeadCommit, head)
+		configureImpactedTestsGitDiff()
 	}
 
 	// initialize the mock tracer for doing assertions on the finished spans
@@ -1052,6 +1052,16 @@ func runFlakyTestRetriesWithEarlyFlakyTestDetectionTests(m *testing.M, impactedT
 	checkLogs()
 
 	os.Exit(0)
+}
+
+func configureImpactedTestsGitDiff() {
+	// Use the fixed range that introduced impacted tests and modified Test_Foo.
+	const base = "b97e7cbb464aef26da8cb5c07a225f7a144f26a4"
+	const head = "3808532bc719ca418b938afb680246109768f343"
+	_ = exec.Command("git", "fetch", "origin", base).Run()
+	_ = exec.Command("git", "fetch", "origin", head).Run()
+	utils.AddCITags(constants.GitPrBaseCommit, base)
+	utils.AddCITags(constants.GitHeadCommit, head)
 }
 
 func runIntelligentTestRunnerTests(m *testing.M) {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 	// We need to spawn separated test process for each scenario
 	scenarios := []string{"TestFlakyTestRetries", "TestEarlyFlakeDetection", "TestFlakyTestRetriesAndEarlyFlakeDetection", "TestIntelligentTestRunner", "TestManagementTests", "TestImpactedTests", "TestParallelEarlyFlakeDetection", "TestFlakyTestRetriesWithTransientSettingsFailure"}
 	if quarantinedRaceScenarioAvailable() {
-		scenarios = append(scenarios, "TestQuarantinedRace", "TestQuarantinedRaceCustomTestMain")
+		scenarios = append(scenarios, "TestQuarantinedRace", "TestQuarantinedCleanupPanic", "TestQuarantinedRaceCustomTestMain")
 	}
 	if coverageModeSupportsITRBackfill() {
 		scenarios = append(scenarios, "TestIntelligentTestRunnerWithCoverageBackfill")
@@ -127,6 +127,9 @@ func TestMain(m *testing.M) {
 	} else if internal.BoolEnv("TestQuarantinedRace", false) {
 		fmt.Printf(scenarioStarted, "TestQuarantinedRace")
 		runQuarantinedRaceTests(m, "process")
+	} else if internal.BoolEnv("TestQuarantinedCleanupPanic", false) {
+		fmt.Printf(scenarioStarted, "TestQuarantinedCleanupPanic")
+		runQuarantinedRaceTests(m, "process")
 	} else if internal.BoolEnv("TestQuarantinedRaceCustomTestMain", false) {
 		fmt.Printf(scenarioStarted, "TestQuarantinedRaceCustomTestMain")
 		runQuarantinedRaceCustomTestMainTests(m)
@@ -166,8 +169,13 @@ func TestMain(m *testing.M) {
 					_ = os.RemoveAll(pidDir)
 					continue
 				}
-				if v == "TestQuarantinedRace" {
+				if v == "TestQuarantinedRace" || v == "TestQuarantinedCleanupPanic" {
 					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedInvocationStateMutator|TestQuarantinedInvocationStateSecondMutator|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
+					orderedTests := []string{"TestQuarantinedSerialOrderProducer", "Test_Foo", "TestQuarantinedInvocationStateMutator", "TestQuarantinedRace", "TestQuarantinedInvocationStateSecondMutator", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer"}
+					if v == "TestQuarantinedCleanupPanic" {
+						runFilter = "^(TestQuarantinedCleanupPanic|TestQuarantinedAfterCleanupPanic)$"
+						orderedTests = []string{"TestQuarantinedCleanupPanic", "TestQuarantinedAfterCleanupPanic"}
+					}
 					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")
 					if err != nil {
 						panic(err)
@@ -194,8 +202,7 @@ func TestMain(m *testing.M) {
 							panic(err)
 						}
 					}
-					shuffleSeed := testControllerShuffleSeedWithOrder(*tests, "TestQuarantinedSerialOrderProducer",
-						"Test_Foo", "TestQuarantinedInvocationStateMutator", "TestQuarantinedRace", "TestQuarantinedInvocationStateSecondMutator", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer")
+					shuffleSeed := testControllerShuffleSeedWithOrder(*tests, orderedTests...)
 					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.failfast=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -52,6 +52,7 @@ var processRetryUnitTestPrefixes = []string{
 	"TestWriteProcessRetry",
 	"TestFinalizeProcessRetry",
 	"TestCombineProcessRetry",
+	"TestUnquarantinedRace",
 }
 
 const retryParityUnitTestPrefix = "TestProcessRetryParity"
@@ -76,11 +77,20 @@ func TestMain(m *testing.M) {
 	const scenarioStarted = "**** [Scenario %s started] ****\n\n"
 	// We need to spawn separated test process for each scenario
 	scenarios := []string{"TestFlakyTestRetries", "TestEarlyFlakeDetection", "TestFlakyTestRetriesAndEarlyFlakeDetection", "TestIntelligentTestRunner", "TestManagementTests", "TestImpactedTests", "TestParallelEarlyFlakeDetection", "TestFlakyTestRetriesWithTransientSettingsFailure"}
+	if quarantinedRaceScenarioAvailable() {
+		scenarios = append(scenarios, "TestQuarantinedRace")
+	}
 	if coverageModeSupportsITRBackfill() {
 		scenarios = append(scenarios, "TestIntelligentTestRunnerWithCoverageBackfill")
 	}
 
-	if internal.BoolEnv(scenarios[0], false) {
+	if unquarantinedRaceFixtureSelected() {
+		runUnquarantinedRaceFixture(m)
+	} else if quarantinedRaceInProcessFixtureSelected() {
+		runQuarantinedRaceTests(m, "in_process")
+	} else if isProcessRetryChild() {
+		os.Exit(runProcessRetryChild(m))
+	} else if internal.BoolEnv(scenarios[0], false) {
 		fmt.Printf(scenarioStarted, scenarios[0])
 		runFlakyTestRetriesTests(m)
 	} else if internal.BoolEnv(scenarios[1], false) {
@@ -107,6 +117,9 @@ func TestMain(m *testing.M) {
 	} else if internal.BoolEnv("TestIntelligentTestRunnerWithCoverageBackfill", false) {
 		fmt.Printf(scenarioStarted, "TestIntelligentTestRunnerWithCoverageBackfill")
 		runIntelligentTestRunnerWithCoverageBackfillTests(m)
+	} else if internal.BoolEnv("TestQuarantinedRace", false) {
+		fmt.Printf(scenarioStarted, "TestQuarantinedRace")
+		runQuarantinedRaceTests(m, "process")
 	} else if internal.BoolEnv(processRetryNativeLifecycleFixtureEnv, false) &&
 		os.Getenv(processRetryChildResultScenarioEnv) != processRetryOrdinaryDescendantHelperScenario {
 		os.Exit(runProcessRetryChild(m))
@@ -128,7 +141,29 @@ func TestMain(m *testing.M) {
 		if layoutAvailable {
 			runTestControllerSubprocess("RetryNativeParallelUnitTest", "^TestRetryAttemptNativeMaxParallelMatchesTestingFlag$", "Bypass=true", "-test.parallel=3")
 			for _, v := range scenarios {
-				runTestControllerSubprocess(v, legacyScenarioRunFilter, v+"=true")
+				runFilter := legacyScenarioRunFilter
+				if v == "TestQuarantinedRace" {
+					runFilter = "^TestQuarantinedRace"
+					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")
+					if err != nil {
+						panic(err)
+					}
+					previousPIDDir, hadPIDDir := os.LookupEnv(quarantinedRacePIDDirEnv)
+					if err := os.Setenv(quarantinedRacePIDDirEnv, pidDir); err != nil {
+						panic(err)
+					}
+					runTestControllerSubprocess(v, runFilter, v+"=true")
+					if hadPIDDir {
+						_ = os.Setenv(quarantinedRacePIDDirEnv, previousPIDDir)
+					} else {
+						_ = os.Unsetenv(quarantinedRacePIDDirEnv)
+					}
+					if err := os.RemoveAll(pidDir); err != nil {
+						panic(err)
+					}
+					continue
+				}
+				runTestControllerSubprocess(v, runFilter, v+"=true")
 			}
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -57,6 +57,8 @@ var processRetryUnitTestPrefixes = []string{
 
 const retryParityUnitTestPrefix = "TestProcessRetryParity"
 
+const quarantinedRaceCoverageEnabledEnv = "DD_TEST_QUARANTINED_RACE_COVERAGE_ENABLED"
+
 var retryParityFallbackUnitTests = map[string]struct{}{
 	"TestProcessRetryParityRuntimeLayoutRejectsMissingCapabilities":                 {},
 	"TestProcessRetryParityMaskedFallbackRunsInstrumentedShellWithoutUserBody":      {},
@@ -68,6 +70,7 @@ var retryParityFallbackUnitTests = map[string]struct{}{
 var mTracer mocktracer.Tracer
 var logsEntries []*mockedLogEntry
 var parallelEfd bool
+var mockCoverageRequests atomic.Int32
 
 // TestMain is the entry point for testing and runs before any test.
 func TestMain(m *testing.M) {
@@ -152,7 +155,18 @@ func TestMain(m *testing.M) {
 					if err := os.Setenv(quarantinedRacePIDDirEnv, pidDir); err != nil {
 						panic(err)
 					}
+					previousCoverageEnabled, hadCoverageEnabled := os.LookupEnv(quarantinedRaceCoverageEnabledEnv)
+					if testing.CoverMode() != "" {
+						if err := os.Setenv(quarantinedRaceCoverageEnabledEnv, "true"); err != nil {
+							panic(err)
+						}
+					}
 					runTestControllerSubprocess(v, runFilter, v+"=true")
+					if hadCoverageEnabled {
+						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
+					} else {
+						_ = os.Unsetenv(quarantinedRaceCoverageEnabledEnv)
+					}
 					if hadPIDDir {
 						_ = os.Setenv(quarantinedRacePIDDirEnv, previousPIDDir)
 					} else {
@@ -1631,6 +1645,7 @@ func setUpHTTPServer(
 
 	// Reset the collected logs for the new server instance.
 	logsEntries = nil
+	mockCoverageRequests.Store(0)
 	enableKnownTests := knownTestsEnabled || earlyFlakyDetectionEnabled
 	// mock the settings api to enable automatic test retries
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1656,6 +1671,7 @@ func setUpHTTPServer(
 				TestsSkipping:           itrEnabled,
 				KnownTestsEnabled:       enableKnownTests,
 				ImpactedTestsEnabled:    impactedTests,
+				CodeCoverage:            os.Getenv(quarantinedRaceCoverageEnabledEnv) == "true",
 			}
 
 			response.Data.Attributes.TestManagement.Enabled = testManagement
@@ -1718,6 +1734,9 @@ func setUpHTTPServer(
 			}
 			log.Debug("MockApi sending response: %v", response)
 			json.NewEncoder(w).Encode(&response)
+		} else if r.URL.Path == "/api/v2/citestcov" {
+			mockCoverageRequests.Add(1)
+			w.WriteHeader(http.StatusAccepted)
 		} else if r.URL.Path == "/api/v2/logs" {
 			// Mock the logs intake endpoint.
 			reader, _ := gzip.NewReader(r.Body)

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -181,7 +182,9 @@ func TestMain(m *testing.M) {
 							panic(err)
 						}
 					}
-					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.parallel=2")
+					shuffleSeed := testControllerShuffleSeedWithFirst(*tests, "TestQuarantinedSerialOrderProducer",
+						"Test_Foo", "TestQuarantinedRace", "TestQuarantinedRaceSecond", "TestQuarantinedSerialOrderConsumer")
+					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.parallel=2", "-test.shuffle="+strconv.FormatInt(shuffleSeed, 10), "-test.timeout=30s")
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
 					} else {
@@ -588,6 +591,40 @@ func buildTestControllerSubprocessArgs(originalArgs []string, runFilter string, 
 	args = append(args, "-test.run="+runFilter)
 	args = append(args, boundary...)
 	return args
+}
+
+func testControllerShuffleSeedWithFirst(tests []testing.InternalTest, first string, later ...string) int64 {
+	for seed := int64(1); seed < 1_000_000; seed++ {
+		shuffled := append([]testing.InternalTest(nil), tests...)
+		rand.New(rand.NewSource(seed)).Shuffle(len(shuffled), func(i, j int) {
+			shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+		})
+		positions := make(map[string]int, len(later)+1)
+		for i, test := range shuffled {
+			if test.Name == first {
+				positions[first] = i
+			}
+			for _, name := range later {
+				if test.Name == name {
+					positions[name] = i
+				}
+			}
+		}
+		if len(positions) != len(later)+1 {
+			break
+		}
+		valid := true
+		for _, name := range later {
+			if positions[first] >= positions[name] {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			return seed
+		}
+	}
+	panic("unable to find deterministic test shuffle seed")
 }
 
 func testControllerBenchmarkSelected(args []string) bool {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -166,7 +166,7 @@ func TestMain(m *testing.M) {
 					continue
 				}
 				if v == "TestQuarantinedRace" {
-					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|Test_Foo)$"
+					runFilter = "^(TestQuarantinedRace|TestQuarantinedRaceSecond|TestQuarantinedSerialOrderProducer|TestQuarantinedSerialOrderConsumer|Test_Foo)$"
 					pidDir, err := os.MkdirTemp("", "dd-quarantined-race-pids-*")
 					if err != nil {
 						panic(err)
@@ -181,7 +181,7 @@ func TestMain(m *testing.M) {
 							panic(err)
 						}
 					}
-					runTestControllerSubprocess(v, runFilter, v+"=true")
+					runTestControllerSubprocess(v, runFilter, v+"=true", "-test.parallel=2")
 					if hadCoverageEnabled {
 						_ = os.Setenv(quarantinedRaceCoverageEnabledEnv, previousCoverageEnabled)
 					} else {

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -598,6 +598,15 @@ func (ddm *M) instrumentInternalTests(internalTests *[]testing.InternalTest, wra
 	if internalTests == nil {
 		return
 	}
+	if wrapperOpts.quarantinedRaceNativeOrder && wrapperOpts.processRetryCoordinator != nil {
+		wrapperOpts.processRetryCoordinator.setNativeTestOrder(func() []string {
+			order := make([]string, len(*internalTests))
+			for i, test := range *internalTests {
+				order[i] = test.Name
+			}
+			return order
+		})
+	}
 	if claim != nil {
 		claim.testDescriptors = internalTests
 	}

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -331,8 +331,11 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 	settings := integrations.GetSettings()
 	testManagementEnabled := settings != nil && settings.TestManagement.Enabled &&
 		internal.BoolEnv(constants.CIVisibilityTestManagementEnabledEnvironmentVariable, true)
+	// A batch child would re-enter a custom TestMain before its parent setup has
+	// been torn down, so keep quarantined first attempts in the native process.
 	if processModeEnabled && testManagementEnabled && retryAttemptRaceEnabled() &&
-		ProcessRetryContainmentSupported() && wrapperOpts.processRetryCoordinator != nil {
+		ProcessRetryContainmentSupported() && wrapperOpts.processRetryCoordinator != nil &&
+		!processRetryCustomTestMainActive() {
 		wrapperOpts.quarantinedRaceIsolation = true
 	}
 	var knownTests *net.KnownTestsResponseData
@@ -434,6 +437,21 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 			panic(deferredTerminalPanic)
 		}
 		return exitCode
+	}
+}
+
+func processRetryCustomTestMainActive() bool {
+	callers := make([]uintptr, 32)
+	count := runtime.Callers(2, callers)
+	frames := runtime.CallersFrames(callers[:count])
+	for {
+		frame, more := frames.Next()
+		if strings.HasSuffix(frame.Function, ".TestMain") {
+			return true
+		}
+		if !more {
+			return false
+		}
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -326,9 +326,14 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 			log.Debug("instrumentTestingM: deferred process retry coordinator registration rejected")
 		}
 	}
-
 	coverageInitialized := false
 	settings := integrations.GetSettings()
+	testManagementEnabled := settings != nil && settings.TestManagement.Enabled &&
+		internal.BoolEnv(constants.CIVisibilityTestManagementEnabledEnvironmentVariable, true)
+	if processModeEnabled && testManagementEnabled && retryAttemptRaceEnabled() &&
+		ProcessRetryContainmentSupported() && wrapperOpts.processRetryCoordinator != nil {
+		wrapperOpts.quarantinedRaceIsolation = true
+	}
 	var knownTests *net.KnownTestsResponseData
 	if settings != nil && settings.EarlyFlakeDetection.Enabled && settings.EarlyFlakeDetection.FaultySessionThreshold != nil {
 		threshold := *settings.EarlyFlakeDetection.FaultySessionThreshold
@@ -343,7 +348,7 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 			coverage.InitializeCoverage(m, true)
 			coverageInitialized = true
 		}
-		if settings.TestManagement.Enabled && internal.BoolEnv(constants.CIVisibilityTestManagementEnabledEnvironmentVariable, true) {
+		if testManagementEnabled {
 			// Set the test management tag if enabled.
 			session.SetTag(constants.TestManagementEnabled, "true")
 		}

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -318,8 +318,13 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 		log.Debug("instrumentTestingM: process retry shutdown action registration failed; falling back to in-process retries")
 		wrapperOpts.processRetryAllowed = false
 	}
+	customTestMainActive := false
 	if processModeEnabled && wrapperOpts.processRetryAllowed {
+		customTestMainActive = processRetryCustomTestMainActive()
 		wrapperOpts.processRetryLaunchTemplate = captureProcessRetryLaunchTemplate()
+		// A retry child re-enters TestMain, so bootstrap it from process-start
+		// state instead of inheriting TestMain's active setup.
+		wrapperOpts.processRetryLaunchTemplate.preserveStartup = customTestMainActive
 		coordinator := newProcessRetryCoordinator(retryAttemptFailfastEnabled, runDeferredProcessRetryAttempt)
 		if registerProcessRetryCoordinator(coordinator) {
 			wrapperOpts.processRetryCoordinator = coordinator
@@ -335,7 +340,7 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 	// been torn down, so keep quarantined first attempts in the native process.
 	if processModeEnabled && testManagementEnabled && retryAttemptRaceEnabled() &&
 		ProcessRetryContainmentSupported() && wrapperOpts.processRetryCoordinator != nil &&
-		!processRetryCustomTestMainActive() {
+		!customTestMainActive {
 		wrapperOpts.quarantinedRaceIsolation = true
 	}
 	var knownTests *net.KnownTestsResponseData

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -599,15 +599,6 @@ func (ddm *M) instrumentInternalTests(internalTests *[]testing.InternalTest, wra
 	if internalTests == nil {
 		return
 	}
-	if wrapperOpts.quarantinedRaceNativeOrder && wrapperOpts.processRetryCoordinator != nil {
-		wrapperOpts.processRetryCoordinator.setNativeTestOrder(func() []string {
-			order := make([]string, len(*internalTests))
-			for i, test := range *internalTests {
-				order[i] = test.Name
-			}
-			return order
-		})
-	}
 	if claim != nil {
 		claim.testDescriptors = internalTests
 	}

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -362,6 +362,11 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 	if !coverageInitialized && testing.CoverMode() != "" {
 		coverage.InitializeCoverage(m, false)
 	}
+	// Per-test coverage counters are process-global, and failfast can stop the
+	// native pass before every registered gate is reached. In those modes keep
+	// the post-M.Run batch; otherwise preserve each first attempt's call order.
+	wrapperOpts.quarantinedRaceNativeOrder = wrapperOpts.quarantinedRaceIsolation &&
+		!coverage.CanCollectPerTestCoverage() && !retryAttemptFailfastEnabled()
 
 	ddm := (*M)(m)
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -362,11 +362,7 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 	if !coverageInitialized && testing.CoverMode() != "" {
 		coverage.InitializeCoverage(m, false)
 	}
-	// Per-test coverage counters are process-global, and failfast can stop the
-	// native pass before every registered gate is reached. In those modes keep
-	// the post-M.Run batch; otherwise preserve each first attempt's call order.
-	wrapperOpts.quarantinedRaceNativeOrder = wrapperOpts.quarantinedRaceIsolation &&
-		!coverage.CanCollectPerTestCoverage() && !retryAttemptFailfastEnabled()
+	wrapperOpts.quarantinedRaceNativeOrder = wrapperOpts.quarantinedRaceIsolation
 
 	ddm := (*M)(m)
 

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -126,6 +126,7 @@ type (
 		testName   string
 		identity   *testIdentity
 		sourceFunc *runtime.Func
+		source     *processRetryTestSource
 	}
 
 	// testingTInfo holds information specific to tests.

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -48,7 +48,11 @@ func TestMyTest02(gt *testing.T) {
 }
 
 func Test_Foo(gt *testing.T) {
-	assertTest(gt)
+	if os.Getenv("TestQuarantinedRace") == "true" {
+		writeQuarantinedRacePID(gt)
+	} else {
+		assertTest(gt)
+	}
 	t := (*T)(gt)
 
 	var tests = []struct {

--- a/internal/civisibility/integrations/manual_api_ddtest.go
+++ b/internal/civisibility/integrations/manual_api_ddtest.go
@@ -232,13 +232,16 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 
 	// Resolve immutable function metadata once. Go -trimpath can return a logical
 	// module path while source parsing still needs a local file path.
-	functionMetadata := loadSourceFunctionMetadata(fn)
+	t.setTestSource(loadSourceFunctionMetadata(fn), fn.Entry())
+}
+
+func (t *tslvTest) setTestSource(functionMetadata sourceFunctionMetadata, entry uintptr) {
 	runtimePath := functionMetadata.runtimePath
 	runtimeStartLine := functionMetadata.runtimeStartLine
 	sourcePath := functionMetadata.sourcePath
 	file := sourcePath.RelativePath
 	log.Debug("civisibility: resolving test source location [function:%s file:%s start_line:%d relative_file:%s runtime_file:%s filesystem_file:%s filesystem_known:%t entry:%#x]",
-		fn.Name(), runtimePath, runtimeStartLine, file, sourcePath.RuntimePath, sourcePath.FilesystemPath, sourcePath.FilesystemKnown, fn.Entry())
+		functionMetadata.fullName, runtimePath, runtimeStartLine, file, sourcePath.RuntimePath, sourcePath.FilesystemPath, sourcePath.FilesystemKnown, entry)
 	t.SetTag(constants.TestSourceFile, file)
 	t.SetTag(constants.TestSourceStartLine, runtimeStartLine)
 	t.suite.SetTag(constants.TestSourceFile, file)
@@ -247,7 +250,7 @@ func (t *tslvTest) SetTestFunc(fn *runtime.Func) {
 	metadata := functionMetadata.fileMetadata
 	if !metadata.parseOK {
 		log.Debug("civisibility: failed parsing test source file [function:%s file:%s runtime_file:%s relative_file:%s start_line:%d error:%v]",
-			fn.Name(), sourcePath.FilesystemPath, runtimePath, file, runtimeStartLine, metadata.parseErr)
+			functionMetadata.fullName, sourcePath.FilesystemPath, runtimePath, file, runtimeStartLine, metadata.parseErr)
 	}
 	if metadata.parseOK {
 		// let's check if the suite was marked as unskippable before

--- a/internal/civisibility/integrations/manual_api_sourcecache.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/impactedtests"
 )
 
 var (
@@ -108,6 +109,15 @@ type impactedTestClassifier interface {
 // classifies fn as modified without requiring a test event to be created first.
 func IsTestFuncModified(testName string, fn *runtime.Func) bool {
 	return isTestFuncModified(GetImpactedTestsAnalyzer(), testName, fn)
+}
+
+// IsTestFuncModifiedWithAnalyzer classifies a test with an explicitly owned
+// analyzer, allowing an isolated test process to avoid CI Visibility startup.
+func IsTestFuncModifiedWithAnalyzer(analyzer *impactedtests.ImpactedTestAnalyzer, testName string, fn *runtime.Func) bool {
+	if analyzer == nil {
+		return false
+	}
+	return isTestFuncModified(analyzer, testName, fn)
 }
 
 // IsTestFuncUnskippable reports whether source metadata marks fn or its suite

--- a/internal/civisibility/integrations/manual_api_sourcecache.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache.go
@@ -40,6 +40,12 @@ type sourceFunctionCacheSlot struct {
 	entry sourceFunctionMetadata
 }
 
+type sourceFunctionIdentity struct {
+	runtimePath      string
+	runtimeStartLine int
+	functionName     string
+}
+
 type sourceFunctionMetadata struct {
 	runtimePath      string
 	runtimeStartLine int
@@ -49,6 +55,16 @@ type sourceFunctionMetadata struct {
 	fileSlot         *sourceFileCacheSlot
 	fileMetadata     sourceFileMetadata
 	resolution       sourceResolution
+}
+
+// SetTestSource applies a source identity captured in another process.
+func SetTestSource(test Test, runtimePath string, runtimeStartLine int, functionName string) {
+	if test == nil || runtimePath == "" || runtimeStartLine <= 0 || functionName == "" {
+		return
+	}
+	if test, ok := test.(*tslvTest); ok {
+		test.setTestSource(loadSourceFunctionMetadataFromIdentity(runtimePath, runtimeStartLine, functionName), 0)
+	}
 }
 
 // sourceFileMetadata contains the parsed source information needed by SetTestFunc.
@@ -124,6 +140,19 @@ func loadSourceFunctionMetadata(fn *runtime.Func) sourceFunctionMetadata {
 	return slot.entry
 }
 
+func loadSourceFunctionMetadataFromIdentity(runtimePath string, runtimeStartLine int, functionName string) sourceFunctionMetadata {
+	key := sourceFunctionIdentity{runtimePath: runtimePath, runtimeStartLine: runtimeStartLine, functionName: functionName}
+	slotAny, ok := sourceFunctionMetadataCache.Load(key)
+	if !ok {
+		slotAny, _ = sourceFunctionMetadataCache.LoadOrStore(key, newSourceFunctionCacheSlot())
+	}
+	slot := slotAny.(*sourceFunctionCacheSlot)
+	slot.once.Do(func() {
+		slot.entry = resolveSourceFunctionMetadataFromIdentity(runtimePath, runtimeStartLine, functionName)
+	})
+	return slot.entry
+}
+
 func loadSourceFunctionCodeOwner(metadata sourceFunctionMetadata) (string, bool) {
 	return loadSourceFunctionCodeOwnerWithLookup(metadata, loadCodeOwnersWithStatus)
 }
@@ -189,10 +218,13 @@ func sourceFunctionSlotForEntry(entry uintptr, newSlot func() *sourceFunctionCac
 
 func resolveSourceFunctionMetadata(fn *runtime.Func) sourceFunctionMetadata {
 	runtimePath, runtimeStartLine := fn.FileLine(fn.Entry())
+	return resolveSourceFunctionMetadataFromIdentity(runtimePath, runtimeStartLine, fn.Name())
+}
+
+func resolveSourceFunctionMetadataFromIdentity(runtimePath string, runtimeStartLine int, fullName string) sourceFunctionMetadata {
 	sourcePath := resolveTestSourcePath(runtimePath)
 	fileSlot := sourceFileSlot(sourcePath.FilesystemPath, newSourceFileCacheSlot)
 	fileMetadata := loadSourceFileMetadataFromSlot(fileSlot, sourcePath.FilesystemPath)
-	fullName := fn.Name()
 	shortName := fullName[strings.LastIndex(fullName, ".")+1:]
 	metadata := sourceFunctionMetadata{
 		runtimePath:      runtimePath,

--- a/internal/civisibility/integrations/manual_api_sourcecache.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache.go
@@ -94,6 +94,14 @@ func IsTestFuncModified(testName string, fn *runtime.Func) bool {
 	return isTestFuncModified(GetImpactedTestsAnalyzer(), testName, fn)
 }
 
+// IsTestFuncUnskippable reports whether source metadata marks fn or its suite
+// as unskippable without requiring a test event to be created first.
+func IsTestFuncUnskippable(fn *runtime.Func) bool {
+	metadata := loadSourceFunctionMetadata(fn)
+	return metadata.fileMetadata.parseOK &&
+		(metadata.fileMetadata.suiteUnskippable || metadata.resolution.functionUnskippable)
+}
+
 func isTestFuncModified(analyzer impactedTestClassifier, testName string, fn *runtime.Func) bool {
 	if analyzer == nil || fn == nil {
 		return false

--- a/internal/civisibility/integrations/manual_api_sourcecache_test.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache_test.go
@@ -73,6 +73,15 @@ func TestIsTestFuncModifiedUsesResolvedSourceRange(t *testing.T) {
 	require.GreaterOrEqual(t, classifier.endLine, classifier.startLine)
 }
 
+func TestIsTestFuncUnskippableUsesCachedSourceMetadata(t *testing.T) {
+	resetSourceCacheTestState(t)
+
+	require.True(t, IsTestFuncUnskippable(runtime.FuncForPC(reflect.ValueOf(declarationUnskippableFixtureFunc).Pointer())))
+	require.True(t, IsTestFuncUnskippable(runtime.FuncForPC(reflect.ValueOf(suiteUnskippableFixtureFunc).Pointer())))
+	require.False(t, IsTestFuncUnskippable(namedSourceFixtureRuntimeFunc()))
+	require.False(t, IsTestFuncUnskippable(nil))
+}
+
 // resetSourceCacheTestState installs repository metadata so sourcecache tests also work with -trimpath.
 func resetSourceCacheTestState(t *testing.T) {
 	t.Helper()

--- a/internal/civisibility/integrations/manual_api_sourcepath_test.go
+++ b/internal/civisibility/integrations/manual_api_sourcepath_test.go
@@ -102,6 +102,37 @@ func TestSetTestFuncUsesResolvedSourcePathForTagsAndParsing(t *testing.T) {
 	assertSourceRangeTags(t, test)
 }
 
+func TestSetTestSourceMatchesSetTestFunc(t *testing.T) {
+	configureSourcePathTestState(t, sourcePathRepositoryRoot(t))
+
+	now := time.Now()
+	session, module, suite, direct := createDDTest(now)
+	transported := suite.CreateTest("transported")
+	defer func() {
+		session.Close(0)
+		module.Close()
+		suite.Close()
+	}()
+
+	fn := runtime.FuncForPC(reflect.ValueOf(sourcePathFixtureFunc).Pointer())
+	require.NotNil(t, fn)
+	direct.SetTestFunc(fn)
+	runtimePath, runtimeStartLine := fn.FileLine(fn.Entry())
+	SetTestSource(transported, runtimePath, runtimeStartLine, fn.Name())
+
+	for _, tag := range []string{
+		constants.TestSourceFile,
+		constants.TestSourceStartLine,
+		constants.TestSourceEndLine,
+		constants.TestCodeOwners,
+	} {
+		directValue, directOK := direct.GetTag(tag)
+		transportedValue, transportedOK := transported.GetTag(tag)
+		assert.Equal(t, directOK, transportedOK, tag)
+		assert.Equal(t, directValue, transportedValue, tag)
+	}
+}
+
 func TestResolveTestSourcePathCanParseTrimpathModulePath(t *testing.T) {
 	workspacePath := t.TempDir()
 	configureSourcePathTestState(t, workspacePath)


### PR DESCRIPTION
## Summary

This change prevents process-global race-detector failures from quarantined tests from affecting the final `go test` result, without masking failures in the isolation machinery itself.

When the race detector is active, every eligible quarantined top-level first attempt runs in its own bounded isolated child process. Each body is gated at its native invocation position, while the parent process remains the sole owner of CI Visibility session, module, suite, and test events. Non-race runs and non-quarantined tests retain their existing execution paths.

## Implementation

- detects race-enabled test binaries without adding a user-facing flag;
- preserves the parent runner's realized test order, shuffle, filters, failfast boundary, and serial/`t.Parallel` scheduling;
- uses a singleton native batch for each invocation so race-detector and coverage counters cannot leak between tests;
- keeps child parallel bodies behind a cross-process barrier until the parent completes top-level test enumeration;
- transfers child working-directory and environment mutations made before `t.Parallel` to the parent before the mirrored transition, then applies the parent's post-enumeration state in the child;
- temporarily releases process admission for parallel enumeration, then reacquires it before opening the child bridge and holds it until the child process exits;
- captures the parent barrier before releasing enumeration, avoiding races with the per-test coverage barrier guard;
- transfers each invocation's current working directory and sanitized environment into its child;
- propagates a serial child's final working directory and environment back to the parent before the next serial test, while preserving parent-only keys excluded from child state and deliberately not propagating process-global changes from parallel children;
- applies disabled-test, exact quarantine, and exact ITR subtest decisions before the isolated body, preserving quarantine masking, modified-test, missing-coverage, and unskippable forced-run behavior;
- transports exact attempt-to-fix and quarantine subtest directives into the child, supports their combination, reuses one fresh `testing.T` retry lifecycle there, and reconstructs every raw execution and aggregate final status in the parent;
- avoids first-attempt isolation when Go test profiling or execution tracing is active so the parent-owned output includes the test body;
- transports strictly validated pass, fail, skip, panic, race, timing, subtest, source, coverage, and bounded output data back to the parent;
- streams complete native first-attempt stdout and stderr to the parent while retaining bounded copies for metadata, filtering only marker-framed stdout runner protocol and avoiding duplicate tail replay;
- preserves an explicit package `-timeout=0` for native batches without creating a fallback retry timer, while still honoring an explicit retry-process timeout or parent deadline;
- contributes isolated counters to Go's package coverage report before the parent `M.Run` returns and records a separate per-test coverage delta for every attempt-to-fix execution;
- retains child action-log records until the parent test log has flushed, then merges them for correct `go test` caching, including from relaunched native attempts;
- relaunches attempts missing after a child exit as singleton native batches while retaining global containment stop conditions;
- latches synchronous infrastructure failures into native testing state under `-failfast`; and
- keeps child CI Visibility APIs and lifecycle ownership disabled while reusing the existing process containment and shutdown machinery.

The private batch protocol uses temporary files, atomic writes, strict JSON validation, bounded manifests/results, and 8 KiB per-test output tails.

## Regression coverage

- quarantined race failures do not fail the parent process;
- concurrent quarantined tests run in distinct child processes, so one test's race count cannot fail a peer;
- serial and parallel quarantined tests execute at their native positions and in realized shuffled order;
- an isolated parallel body cannot start before ordinary serial tests that follow its descriptor have completed enumeration;
- child mutations made before `t.Parallel` reach the parent before its mirrored transition, and the child observes parent mutations made before enumeration completes without leaking its later parallel mutations back;
- serial child working-directory and environment mutations are visible to the next parent test;
- parent-only environment entries such as `GOCOVERDIR` and `DD_CIVISIBILITY_ENABLED=parent` survive child final-state application while ordinary child deletions still propagate;
- process concurrency of one does not deadlock parallel enumeration, and the child bridge cannot open before process admission is reacquired;
- a cleanup panic does not prevent later quarantined tests from running in a fresh process;
- disabled and ITR-skippable isolated subtests do not run, while unskippable forced-run behavior is preserved;
- exact quarantined subtests retain raw failure, output, and coverage telemetry while masking only the package result, including when combined with attempt-to-fix;
- exact attempt-to-fix subtests execute the configured number of times after a race, publish every attempt with correct retry and final-status tags, and carry a distinct non-empty coverage delta per execution;
- CPU, memory, block, and mutex profiles and execution traces retain native in-process first-attempt execution;
- isolated first-attempt counters appear in the parent atomic coverprofile with their exact expected count, detecting any future double merge;
- child user output and race details survive without duplicate runner headers under ordinary `go test -v`, including more than 32 KiB on both stdout and stderr and user lines that resemble Go test protocol;
- `-timeout=0` remains disabled in native batch children, creates no retry timer, and remains bounded by explicit retry or parent deadlines when present;
- race-only subtests are serialized as failed after the native race checkpoint;
- child action-log records survive the parent flush and native-attempt relaunch cleanup;
- synchronous infrastructure failures under `-failfast` prevent later tests from starting;
- unexplained exits, timeouts, unreaped children, setup failures, missing or invalid results, and launch failures fail the package;
- test failures, panics, and race reports remain eligible for quarantine masking; and
- non-race execution remains inline.

## Validation

```sh
go test ./internal/civisibility/integrations/gotesting -count=1
go test -race ./internal/civisibility/integrations/gotesting -count=1
go test -race -cover ./internal/civisibility/integrations/gotesting/retryprocess \
  -run '^TestProcessRetryQuarantinedCoverageIncludesIsolatedFirstAttempt$' \
  -count=1 -v
make lint/go
git diff --check
```

All commands pass locally on `4ed53cd2d` with Go 1.26.5; `make lint/go` also passes with the repository's Go 1.25-compatible lint toolchain.
