### PR TITLE
fix(contrib): use each body's own Content-Encoding in Elasticsearch peek()

### DIFF
--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -148,7 +149,7 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	if err != nil {
 		return string(snip), rc2, err
 	}
-	if encoding == "gzip" {
+	if strings.EqualFold(encoding, "gzip") {
 		// unpack the snippet
 		gzr, err2 := gzip.NewReader(bytes.NewReader(snip))
 		if err2 != nil {

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -76,8 +76,7 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	span, _ := tracer.StartSpanFromContext(req.Context(), t.config.operationName, opts...)
 	defer span.Finish()
 
-	contentEncoding := req.Header.Get("Content-Encoding")
-	snip, rc, err := peek(req.Body, contentEncoding, int(req.ContentLength), bodyCutoff)
+	snip, rc, err := peek(req.Body, req.Header.Get("Content-Encoding"), int(req.ContentLength), bodyCutoff)
 	if err == nil {
 		span.SetTag("elasticsearch.body", snip)
 	}
@@ -89,7 +88,7 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		span.SetTag(ext.Error, err)
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
 		// HTTP error
-		snip, rc, err := peek(res.Body, contentEncoding, int(res.ContentLength), bodyCutoff)
+		snip, rc, err := peek(res.Body, res.Header.Get("Content-Encoding"), int(res.ContentLength), bodyCutoff)
 		if err != nil {
 			snip = http.StatusText(res.StatusCode)
 		}

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -248,3 +248,36 @@ func TestRoundTripperGzipErrorResponseUncompressedRequest(t *testing.T) {
 	span := mt.FinishedSpans()[0]
 	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
 }
+
+// TestRoundTripperGzipBodyCutoffUncompressedRequest covers the path TestRoundTripperGzipBodyCutoff
+// doesn't: a gzip-bomb response arriving on an uncompressed request. Content-Encoding is now read
+// from the response's own header, so this path decodes gzip where it previously wouldn't have; it
+// must still respect bodyCutoff.
+func TestRoundTripperGzipBodyCutoffUncompressedRequest(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	bomb := gzipped(t, make([]byte, 4<<20))
+	require.Less(t, len(bomb), bodyCutoff)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bomb)))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/twitter/_search", nil)
+	require.NoError(t, err)
+	// Set explicitly: otherwise net/http requests gzip on its own, transparently
+	// inflates the response, and strips Content-Encoding before peek() sees it.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := (&http.Client{Transport: NewRoundTripper()}).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
+}

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -184,6 +184,16 @@ func TestPeekGzip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, body, snip)
 	})
