### PR TITLE
perf(ddtrace/opentelemetry): batch baggage sync in oteltracer.Start

### DIFF
--- a/ddtrace/baggage/baggage.go
+++ b/ddtrace/baggage/baggage.go
@@ -45,6 +45,25 @@ func Set(ctx context.Context, key, value string) context.Context {
 	return withBaggage(ctx, bm)
 }
 
+// SetAll merges multiple key/value pairs into the baggage in a single context write.
+// Equivalent to calling Set once per entry in values, but only clones the baggage map
+// once instead of once per key. Prefer this over a Set loop when writing more than one
+// key at a time, e.g. when reconciling baggage from another source.
+func SetAll(ctx context.Context, values map[string]string) context.Context {
+	if len(values) == 0 {
+		return ctx
+	}
+
+	bm, ok := baggageMap(ctx)
+	merged := make(map[string]string, len(bm)+len(values))
+	if ok {
+		maps.Copy(merged, bm)
+	}
+	maps.Copy(merged, values)
+
+	return withBaggage(ctx, merged)
+}
+
 // Get retrieves the value associated with a baggage key.
 // If the key isn't found, it returns an empty string.
 func Get(ctx context.Context, key string) (string, bool) {

--- a/ddtrace/baggage/baggage_test.go
+++ b/ddtrace/baggage/baggage_test.go
@@ -70,6 +70,40 @@ func TestBaggageFunctions(t *testing.T) {
 		}
 	})
 
+	t.Run("SetAll merges into existing baggage", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = Set(ctx, "existing", "value")
+		ctx = SetAll(ctx, map[string]string{"a": "1", "b": "2"})
+
+		all := All(ctx)
+		assert.Equal(t, map[string]string{"existing": "value", "a": "1", "b": "2"}, all)
+	})
+
+	t.Run("SetAll overwrites existing keys", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = Set(ctx, "key", "original")
+		ctx = SetAll(ctx, map[string]string{"key": "updated"})
+
+		got, _ := Get(ctx, "key")
+		assert.Equal(t, "updated", got)
+	})
+
+	t.Run("SetAll with empty map is a no-op", func(t *testing.T) {
+		ctx := Set(context.Background(), "key", "value")
+		result := SetAll(ctx, map[string]string{})
+
+		assert.True(t, ctx == result, "SetAll with no values should return the same context") //nolint
+	})
+
+	t.Run("SetAll does not allow external mutation", func(t *testing.T) {
+		m := map[string]string{"key": "original"}
+		ctx := SetAll(context.Background(), m)
+		m["key"] = "mutated"
+
+		got, _ := Get(ctx, "key")
+		assert.Equal(t, "original", got)
+	})
+
 	t.Run("Remove", func(t *testing.T) {
 		ctx := context.Background()
 

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -102,9 +102,12 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 
 	// Merge baggage from otel and dd, update Datadog baggage, and update the context.
 	mergedBag := mergeBaggageFromContext(ctx)
-	for _, m := range mergedBag.Members() {
-		ctx = baggage.Set(ctx, m.Key(), m.Value())
+	members := mergedBag.Members()
+	ddBag := make(map[string]string, len(members))
+	for _, m := range members {
+		ddBag[m.Key()] = m.Value()
 	}
+	ctx = baggage.SetAll(ctx, ddBag)
 	ctx = otelbaggage.ContextWithBaggage(ctx, mergedBag)
 
 	os := oteltrace.Span(&span{


### PR DESCRIPTION
### What does this PR do?

`oteltracer.Start` (`ddtrace/opentelemetry/tracer.go`) merges OTel and Datadog-native baggage on **every span start**, then writes the merged set into `ddtrace/baggage` by calling `Set()` once per key:

```go
mergedBag := mergeBaggageFromContext(ctx)
for _, m := range mergedBag.Members() {
    ctx = baggage.Set(ctx, m.Key(), m.Value())
}
```

`baggage.Set()` clones the *entire* baggage map on every call (`ddtrace/baggage/baggage.go`). Since this loop runs on every span (not just the root span) for every baggage key, a request with N spans and M baggage members does O(N×M) map clones and `context.WithValue` calls for this sync step alone — most of them redundant rewrites of values that haven't changed since the previous span.

This PR adds `baggage.SetAll(ctx, map[string]string)`, which merges a whole batch of keys into the existing baggage with a single clone and a single `context.WithValue`, and updates `oteltracer.Start` to build the merged map once and call `SetAll` instead of looping `Set()`.

No behavior change — same end-state baggage contents on the context, just fewer allocations per span.

### Motivation

We noticed via a context-chain diagnostic on one of our services (many `context.Context` nodes accumulating per request) that this loop was contributing a disproportionate number of `baggage.baggageKey` context nodes relative to the actual number of distinct baggage keys in use (4 keys → up to ~9 context nodes observed across a single request's spans, from partial-then-full rebuilds on each span start).

I didn't find an existing issue for this, and confirmed it's still present in the current `main` (this loop hasn't been touched since it was introduced in #3362, aside from an unrelated logging refactor). It looks adjacent to the baggage-performance work already landed this week (#5119, #5120), but those are scoped to `ddtrace/tracer/textmap.go`'s propagator extraction path, not this OTel-bridge merge step.

Opening as a draft since I'm an external contributor and want to confirm this is the direction you'd want before polishing further (benchmark, etc.) — happy to add a benchmark and expand test coverage per the checklist below if this approach looks right.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality (added `SetAll` merge/overwrite/no-op/no-external-mutation cases in `baggage_test.go`; existing `TestMergeOtelDDBaggage` and `TestHttpDistributedTraceWithBaggage` in `ddtrace/opentelemetry` pass unchanged).
- [ ] System-Tests covering this feature have been added and enabled — not added yet, happy to if this direction is right.
- [ ] There is a benchmark for any new code, or changes to existing code — not added yet, happy to if useful.
- [ ] If this interacts with the agent in a new way — N/A, no agent-facing change.
- [x] New code is free of linting errors (`gofmt`, `go vet` clean on changed files).
- [x] New code doesn't break existing tests (`go test -race ./ddtrace/baggage/... ./ddtrace/opentelemetry/...` passes).
- [ ] Add an appropriate team label — not able to as an external contributor.
- [x] No generated files affected.
- [x] No go.mod changes.