### PR TITLE
fix(ddtrace/tracer): make OTLP metric attrs mode-independent

### DIFF
--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -219,8 +219,11 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool) []*otlpco
 	}
 	// top_level is true only when all spans in the group were top-level (TopLevelHits == Hits).
 	attrs = append(attrs, otlpKeyValue("datadog.span.top_level", otlpBoolValue(gs.Hits > 0 && gs.TopLevelHits == gs.Hits)))
-	if gs.IsTraceRoot != pb.Trilean_NOT_SET {
-		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
+	switch gs.IsTraceRoot {
+	case pb.Trilean_TRUE:
+		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(true)))
+	case pb.Trilean_FALSE:
+		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(false)))
 	}
 	if len(gs.PeerTags) > 0 {
 		attrs = append(attrs, otlpKeyValue("datadog.peer_tags", otlpStringArrayValue(gs.PeerTags)))

--- a/ddtrace/tracer/stats_to_otlp_metrics.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics.go
@@ -60,13 +60,11 @@ var spanMetricBounds = [16]float64{0.002, 0.004, 0.006, 0.008, 0.01, 0.05, 0.1, 
 // buildOTLPMetricsRequest converts a ClientStatsPayload to OTLP ResourceMetrics (DELTA histogram).
 // Returns nil when empty.
 func buildOTLPMetricsRequest(payload *pb.ClientStatsPayload, cfg *internalconfig.Config) []*otlpmetrics.ResourceMetrics {
-	otelMode := cfg.OTelSemanticsEnabled()
-
 	var allPoints []*otlpmetrics.HistogramDataPoint
 	for _, bucket := range payload.Stats {
 		bucketEnd := bucket.Start + bucket.Duration
 		for _, gs := range bucket.Stats {
-			pts := buildGroupDataPoints(gs, bucket.Start, bucketEnd, otelMode)
+			pts := buildGroupDataPoints(gs, bucket.Start, bucketEnd)
 			allPoints = append(allPoints, pts...)
 		}
 	}
@@ -75,7 +73,7 @@ func buildOTLPMetricsRequest(payload *pb.ClientStatsPayload, cfg *internalconfig
 		return nil
 	}
 
-	resource := buildMetricsResource(payload, otelMode, cfg.ReportHostname(), cfg.Hostname())
+	resource := buildMetricsResource(payload, cfg.ReportHostname(), cfg.Hostname())
 
 	scopeMetrics := []*otlpmetrics.ScopeMetrics{
 		{
@@ -102,42 +100,40 @@ func buildOTLPMetricsRequest(payload *pb.ClientStatsPayload, cfg *internalconfig
 	}
 }
 
-// buildMetricsResource builds the OTLP Resource; adds host.name and datadog.* attrs in default mode.
-func buildMetricsResource(payload *pb.ClientStatsPayload, otelMode bool, reportHostname bool, hostname string) *otlpresource.Resource {
+// buildMetricsResource builds the OTLP Resource.
+func buildMetricsResource(payload *pb.ClientStatsPayload, reportHostname bool, hostname string) *otlpresource.Resource {
 	attrs := buildBaseResourceAttrs(payload.Service, payload.Version, payload.Env)
 	if reportHostname && hostname != "" {
 		attrs = append(attrs, otlpKeyValue("host.name", otlpStringValue(hostname)))
 	}
-	if !otelMode {
-		if payload.RuntimeID != "" {
-			attrs = append(attrs, otlpKeyValue("datadog.runtime_id", otlpStringValue(payload.RuntimeID)))
-		}
-		if payload.ProcessTags != "" {
-			// Mirrors the same comma-separated ProcessTags string the /v0.6/stats (ddStatsSender) path sends as-is; update both if that shape changes.
-			tags := strings.Split(payload.ProcessTags, ",")
-			attrs = append(attrs, otlpKeyValue("datadog.process_tags", otlpStringArrayValue(tags)))
-		}
+	if payload.RuntimeID != "" {
+		attrs = append(attrs, otlpKeyValue("datadog.runtime_id", otlpStringValue(payload.RuntimeID)))
+	}
+	if payload.ProcessTags != "" {
+		// Mirrors the same comma-separated ProcessTags string the /v0.6/stats (ddStatsSender) path sends as-is; update both if that shape changes.
+		tags := strings.Split(payload.ProcessTags, ",")
+		attrs = append(attrs, otlpKeyValue("datadog.process_tags", otlpStringArrayValue(tags)))
 	}
 	return &otlpresource.Resource{Attributes: attrs}
 }
 
 // buildGroupDataPoints produces up to two OTLP histogram data points (ok + error) from a ClientGroupedStats.
-func buildGroupDataPoints(gs *pb.ClientGroupedStats, startNs, endNs uint64, otelMode bool) []*otlpmetrics.HistogramDataPoint {
+func buildGroupDataPoints(gs *pb.ClientGroupedStats, startNs, endNs uint64) []*otlpmetrics.HistogramDataPoint {
 	var pts []*otlpmetrics.HistogramDataPoint
 	if len(gs.OkSummary) > 0 {
-		if dp := decodeAndBuildDataPoint(gs, gs.OkSummary, startNs, endNs, false, otelMode); dp != nil {
+		if dp := decodeAndBuildDataPoint(gs, gs.OkSummary, startNs, endNs, false); dp != nil {
 			pts = append(pts, dp)
 		}
 	}
 	if len(gs.ErrorSummary) > 0 {
-		if dp := decodeAndBuildDataPoint(gs, gs.ErrorSummary, startNs, endNs, true, otelMode); dp != nil {
+		if dp := decodeAndBuildDataPoint(gs, gs.ErrorSummary, startNs, endNs, true); dp != nil {
 			pts = append(pts, dp)
 		}
 	}
 	return pts
 }
 
-func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, startNs, endNs uint64, isError bool, otelMode bool) *otlpmetrics.HistogramDataPoint {
+func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, startNs, endNs uint64, isError bool) *otlpmetrics.HistogramDataPoint {
 	bucketCounts, sum, minSec, maxSec, count, err := sketchToHistogram(sketchBytes, spanMetricBounds[:])
 	if err != nil {
 		log.Warn("stats_to_otlp_metrics: failed to decode sketch: %v", err.Error())
@@ -157,20 +153,17 @@ func decodeAndBuildDataPoint(gs *pb.ClientGroupedStats, sketchBytes []byte, star
 		Max:               &maxSec,
 		ExplicitBounds:    spanMetricBounds[:],
 		BucketCounts:      bucketCounts,
-		Attributes:        buildDataPointAttributes(gs, isError, otelMode),
+		Attributes:        buildDataPointAttributes(gs, isError),
 	}
 	return dp
 }
 
 // buildDataPointAttributes returns OTLP data-point attributes.
-func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode bool) []*otlpcommon.KeyValue {
+func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool) []*otlpcommon.KeyValue {
 	var attrs []*otlpcommon.KeyValue
 
 	// OTel semantic-convention attributes.
 	// Resource (e.g. "GET /users/{id}") maps to span.name.
-	// gs.Name (the Datadog operation name, e.g. "web.request") is intentionally
-	// omitted in OTel mode — it has no OTel semconv equivalent and is only
-	// emitted as datadog.operation.name in default mode below.
 	if gs.Resource != "" {
 		attrs = append(attrs, otlpKeyValue("span.name", otlpStringValue(gs.Resource)))
 	}
@@ -212,41 +205,37 @@ func buildDataPointAttributes(gs *pb.ClientGroupedStats, isError bool, otelMode 
 	// additional_metric_tags support is still evolving/TBD across most SDKs.
 	for _, tag := range gs.AdditionalMetricTags {
 		key, value, ok := strings.Cut(tag, ":")
-		if !ok || key == "" || value == "" || otelMode && isDatadogAttribute(key) {
+		if !ok || key == "" || value == "" {
 			continue
 		}
 		attrs = append(attrs, otlpKeyValue(key, otlpStringValue(value)))
 	}
 
-	// Datadog-specific attributes (default mode only).
-	if !otelMode {
-		if gs.Name != "" {
-			attrs = append(attrs, otlpKeyValue("datadog.operation.name", otlpStringValue(gs.Name)))
-		}
-		if gs.Type != "" {
-			attrs = append(attrs, otlpKeyValue("datadog.span.type", otlpStringValue(gs.Type)))
-		}
-		// top_level is true only when all spans in the group were top-level (TopLevelHits == Hits).
-		attrs = append(attrs, otlpKeyValue("datadog.span.top_level", otlpBoolValue(gs.Hits > 0 && gs.TopLevelHits == gs.Hits)))
-		if gs.IsTraceRoot != pb.Trilean_NOT_SET {
-			attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
-		}
-		if len(gs.PeerTags) > 0 {
-			attrs = append(attrs, otlpKeyValue("datadog.peer_tags", otlpStringArrayValue(gs.PeerTags)))
-		}
-		// ClientGroupedStats carries only a boolean Synthetics field; finer-grained
-		// origin values (synthetics-browser, rum, ciapp-test, lambda) are not available
-		// at the stats aggregation layer and require a proto change upstream to support.
-		if gs.Synthetics {
-			attrs = append(attrs, otlpKeyValue("datadog.origin", otlpStringValue("synthetics")))
-		}
+	if gs.Name != "" {
+		attrs = append(attrs, otlpKeyValue("datadog.operation.name", otlpStringValue(gs.Name)))
+	}
+	if gs.Type != "" {
+		attrs = append(attrs, otlpKeyValue("datadog.span.type", otlpStringValue(gs.Type)))
+	}
+	// top_level is true only when all spans in the group were top-level (TopLevelHits == Hits).
+	attrs = append(attrs, otlpKeyValue("datadog.span.top_level", otlpBoolValue(gs.Hits > 0 && gs.TopLevelHits == gs.Hits)))
+	if gs.IsTraceRoot != pb.Trilean_NOT_SET {
+		attrs = append(attrs, otlpKeyValue("datadog.is_trace_root", otlpBoolValue(gs.IsTraceRoot == pb.Trilean_TRUE)))
+	}
+	if len(gs.PeerTags) > 0 {
+		attrs = append(attrs, otlpKeyValue("datadog.peer_tags", otlpStringArrayValue(gs.PeerTags)))
+	}
+	if gs.ServiceSource != "" {
+		attrs = append(attrs, otlpKeyValue("datadog.svc_src", otlpStringValue(gs.ServiceSource)))
+	}
+	// ClientGroupedStats carries only a boolean Synthetics field; finer-grained
+	// origin values (synthetics-browser, rum, ciapp-test, lambda) are not available
+	// at the stats aggregation layer and require a proto change upstream to support.
+	if gs.Synthetics {
+		attrs = append(attrs, otlpKeyValue("datadog.origin", otlpStringValue("synthetics")))
 	}
 
 	return attrs
-}
-
-func isDatadogAttribute(key string) bool {
-	return strings.HasPrefix(key, "datadog.")
 }
 
 func otlpStringArrayValue(values []string) *otlpcommon.AnyValue {

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -249,10 +249,44 @@ func TestBuildOTLPMetricsRequestMultipleServices(t *testing.T) {
 	assert.Equal(t, "svc-b", kvAttrsToMap(svcBPoint.Attributes)["service.name"])
 }
 
+func TestBuildOTLPMetricsRequestIgnoresOTelSemanticsMode(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
+			t.Cleanup(func() { internalconfig.CreateNew() })
+			t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", strconv.FormatBool(enabled))
+			cfg := internalconfig.CreateNew()
+			assert.Equal(t, enabled, cfg.OTelSemanticsEnabled())
+
+			gs := &pb.ClientGroupedStats{
+				Service:      "svc",
+				Name:         "web.request",
+				Resource:     "/users",
+				Type:         "web",
+				Hits:         1,
+				TopLevelHits: 1,
+				OkSummary:    encodeSketch(t, 50e6),
+			}
+			payload := makePayload("svc", "", "", []*pb.ClientGroupedStats{gs})
+			payload.RuntimeID = "abc-123"
+			payload.ProcessTags = "entrypoint.name:myapp"
+
+			rm := buildOTLPMetricsRequest(payload, cfg)
+			require.Len(t, rm, 1)
+			resourceAttrs := kvAttrsToMap(rm[0].Resource.Attributes)
+			assert.Equal(t, "abc-123", resourceAttrs["datadog.runtime_id"])
+			assert.Equal(t, []string{"entrypoint.name:myapp"}, kvArrayValue(rm[0].Resource.Attributes, "datadog.process_tags"))
+
+			attrs := rm[0].ScopeMetrics[0].Metrics[0].GetHistogram().DataPoints[0].Attributes
+			assert.Equal(t, "web.request", kvAttrsToMap(attrs)["datadog.operation.name"])
+			assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", true)
+		})
+	}
+}
+
 // ---- Resource attributes ----
 
 func TestBuildMetricsResourceSDKAttributes(t *testing.T) {
-	res := buildMetricsResource(makePayload("svc", "", "", nil), false, false, "")
+	res := buildMetricsResource(makePayload("svc", "", "", nil), false, "")
 	m := kvAttrsToMap(res.Attributes)
 	assert.Equal(t, "datadog", m["telemetry.sdk.name"])
 	assert.Equal(t, "go", m["telemetry.sdk.language"])
@@ -260,7 +294,7 @@ func TestBuildMetricsResourceSDKAttributes(t *testing.T) {
 }
 
 func TestBuildMetricsResourceServiceIdentity(t *testing.T) {
-	res := buildMetricsResource(makePayload("my-svc", "prod", "2.1.0", nil), false, false, "")
+	res := buildMetricsResource(makePayload("my-svc", "prod", "2.1.0", nil), false, "")
 	m := kvAttrsToMap(res.Attributes)
 	assert.Equal(t, "my-svc", m["service.name"])
 	assert.Equal(t, "prod", m["deployment.environment.name"])
@@ -268,7 +302,7 @@ func TestBuildMetricsResourceServiceIdentity(t *testing.T) {
 }
 
 func TestBuildMetricsResourceServiceIdentityOmitsEmptyEnvVer(t *testing.T) {
-	res := buildMetricsResource(makePayload("svc", "", "", nil), false, false, "")
+	res := buildMetricsResource(makePayload("svc", "", "", nil), false, "")
 	m := kvAttrsToMap(res.Attributes)
 	assert.Equal(t, "svc", m["service.name"])
 	assert.NotContains(t, m, "deployment.environment.name")
@@ -276,44 +310,33 @@ func TestBuildMetricsResourceServiceIdentityOmitsEmptyEnvVer(t *testing.T) {
 }
 
 func TestBuildMetricsResourceHostnameOmitted(t *testing.T) {
-	res := buildMetricsResource(makePayload("svc", "", "", nil), false, false, "")
+	res := buildMetricsResource(makePayload("svc", "", "", nil), false, "")
 	assert.NotContains(t, kvAttrsToMap(res.Attributes), "host.name")
 }
 
-func TestBuildMetricsResourceProcessTagsDefaultMode(t *testing.T) {
+func TestBuildMetricsResourceProcessTags(t *testing.T) {
 	payload := makePayload("svc", "", "", nil)
 	payload.ProcessTags = "entrypoint.name:myapp,entrypoint.type:binary"
-	res := buildMetricsResource(payload, false /* otelMode */, false, "")
+	res := buildMetricsResource(payload, false, "")
 	values := kvArrayValue(res.Attributes, "datadog.process_tags")
 	assert.ElementsMatch(t, []string{"entrypoint.name:myapp", "entrypoint.type:binary"}, values)
 }
 
-func TestBuildMetricsResourceRuntimeIDDefaultMode(t *testing.T) {
+func TestBuildMetricsResourceRuntimeID(t *testing.T) {
 	payload := makePayload("svc", "", "", nil)
 	payload.RuntimeID = "abc-123"
-	res := buildMetricsResource(payload, false /* otelMode */, false, "")
+	res := buildMetricsResource(payload, false, "")
 	assert.Equal(t, "abc-123", kvAttrsToMap(res.Attributes)["datadog.runtime_id"])
 }
 
 func TestBuildMetricsResourceNoRuntimeIDWhenEmpty(t *testing.T) {
-	res := buildMetricsResource(makePayload("svc", "", "", nil), false, false, "")
+	res := buildMetricsResource(makePayload("svc", "", "", nil), false, "")
 	assert.NotContains(t, kvAttrsToMap(res.Attributes), "datadog.runtime_id")
-}
-
-func TestBuildMetricsResourceOtelModeSuppressesDatadogAttrs(t *testing.T) {
-	// OTel mode must not emit any datadog.* resource attributes (process tags, runtime ID, etc.).
-	payload := makePayload("svc", "", "", nil)
-	payload.ProcessTags = "entrypoint.name:myapp"
-	payload.RuntimeID = "abc-123"
-	res := buildMetricsResource(payload, true /* otelMode */, false, "")
-	m := kvAttrsToMap(res.Attributes)
-	assert.NotContains(t, m, "datadog.process_tags")
-	assert.NotContains(t, m, "datadog.runtime_id")
 }
 
 // ---- Data-point attributes ----
 
-func TestDataPointAttributesOTelMode(t *testing.T) {
+func TestDataPointAttributesIncludeOTelAndDatadogAttributes(t *testing.T) {
 	gs := &pb.ClientGroupedStats{
 		Service:        "api",
 		Name:           "web.request",
@@ -322,14 +345,16 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 		SpanKind:       "server",
 		HTTPMethod:     "GET",
 		HTTPStatusCode: 200,
+		Hits:           1,
 		TopLevelHits:   1,
 		IsTraceRoot:    pb.Trilean_TRUE,
 		AdditionalMetricTags: []string{
 			"customer.tier:gold",
-			"datadog.custom:hidden",
+			"datadog.custom:visible",
 		},
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
+	attrs := buildDataPointAttributes(gs, false)
+	m := kvAttrsToMap(attrs)
 	assert.Equal(t, "/users", m["span.name"])
 	assert.Equal(t, "SPAN_KIND_SERVER", m["span.kind"])
 	assert.Equal(t, "GET", m["http.request.method"])
@@ -337,12 +362,14 @@ func TestDataPointAttributesOTelMode(t *testing.T) {
 	assert.Equal(t, "STATUS_CODE_OK", m["status.code"])
 	assert.Equal(t, "api", m["service.name"])
 	assert.Equal(t, "gold", m["customer.tier"])
-	for key := range m {
-		assert.False(t, isDatadogAttribute(key), "unexpected Datadog attribute %q", key)
-	}
+	assert.Equal(t, "web.request", m["datadog.operation.name"])
+	assert.Equal(t, "web", m["datadog.span.type"])
+	assert.Equal(t, "visible", m["datadog.custom"])
+	assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", true)
+	assertOTLPBoolAttribute(t, attrs, "datadog.is_trace_root", true)
 }
 
-func TestDataPointAttributesDefaultMode(t *testing.T) {
+func TestDataPointAttributesDatadogAttributes(t *testing.T) {
 	gs := &pb.ClientGroupedStats{
 		Name:         "web.request",
 		Resource:     "/users",
@@ -350,7 +377,7 @@ func TestDataPointAttributesDefaultMode(t *testing.T) {
 		Hits:         1,
 		TopLevelHits: 1,
 	}
-	attrs := buildDataPointAttributes(gs, false, false /* default mode */)
+	attrs := buildDataPointAttributes(gs, false)
 	m := kvAttrsToMap(attrs)
 	assert.Equal(t, "web.request", m["datadog.operation.name"])
 	assert.Equal(t, "web", m["datadog.span.type"])
@@ -360,23 +387,23 @@ func TestDataPointAttributesDefaultMode(t *testing.T) {
 func TestDataPointAttributesTopLevelFalse(t *testing.T) {
 	t.Run("no top-level spans in group", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "child-resource", Hits: 1, TopLevelHits: 0}
-		attrs := buildDataPointAttributes(gs, false, false)
+		attrs := buildDataPointAttributes(gs, false)
 		assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", false)
 	})
 	t.Run("mixed group conservatively non-top-level", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Resource: "mixed", Hits: 10, TopLevelHits: 5}
-		attrs := buildDataPointAttributes(gs, false, false)
+		attrs := buildDataPointAttributes(gs, false)
 		assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", false)
 	})
 }
 
 func TestDataPointAttributesStatusCode(t *testing.T) {
 	gs := &pb.ClientGroupedStats{Resource: "/ok"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false /* isError */, true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false /* isError */))
 	assert.Equal(t, "STATUS_CODE_OK", m["status.code"])
 
 	gs = &pb.ClientGroupedStats{Resource: "/err"}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, true /* isError */, true))
+	m = kvAttrsToMap(buildDataPointAttributes(gs, true /* isError */))
 	assert.Equal(t, "STATUS_CODE_ERROR", m["status.code"])
 }
 
@@ -391,7 +418,7 @@ func TestDataPointAttributesSpanKind(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			gs := &pb.ClientGroupedStats{SpanKind: tc.spanKind}
-			m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+			m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 			assert.Equal(t, tc.want, m["span.kind"])
 		})
 	}
@@ -399,19 +426,15 @@ func TestDataPointAttributesSpanKind(t *testing.T) {
 
 func TestDataPointAttributesIsTraceRoot(t *testing.T) {
 	gs := &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
-	attrs := buildDataPointAttributes(gs, false, false /* default mode */)
+	attrs := buildDataPointAttributes(gs, false)
 	assertOTLPBoolAttribute(t, attrs, "datadog.is_trace_root", true)
 
 	gs = &pb.ClientGroupedStats{Resource: "child", IsTraceRoot: pb.Trilean_FALSE}
-	attrs = buildDataPointAttributes(gs, false, false)
+	attrs = buildDataPointAttributes(gs, false)
 	assertOTLPBoolAttribute(t, attrs, "datadog.is_trace_root", false)
 
 	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-	assert.NotContains(t, m, "datadog.is_trace_root")
-
-	gs = &pb.ClientGroupedStats{Resource: "root", IsTraceRoot: pb.Trilean_TRUE}
-	m = kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.NotContains(t, m, "datadog.is_trace_root")
 }
 
@@ -427,15 +450,12 @@ func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {
 		},
 	}
 
-	defaultAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-	assert.Equal(t, "visible-by-default", defaultAttrs["datadog.custom"])
-
-	otelAttrs := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
-	assert.Equal(t, "gold", otelAttrs["customer.tier"])
-	assert.Equal(t, "us-east-1", otelAttrs["region"])
-	assert.NotContains(t, otelAttrs, "datadog.custom")
-	assert.NotContains(t, otelAttrs, "malformed")
-	assert.NotContains(t, otelAttrs, "empty")
+	attrs := kvAttrsToMap(buildDataPointAttributes(gs, false))
+	assert.Equal(t, "gold", attrs["customer.tier"])
+	assert.Equal(t, "us-east-1", attrs["region"])
+	assert.Equal(t, "visible-by-default", attrs["datadog.custom"])
+	assert.NotContains(t, attrs, "malformed")
+	assert.NotContains(t, attrs, "empty")
 }
 
 func TestDataPointAttributesHTTPRoute(t *testing.T) {
@@ -443,14 +463,14 @@ func TestDataPointAttributesHTTPRoute(t *testing.T) {
 		Resource:     "web.request",
 		HTTPEndpoint: "/users/{id}",
 	}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.Equal(t, "/users/{id}", m["http.route"])
 }
 
 func TestDataPointAttributesOptionalFieldsAbsentWhenUnset(t *testing.T) {
 	// Optional OTel attributes are omitted when the corresponding source field is zero/empty.
 	gs := &pb.ClientGroupedStats{Resource: "op"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.NotContains(t, m, "http.route")
 	assert.NotContains(t, m, "rpc.response.status_code")
 }
@@ -460,11 +480,8 @@ func TestDataPointAttributesPeerTags(t *testing.T) {
 		Resource: "postgres.query",
 		PeerTags: []string{"db.hostname:prod-db-1"},
 	}
-	values := kvArrayValue(buildDataPointAttributes(gs, false, false /* default mode */), "datadog.peer_tags")
+	values := kvArrayValue(buildDataPointAttributes(gs, false), "datadog.peer_tags")
 	assert.Contains(t, values, "db.hostname:prod-db-1")
-
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
-	assert.NotContains(t, m, "datadog.peer_tags")
 }
 
 func TestDataPointAttributesGRPCStatusCode(t *testing.T) {
@@ -475,50 +492,58 @@ func TestDataPointAttributesGRPCStatusCode(t *testing.T) {
 		"14": "UNAVAILABLE",
 	} {
 		gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: code}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 		assert.Equal(t, name, m["rpc.response.status_code"], "code %s", code)
 	}
 	// Unknown numeric code: keep as integer (kvAttrsToMap renders it as a decimal string).
 	gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: "99"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.Equal(t, "99", m["rpc.response.status_code"])
 }
 
 func TestDataPointAttributesSyntheticsOrigin(t *testing.T) {
-	// Synthetics=true emits datadog.origin=synthetics in default mode.
 	gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: true}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, false /* default mode */))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.Equal(t, "synthetics", m["datadog.origin"])
 }
 
 func TestDataPointAttributesSyntheticsOriginOmitted(t *testing.T) {
-	t.Run("otel mode", func(t *testing.T) {
-		gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: true}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
-		assert.NotContains(t, m, "datadog.origin")
-	})
-	t.Run("synthetics false", func(t *testing.T) {
-		gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: false}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
-		assert.NotContains(t, m, "datadog.origin")
-	})
+	gs := &pb.ClientGroupedStats{Resource: "web.request", Synthetics: false}
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
+	assert.NotContains(t, m, "datadog.origin")
 }
 
 func TestDataPointAttributesServiceName(t *testing.T) {
 	t.Run("non-default service carries service.name on data point", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Service: "postgres", Resource: "SELECT"}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 		assert.Equal(t, "postgres", m["service.name"])
 	})
 	t.Run("service matching the default/global service is still emitted", func(t *testing.T) {
 		gs := &pb.ClientGroupedStats{Service: "my-app", Resource: "web.request"}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, false))
+		m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 		assert.Equal(t, "my-app", m["service.name"])
 	})
-	t.Run("emitted in OTel-semantics mode too", func(t *testing.T) {
-		gs := &pb.ClientGroupedStats{Service: "my-app", Resource: "web.request"}
-		m := kvAttrsToMap(buildDataPointAttributes(gs, false, true /* otelMode */))
-		assert.Equal(t, "my-app", m["service.name"])
+}
+
+func TestDataPointAttributesServiceSource(t *testing.T) {
+	t.Run("present as string", func(t *testing.T) {
+		attrs := buildDataPointAttributes(&pb.ClientGroupedStats{ServiceSource: "manual"}, false)
+		for _, attr := range attrs {
+			if attr.Key != "datadog.svc_src" {
+				continue
+			}
+			value, ok := attr.Value.Value.(*otlpcommon.AnyValue_StringValue)
+			require.True(t, ok, "datadog.svc_src must use an OTLP string value")
+			assert.Equal(t, "manual", value.StringValue)
+			return
+		}
+		require.Fail(t, "missing datadog.svc_src attribute")
+	})
+
+	t.Run("absent when empty", func(t *testing.T) {
+		attrs := kvAttrsToMap(buildDataPointAttributes(&pb.ClientGroupedStats{}, false))
+		assert.NotContains(t, attrs, "datadog.svc_src")
 	})
 }
 
@@ -545,7 +570,7 @@ func TestDataPointCountEqualsBucketCountSum(t *testing.T) {
 }
 
 func TestBuildMetricsResourceHostnamePresent(t *testing.T) {
-	res := buildMetricsResource(makePayload("svc", "", "", nil), false, true, "myhost")
+	res := buildMetricsResource(makePayload("svc", "", "", nil), true, "myhost")
 	assert.Equal(t, "myhost", kvAttrsToMap(res.Attributes)["host.name"])
 }
 
@@ -579,6 +604,6 @@ func TestDataPointAttributesGRPCStatusCodeStringFallback(t *testing.T) {
 	// Non-numeric GRPCStatusCode is malformed; it is dropped rather than emitting a
 	// value that would change rpc.response.status_code's type across data points.
 	gs := &pb.ClientGroupedStats{Resource: "grpc.request", GRPCStatusCode: "CUSTOM_STATUS"}
-	m := kvAttrsToMap(buildDataPointAttributes(gs, false, true))
+	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.NotContains(t, m, "rpc.response.status_code")
 }

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -249,40 +249,6 @@ func TestBuildOTLPMetricsRequestMultipleServices(t *testing.T) {
 	assert.Equal(t, "svc-b", kvAttrsToMap(svcBPoint.Attributes)["service.name"])
 }
 
-func TestBuildOTLPMetricsRequestIgnoresOTelSemanticsMode(t *testing.T) {
-	for _, enabled := range []bool{false, true} {
-		t.Run(strconv.FormatBool(enabled), func(t *testing.T) {
-			t.Cleanup(func() { internalconfig.CreateNew() })
-			t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", strconv.FormatBool(enabled))
-			cfg := internalconfig.CreateNew()
-			assert.Equal(t, enabled, cfg.OTelSemanticsEnabled())
-
-			gs := &pb.ClientGroupedStats{
-				Service:      "svc",
-				Name:         "web.request",
-				Resource:     "/users",
-				Type:         "web",
-				Hits:         1,
-				TopLevelHits: 1,
-				OkSummary:    encodeSketch(t, 50e6),
-			}
-			payload := makePayload("svc", "", "", []*pb.ClientGroupedStats{gs})
-			payload.RuntimeID = "abc-123"
-			payload.ProcessTags = "entrypoint.name:myapp"
-
-			rm := buildOTLPMetricsRequest(payload, cfg)
-			require.Len(t, rm, 1)
-			resourceAttrs := kvAttrsToMap(rm[0].Resource.Attributes)
-			assert.Equal(t, "abc-123", resourceAttrs["datadog.runtime_id"])
-			assert.Equal(t, []string{"entrypoint.name:myapp"}, kvArrayValue(rm[0].Resource.Attributes, "datadog.process_tags"))
-
-			attrs := rm[0].ScopeMetrics[0].Metrics[0].GetHistogram().DataPoints[0].Attributes
-			assert.Equal(t, "web.request", kvAttrsToMap(attrs)["datadog.operation.name"])
-			assertOTLPBoolAttribute(t, attrs, "datadog.span.top_level", true)
-		})
-	}
-}
-
 // ---- Resource attributes ----
 
 func TestBuildMetricsResourceSDKAttributes(t *testing.T) {

--- a/ddtrace/tracer/stats_to_otlp_metrics_test.go
+++ b/ddtrace/tracer/stats_to_otlp_metrics_test.go
@@ -402,6 +402,10 @@ func TestDataPointAttributesIsTraceRoot(t *testing.T) {
 	gs = &pb.ClientGroupedStats{Resource: "unknown", IsTraceRoot: pb.Trilean_NOT_SET}
 	m := kvAttrsToMap(buildDataPointAttributes(gs, false))
 	assert.NotContains(t, m, "datadog.is_trace_root")
+
+	gs = &pb.ClientGroupedStats{Resource: "invalid", IsTraceRoot: pb.Trilean(99)}
+	m = kvAttrsToMap(buildDataPointAttributes(gs, false))
+	assert.NotContains(t, m, "datadog.is_trace_root")
 }
 
 func TestDataPointAttributesAdditionalMetricTags(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

- Makes OTLP trace metrics ignore `DD_TRACE_OTEL_SEMANTICS_ENABLED`; available OTel and `datadog.*` resource/data-point attributes are always emitted together.
- Exports a non-empty `ClientGroupedStats.ServiceSource` as the OTLP string attribute `datadog.svc_src` and omits it when absent.
- Removes trace-metrics-only mode plumbing while preserving OTel-semantics behavior for trace export.
- Emits known trace-root values as native Booleans and omits unset or unrecognized values. Adds focused coverage for unconditional attributes and service-source presence, absence, and typing.

### Motivation

Follow-up to merged #5130 for the revised cross-SDK OTLP trace-metrics contract. Shared coverage is tracked in DataDog/system-tests#7466.

### Validation

- `go test ./ddtrace/tracer -count=1`
- `go vet ./ddtrace/tracer`
- `make format/go`
- `./bin/golangci-lint run --new-from-rev=origin/main ./ddtrace/tracer`

### Reviewer's Checklist

- [x] Changed code has focused unit coverage.
- [x] Shared system-test coverage is added in DataDog/system-tests#7466.
- [x] No generated files, dependencies, or public APIs changed.
