### PR TITLE
fix(contrib): bound gzip-decompressed size in Elasticsearch body snippets

### DIFF
--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -128,6 +128,9 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	if rc == nil {
 		return "", rc, errors.New("empty stream")
 	}
+	// A gzip stream can inflate ~1000x, so the decompressed snippet is bounded by
+	// the caller's limit rather than by however few compressed bytes n is lowered to.
+	cutoff := n
 	if max > 0 && max < n {
 		n = max
 	}
@@ -154,7 +157,7 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 			return string(snip), rc2, nil
 		}
 		defer gzr.Close()
-		snip, err = io.ReadAll(gzr)
+		snip, err = io.ReadAll(io.LimitReader(gzr, int64(cutoff)))
 	}
 	return string(snip), rc2, err
 }

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -7,13 +7,21 @@ package elastic
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const debug = false
@@ -135,4 +143,77 @@ func TestPeek(t *testing.T) {
 			assert.Equal(tt.txt, string(all))
 		}
 	}
+}
+
+// gzipped returns b compressed as a single gzip member.
+func gzipped(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	require.NoError(t, err)
+	_, err = zw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestPeekGzip(t *testing.T) {
+	t.Run("bomb fits in the peek window", func(t *testing.T) {
+		gz := gzipped(t, make([]byte, 4<<20))
+		require.Less(t, len(gz), bodyCutoff)
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Len(t, snip, bodyCutoff)
+	})
+
+	t.Run("bomb exceeds the peek window", func(t *testing.T) {
+		gz := gzipped(t, make([]byte, 8<<20))
+		require.Greater(t, len(gz), bodyCutoff)
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Len(t, snip, bodyCutoff)
+	})
+
+	t.Run("small body decodes in full", func(t *testing.T) {
+		body := `{"error":{"type":"index_not_found_exception"}}`
+		gz := gzipped(t, []byte(body))
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Equal(t, body, snip)
+	})
+}
+
+func TestRoundTripperGzipBodyCutoff(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	bomb := gzipped(t, make([]byte, 4<<20))
+	require.Less(t, len(bomb), bodyCutoff)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bomb)))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	reqBody := `{"query":{"match_all":{}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/twitter/_search", bytes.NewReader(gzipped(t, []byte(reqBody))))
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+	// Set explicitly: otherwise net/http adds it itself, transparently inflates the
+	// response, and strips Content-Encoding before peek() ever sees a gzip stream.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := (&http.Client{Transport: NewRoundTripper()}).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, reqBody, span.Tag("elasticsearch.body"))
+	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
 }

--- a/contrib/olivere/elastic.v5/elastictrace.go
+++ b/contrib/olivere/elastic.v5/elastictrace.go
@@ -129,6 +129,9 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	if rc == nil {
 		return "", rc, errors.New("empty stream")
 	}
+	// A gzip stream can inflate ~1000x, so the decompressed snippet is bounded by
+	// the caller's limit rather than by however few compressed bytes n is lowered to.
+	cutoff := n
 	if max > 0 && max < n {
 		n = max
 	}
@@ -155,7 +158,7 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 			return string(snip), rc2, nil
 		}
 		defer gzr.Close()
-		snip, err = io.ReadAll(gzr)
+		snip, err = io.ReadAll(io.LimitReader(gzr, int64(cutoff)))
 	}
 	return string(snip), rc2, err
 }

--- a/contrib/olivere/elastic.v5/elastictrace_test.go
+++ b/contrib/olivere/elastic.v5/elastictrace_test.go
@@ -7,11 +7,15 @@ package elastic
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -19,6 +23,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/testutils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/olivere/elastic.v5"
 )
 
@@ -357,6 +362,79 @@ func TestPeek(t *testing.T) {
 			assert.Equal(tt.txt, string(all))
 		}
 	}
+}
+
+// gzipped returns b compressed as a single gzip member.
+func gzipped(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	require.NoError(t, err)
+	_, err = zw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestPeekGzip(t *testing.T) {
+	t.Run("bomb fits in the peek window", func(t *testing.T) {
+		gz := gzipped(t, make([]byte, 4<<20))
+		require.Less(t, len(gz), bodyCutoff)
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Len(t, snip, bodyCutoff)
+	})
+
+	t.Run("bomb exceeds the peek window", func(t *testing.T) {
+		gz := gzipped(t, make([]byte, 8<<20))
+		require.Greater(t, len(gz), bodyCutoff)
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Len(t, snip, bodyCutoff)
+	})
+
+	t.Run("small body decodes in full", func(t *testing.T) {
+		body := `{"error":{"type":"index_not_found_exception"}}`
+		gz := gzipped(t, []byte(body))
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "gzip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Equal(t, body, snip)
+	})
+}
+
+func TestHTTPClientGzipBodyCutoff(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	bomb := gzipped(t, make([]byte, 4<<20))
+	require.Less(t, len(bomb), bodyCutoff)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bomb)))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	reqBody := `{"query":{"match_all":{}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/twitter/_search", bytes.NewReader(gzipped(t, []byte(reqBody))))
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+	// Set explicitly: otherwise net/http adds it itself, transparently inflates the
+	// response, and strips Content-Encoding before peek() ever sees a gzip stream.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := NewHTTPClient().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, reqBody, span.Tag("elasticsearch.body"))
+	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
 }
 
 func TestAnalyticsSettings(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Two identical fixes, one commit each, in the Elasticsearch contrib integrations' shared `peek()` helper:

1. **contrib/elastic/go-elasticsearch.v6**: wraps the `gzip.Reader` in `io.LimitReader(gzr, int64(cutoff))` before `io.ReadAll`, so the decompressed body snippet is capped at the same `bodyCutoff` (5 KiB) as the compressed input.
2. **contrib/olivere/elastic.v5**: the identical fix, same root cause, separate package.

`peek()` reads at most `bodyCutoff` of the *compressed* HTTP body, but on `Content-Encoding: gzip` it then ran `io.ReadAll` over the `gzip.Reader` with no output limit. DEFLATE's ~1032:1 ceiling means those 5 KiB inflate to ~5 MiB of heap inside the tracer on every captured body (`elasticsearch.body` tag, or the error tag on a non-2xx response) — a compromised or spoofed Elasticsearch backend can drive that allocation across concurrent requests.

Each commit adds:
- `TestPeekGzip`, unit-level against `peek()` directly: a bomb that fits the 5 KiB window, one that exceeds it, and a small legitimate gzip body that still decodes in full.
- An end-to-end `httptest`-backed test (`TestRoundTripperGzipBodyCutoff` / `TestHTTPClientGzipBodyCutoff`) driving the real `RoundTrip`/`HTTPClient`, confirming the captured error tag is bounded to `bodyCutoff` bytes.

**One observable side effect, unavoidable and beneficial.** When the compressed member is larger than the peek window, the snippet is a *truncated* gzip stream. Before this fix, `io.ReadAll(gzr)` inflated the truncated stream, hit `io.ErrUnexpectedEOF`, and the caller fell back to `http.StatusText(code)`. With the bound, `LimitReader` returns EOF before the truncation is reached, so `peek()` now returns a clean 5 KiB snippet and `nil` — callers get the real (truncated) ES error body where they previously got a generic status string.

### Motivation

Low, CVSS 3.7: unbounded gzip decompression in Elasticsearch error-snippet capture allows a malicious/compromised ES backend to force excess heap allocation in the tracer.

**Known adjacent issue, deliberately not fixed here:** `RoundTrip` in both packages reads `Content-Encoding` from the *request* header and reuses that value when peeking the *response* body — `res.Header.Get("Content-Encoding")` is never consulted. This gates reachability of the bug fixed in this PR (the backend-controlled bomb only lands if the client also compresses its requests), and is a separate, pre-existing, lower-severity correctness bug (a gzip-compressed response won't be decoded if the request wasn't also compressed). Fixing it would *widen* what triggers gzip decompression, so it must not ride along with this security fix. Tracked separately.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.