+
+	t.Run("encoding casing is ignored", func(t *testing.T) {
+		// Content-Encoding is a case-insensitive HTTP token (RFC 9110 8.4.1).
+		body := `{"error":{"type":"index_not_found_exception"}}`
+		gz := gzipped(t, []byte(body))
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "GZip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Equal(t, body, snip)
+	})
 }
 
 func TestRoundTripperGzipBodyCutoff(t *testing.T) {
@@ -280,4 +290,38 @@ func TestRoundTripperGzipBodyCutoffUncompressedRequest(t *testing.T) {
 
 	span := mt.FinishedSpans()[0]
 	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
+}
+
+// TestRoundTripperGzipResponseCaseInsensitiveEncoding is a regression test: peek() must treat
+// Content-Encoding as case-insensitive per RFC 9110 8.4.1. A gzip-compressed request must not
+// prevent decoding a gzip-compressed response whose header uses different casing.
+func TestRoundTripperGzipResponseCaseInsensitiveEncoding(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	errBody := `{"error":{"type":"index_not_found_exception"}}`
+	gz := gzipped(t, []byte(errBody))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "GZip")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(gz)
+	}))
+	defer srv.Close()
+
+	reqBody := `{"query":{"match_all":{}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/twitter/_search", bytes.NewReader(gzipped(t, []byte(reqBody))))
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+	// Set explicitly: otherwise net/http adds it itself, transparently inflates the
+	// response, and strips Content-Encoding before peek() ever sees a gzip stream.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := (&http.Client{Transport: NewRoundTripper()}).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, reqBody, span.Tag("elasticsearch.body"))
+	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
 }

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -217,3 +217,34 @@ func TestRoundTripperGzipBodyCutoff(t *testing.T) {
 	assert.Equal(t, reqBody, span.Tag("elasticsearch.body"))
 	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
 }
+
+// TestRoundTripperGzipErrorResponseUncompressedRequest is a regression test: peek() must use
+// each body's own Content-Encoding header. A gzip-compressed error response must be decoded
+// even when the request itself was not gzip-compressed.
+func TestRoundTripperGzipErrorResponseUncompressedRequest(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	errBody := `{"error":{"type":"index_not_found_exception"}}`
+	gz := gzipped(t, []byte(errBody))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(gz)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/twitter/_search", nil)
+	require.NoError(t, err)
+	// Set explicitly: otherwise net/http requests gzip on its own, transparently
+	// inflates the response, and strips Content-Encoding before peek() sees it.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := (&http.Client{Transport: NewRoundTripper()}).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
+}

--- a/contrib/olivere/elastic.v5/elastictrace.go
+++ b/contrib/olivere/elastic.v5/elastictrace.go
@@ -78,8 +78,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	span, _ := tracer.StartSpanFromContext(req.Context(), t.config.spanName, opts...)
 	defer span.Finish()
 
-	contentEncoding := req.Header.Get("Content-Encoding")
-	snip, rc, err := peek(req.Body, contentEncoding, int(req.ContentLength), bodyCutoff)
+	snip, rc, err := peek(req.Body, req.Header.Get("Content-Encoding"), int(req.ContentLength), bodyCutoff)
 	if err == nil {
 		span.SetTag("elasticsearch.body", snip)
 	}
@@ -91,7 +90,7 @@ func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		span.SetTag(ext.Error, err)
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
 		// HTTP error
-		snip, rc, err := peek(res.Body, contentEncoding, int(res.ContentLength), bodyCutoff)
+		snip, rc, err := peek(res.Body, res.Header.Get("Content-Encoding"), int(res.ContentLength), bodyCutoff)
 		if err != nil {
 			snip = http.StatusText(res.StatusCode)
 		}

--- a/contrib/olivere/elastic.v5/elastictrace.go
+++ b/contrib/olivere/elastic.v5/elastictrace.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -149,7 +150,7 @@ func peek(rc io.ReadCloser, encoding string, max, n int) (string, io.ReadCloser,
 	if err != nil {
 		return string(snip), rc2, err
 	}
-	if encoding == "gzip" {
+	if strings.EqualFold(encoding, "gzip") {
 		// unpack the snippet
 		gzr, err2 := gzip.NewReader(bytes.NewReader(snip))
 		if err2 != nil {

--- a/contrib/olivere/elastic.v5/elastictrace_test.go
+++ b/contrib/olivere/elastic.v5/elastictrace_test.go
@@ -437,6 +437,37 @@ func TestHTTPClientGzipBodyCutoff(t *testing.T) {
 	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
 }
 
+// TestHTTPClientGzipErrorResponseUncompressedRequest is a regression test: peek() must use
+// each body's own Content-Encoding header. A gzip-compressed error response must be decoded
+// even when the request itself was not gzip-compressed.
+func TestHTTPClientGzipErrorResponseUncompressedRequest(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	errBody := `{"error":{"type":"index_not_found_exception"}}`
+	gz := gzipped(t, []byte(errBody))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(gz)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/twitter/_search", nil)
+	require.NoError(t, err)
+	// Set explicitly: otherwise net/http requests gzip on its own, transparently
+	// inflates the response, and strips Content-Encoding before peek() sees it.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := NewHTTPClient().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
+}
+
 func TestAnalyticsSettings(t *testing.T) {
 	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
 		tc := NewHTTPClient(opts...)

--- a/contrib/olivere/elastic.v5/elastictrace_test.go
+++ b/contrib/olivere/elastic.v5/elastictrace_test.go
@@ -403,6 +403,16 @@ func TestPeekGzip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, body, snip)
 	})
+
+	t.Run("encoding casing is ignored", func(t *testing.T) {
+		// Content-Encoding is a case-insensitive HTTP token (RFC 9110 8.4.1).
+		body := `{"error":{"type":"index_not_found_exception"}}`
+		gz := gzipped(t, []byte(body))
+
+		snip, _, err := peek(io.NopCloser(bytes.NewReader(gz)), "GZip", len(gz), bodyCutoff)
+		require.NoError(t, err)
+		assert.Equal(t, body, snip)
+	})
 }
 
 func TestHTTPClientGzipBodyCutoff(t *testing.T) {
@@ -499,6 +509,40 @@ func TestHTTPClientGzipBodyCutoffUncompressedRequest(t *testing.T) {
 
 	span := mt.FinishedSpans()[0]
 	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
+}
+
+// TestHTTPClientGzipResponseCaseInsensitiveEncoding is a regression test: peek() must treat
+// Content-Encoding as case-insensitive per RFC 9110 8.4.1. A gzip-compressed request must not
+// prevent decoding a gzip-compressed response whose header uses different casing.
+func TestHTTPClientGzipResponseCaseInsensitiveEncoding(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	errBody := `{"error":{"type":"index_not_found_exception"}}`
+	gz := gzipped(t, []byte(errBody))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "GZip")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(gz)
+	}))
+	defer srv.Close()
+
+	reqBody := `{"query":{"match_all":{}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/twitter/_search", bytes.NewReader(gzipped(t, []byte(reqBody))))
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+	// Set explicitly: otherwise net/http adds it itself, transparently inflates the
+	// response, and strips Content-Encoding before peek() ever sees a gzip stream.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := NewHTTPClient().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, reqBody, span.Tag("elasticsearch.body"))
+	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
 }
 
 func TestAnalyticsSettings(t *testing.T) {

--- a/contrib/olivere/elastic.v5/elastictrace_test.go
+++ b/contrib/olivere/elastic.v5/elastictrace_test.go
@@ -468,6 +468,39 @@ func TestHTTPClientGzipErrorResponseUncompressedRequest(t *testing.T) {
 	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
 }
 
+// TestHTTPClientGzipBodyCutoffUncompressedRequest covers the path TestHTTPClientGzipBodyCutoff
+// doesn't: a gzip-bomb response arriving on an uncompressed request. Content-Encoding is now read
+// from the response's own header, so this path decodes gzip where it previously wouldn't have; it
+// must still respect bodyCutoff.
+func TestHTTPClientGzipBodyCutoffUncompressedRequest(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	bomb := gzipped(t, make([]byte, 4<<20))
+	require.Less(t, len(bomb), bodyCutoff)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bomb)))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/twitter/_search", nil)
+	require.NoError(t, err)
+	// Set explicitly: otherwise net/http requests gzip on its own, transparently
+	// inflates the response, and strips Content-Encoding before peek() sees it.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	res, err := NewHTTPClient().Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Len(t, span.Tag(ext.ErrorMsg).(string), bodyCutoff)
+}
+
 func TestAnalyticsSettings(t *testing.T) {
 	assertRate := func(t *testing.T, mt mocktracer.Tracer, rate interface{}, opts ...ClientOption) {
 		tc := NewHTTPClient(opts...)


### PR DESCRIPTION
### What does this PR do?

**Stacked on #5159** — this PR's base is `dario.castane/wizardly-hermann-e49a8a` (the branch backing #5159), not `main`. See "Update" below for why.

Two identical fixes, one commit each, in the Elasticsearch contrib integrations' shared `peek()` call sites:

1. **contrib/elastic/go-elasticsearch.v6**: `RoundTrip` now peeks the request body with `req.Header.Get("Content-Encoding")` and the response body with `res.Header.Get("Content-Encoding")`.
2. **contrib/olivere/elastic.v5**: the identical fix, same root cause, separate package.

`RoundTrip` in both packages read `Content-Encoding` once from the *request* header and reused that single value for both the request-body peek and the response-body peek. `res.Header.Get("Content-Encoding")` was never consulted. A response can be compressed independently of its request, so an uncompressed request paired with a gzip-compressed error response left `peek()` skipping decompression — the raw gzip bytes ended up in the `elasticsearch.body`/error tags instead of the decoded text. This is visible in production APM error tags for any Elasticsearch server that gzips its error responses independent of request compression.

Each fix commit adds `TestRoundTripperGzipErrorResponseUncompressedRequest` / `TestHTTPClientGzipErrorResponseUncompressedRequest`: an `httptest` server returns a gzip-compressed error body while the request itself is not gzip-compressed, asserting the captured error tag contains the decoded text rather than raw gzip bytes. Verified both regression tests actually catch the bug (temporarily reverted just the source fix and confirmed both failed with raw gzip bytes in the tag) before confirming they pass with the fix.

### Update: stacked on #5159 after Codex review

Codex flagged a real interaction in [these two comments](https://github.com/DataDog/dd-trace-go/pull/5160#discussion_r3736866343): before this fix, the response-body peek reused the *request's* `Content-Encoding`, so `peek()`'s unbounded `io.ReadAll(gzr)` (fixed in #5159, still open at the time) only ran on a response if the request was *also* compressed. That accidentally gated reachability of the size-bomb bug #5159 fixes. This PR's fix removes that gate — a gzip-compressed error response now decodes regardless of request compression — which widens reachability of #5159's bug for as long as #5159 isn't merged.

Rather than duplicating #5159's `io.LimitReader` bound in this PR (the two fixes were deliberately kept in separate PRs for focused review), this PR is now based on #5159's branch so it can't land before the bound does. Two more commits add direct coverage for the exact interaction Codex called out: a gzip-bomb response on an *uncompressed* request, confirming the decompressed error tag still respects `bodyCutoff` on this newly-reachable path.

### Motivation

This is the deliberately-not-fixed adjacent issue called out in #5159 (bounding gzip-decompressed size in the same `peek()` helper): a separate, lower-severity, pre-existing correctness bug that needed its own review/testing since fixing it widens what triggers gzip decompression.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.