### PR TITLE
fix(ddtrace/tracer): decouple trace protocol v1.0 from client-side stats

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -164,4 +164,13 @@
 //
 // or the environment variable DD_TRACE_STATS_ADDITIONAL_TAGS (comma-separated).
 // This feature requires DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED=true.
+//
+// # Trace Protocol
+//
+// Client-side stats computation is independent of the Datadog trace protocol
+// version (DD_TRACE_AGENT_PROTOCOL_VERSION). Disabling stats computation does
+// not change the wire format used to send traces, and selecting a protocol
+// version does not enable or disable stats computation. The protocol falls
+// back from 1.0 to 0.4 only when the Datadog Agent does not advertise the
+// /v1.0/traces endpoint.
 package tracer // import "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"

--- a/ddtrace/tracer/log.go
+++ b/ddtrace/tracer/log.go
@@ -148,7 +148,10 @@ func logStartup(t *tracer) {
 		injectorNames = "custom"
 		extractorNames = "custom"
 	}
-	proto := t.config.internalConfig.RequestedTraceProtocol()
+	// The agent snapshot is loaded once so agent_features and the protocol the
+	// endpoint probe targets cannot come from two different /info responses.
+	af := t.config.agent.load()
+	proto := t.config.effectiveTraceProtocolWithAgent(af)
 
 	// Determine the agent URL to use in the logs.
 	// Use the source URL from internalConfig for unix sockets (before UDS rewriting).
@@ -184,7 +187,7 @@ func logStartup(t *tracer) {
 		Architecture:                runtime.GOARCH,
 		GlobalService:               globalconfig.ServiceName(),
 		LambdaMode:                  strconv.FormatBool(t.config.internalConfig.LogToStdout()),
-		AgentFeatures:               t.config.agent.load(),
+		AgentFeatures:               af,
 		Integrations:                t.config.integrations,
 		AppSec:                      appsec.Enabled(),
 		PartialFlushEnabled:         partialFlushEnabled,

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -330,17 +330,11 @@ func newConfig(opts ...StartOption) (*config, error) {
 	agentURL := c.internalConfig.AgentURL()
 	af := loadAgentFeatures(agentDisabled, agentURL, c.httpClient)
 	c.agent.store(af)
-	// If the agent doesn't support the v1 protocol, downgrade to v0.4.
-	// Also downgrade if CSS is disabled (v1 requires CSS); this is independent
-	// of OTLP span metrics, which no longer affect RequestedTraceProtocol()
-	// (see internal/config).
-	//
-	// Only the config is downgraded: the transport holds a URL per protocol and
-	// picks between them from the payload's own protocol at send time, so it has
-	// nothing left to keep in sync with this decision.
-	if c.internalConfig.RequestedTraceProtocol() == traceProtocolV1 && (!af.v1ProtocolAvailable || !c.canComputeStats()) {
-		c.internalConfig.SetTraceProtocol(traceProtocolV04, internalconfig.OriginCalculated)
-	}
+	// The wire protocol is derived per-use from the requested protocol and the
+	// agent's advertised endpoints (see (*config).effectiveTraceProtocol);
+	// nothing is baked into the transport or downgraded in config here. Report
+	// the resolved value to config telemetry so it reflects what is on the wire.
+	c.internalConfig.ReportEffectiveTraceProtocol(c.effectiveTraceProtocol())
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
@@ -711,6 +705,27 @@ func (c *config) canComputeStatsWithAgent(a agentFeatures) bool {
 // of the Client-Side Stats feature and cannot be enabled independently.
 func (c *config) canDropP0s() bool {
 	return c.canComputeStats()
+}
+
+// effectiveTraceProtocol returns the wire protocol in use right now: the
+// requested protocol, downgraded to v0.4 when the agent does not advertise
+// /v1.0/traces. It is a pure function of (requested config, agent features),
+// re-evaluated on every call. Client-side stats are deliberately absent from
+// this check: CSS has no bearing on the wire format — the Agent has always
+// accepted v1.0 payloads without it.
+func (c *config) effectiveTraceProtocol() float64 {
+	return c.effectiveTraceProtocolWithAgent(c.agent.load())
+}
+
+// effectiveTraceProtocolWithAgent resolves the protocol against a caller-held
+// agent snapshot, so a caller that reports several agent-derived values at
+// once can keep them all consistent with one /info response. Mirrors the
+// canComputeStats/canComputeStatsWithAgent pair above.
+func (c *config) effectiveTraceProtocolWithAgent(a agentFeatures) float64 {
+	if c.internalConfig.RequestedTraceProtocol() == traceProtocolV1 && a.v1ProtocolAvailable {
+		return traceProtocolV1
+	}
+	return traceProtocolV04
 }
 
 func statsTags(c *config) []string {
@@ -1162,6 +1177,9 @@ func WithPartialFlushing(numSpans int) StartOption {
 // traffic to the Datadog Agent, and produce more accurate stats data.
 // This can also be configured by setting DD_TRACE_STATS_COMPUTATION_ENABLED.
 // Client-side stats is on by default.
+//
+// This option does not affect the Datadog trace protocol version used to send
+// traces; see DD_TRACE_AGENT_PROTOCOL_VERSION.
 func WithStatsComputation(enabled bool) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetStatsComputationEnabled(enabled, internalconfig.OriginCode)

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -1926,11 +1926,24 @@ func TestWithStatsComputation(t *testing.T) {
 		assert.True(c.internalConfig.StatsComputationEnabled())
 	})
 	t.Run("disabled-via-option", func(t *testing.T) {
+		// Regression pin for the CSS<->trace-protocol decoupling: disabling
+		// client-side stats must not change the wire protocol. Previously this
+		// subtest asserted a v0.4 downgrade, but that assertion was
+		// environment-ambiguous — plain newTestConfig makes a real /info
+		// request, so it passed in CI (no local agent, v1 unavailable anyway)
+		// for a reason unrelated to CSS, and would have failed on a dev machine
+		// with a v1-capable agent running locally. Pin it against a stub that
+		// unambiguously advertises v1 instead.
 		assert := assert.New(t)
-		c, err := newTestConfig(WithStatsComputation(false))
+		url := mockAgentEndpoint(t, "/v1.0/traces")
+		c, err := newTestConfig(
+			WithAgentAddr(strings.TrimPrefix(url.Host, "http://")),
+			WithStatsComputation(false),
+		)
 		assert.NoError(err)
 		assert.False(c.internalConfig.StatsComputationEnabled())
-		assert.Equal(traceProtocolV04, c.internalConfig.RequestedTraceProtocol())
+		assert.False(c.canComputeStats(), "sanity check: CSS must actually be off")
+		assert.Equal(traceProtocolV1, c.effectiveTraceProtocol(), "disabling CSS must not downgrade the trace protocol")
 	})
 	t.Run("enabled-via-env", func(t *testing.T) {
 		assert := assert.New(t)

--- a/ddtrace/tracer/span_pool_config_test.go
+++ b/ddtrace/tracer/span_pool_config_test.go
@@ -212,10 +212,11 @@ func TestSpanPoolActivationReachesHotPath(t *testing.T) {
 // guard for a reported production symptom: a service set
 // DD_TRACER_EXPERIMENTAL_SPAN_POOL_ENABLED=true alongside
 // DD_TRACE_STATS_COMPUTATION_ENABLED=false and DD_DATA_STREAMS_ENABLED=true,
-// and observed the trace protocol downgrade to v0.4 — a real, intentional
-// consequence of disabling stats computation (see newConfig: "v1 is not
-// compatible without CSS") — and suspected the span pool was disabled too.
-// It wasn't, and can't be by this config: SetSpanPoolEnabled has exactly two
+// and suspected the span pool was disabled by that combination. (Disabling
+// stats computation was once believed to also force the trace protocol down
+// to v0.4; it doesn't — client-side stats and the wire protocol are
+// independent, see effectiveTraceProtocol.) The span pool wasn't disabled
+// either, and can't be by this config: SetSpanPoolEnabled has exactly two
 // call sites in the whole repo (the env-var load in internal/config and
 // WithSpanPool in this package's newConfig), and neither references stats
 // computation, trace protocol, or DSM. There is now no mechanism that forces

--- a/ddtrace/tracer/trace_protocol_selection_test.go
+++ b/ddtrace/tracer/trace_protocol_selection_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package tracer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/statsdtest"
+)
+
+// isV1WireByte reports whether b is the first byte of a msgpack map — the
+// shape of a v1.0 trace payload. Mirrors the sniffing logic in decode().
+func isV1WireByte(b byte) bool {
+	return b == msgpackMap16 || b == msgpackMap32 || b&0xf0 == msgpackMapFix
+}
+
+// TestNewConfigKeepsV1WhenCSSDisabled is the headline regression pin for the
+// CSS<->trace-protocol decoupling: disabling client-side stats computation
+// must not downgrade the wire protocol. Before the fix, this failed — the
+// tracer POSTed a v0.4 array body to /v0.4/traces even though the agent
+// advertised /v1.0/traces.
+func TestNewConfigKeepsV1WhenCSSDisabled(t *testing.T) {
+	agent := startTestAgent(t)
+	tr := newTracerTest(t, agent, WithStatsComputation(false))
+	defer stopTracerTest(tr)
+
+	require.False(t, tr.config.canComputeStats(), "sanity check: CSS must actually be off")
+	assert.Equal(t, traceProtocolV1, tr.config.effectiveTraceProtocol())
+	assert.Equal(t, agent.URL()+tracesAPIPathV1, tr.config.ddTransport.endpoint(tr.config.effectiveTraceProtocol()))
+
+	span := tr.StartSpan("op")
+	span.Finish()
+	flushAgentTracerTest(t, tr, agent, 1)
+
+	assert.Equal(t, []string{tracesAPIPathV1}, agent.Requests(), "the request must land on /v1.0/traces")
+	firstBytes := agent.RequestFirstBytes()
+	require.Len(t, firstBytes, 1)
+	assert.True(t, isV1WireByte(firstBytes[0]), "expected a msgpack map (v1) body, got byte 0x%02x", firstBytes[0])
+}
+
+// TestTraceProtocolDecoupling is the decision matrix: the effective protocol
+// must be a function of (requested protocol, agent v1 availability) alone.
+// Client-side stats may not move it. The expected value is computed, not
+// hand-enumerated, so the invariant itself — not a fixed table of outcomes —
+// is what's being pinned.
+func TestTraceProtocolDecoupling(t *testing.T) {
+	requested := []struct {
+		name string
+		env  string // "" means DD_TRACE_AGENT_PROTOCOL_VERSION is left unset
+	}{
+		{"unset", ""},
+		{"v1", "1.0"},
+		{"v04", "0.4"},
+		{"invalid", "garbage"}, // must behave exactly like "unset" (falls back to the default, v1)
+	}
+
+	for _, req := range requested {
+		for _, v1Advertised := range []bool{true, false} {
+			for _, cssOff := range []bool{false, true} {
+				t.Run(fmt.Sprintf("requested=%s/v1_advertised=%t/css_off=%t", req.name, v1Advertised, cssOff), func(t *testing.T) {
+					if req.env != "" {
+						t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", req.env)
+					}
+					agent := startTestAgent(t)
+					endpoints := `"/v0.4/traces","/v0.6/stats"`
+					if v1Advertised {
+						endpoints = `"/v0.4/traces","/v1.0/traces","/v0.6/stats"`
+					}
+					agent.SetInfo(`{"endpoints":[` + endpoints + `],"client_drop_p0s":true}`)
+
+					var opts []StartOption
+					if cssOff {
+						opts = append(opts, WithStatsComputation(false))
+					}
+					tr := newTracerTest(t, agent, opts...)
+					defer stopTracerTest(tr)
+
+					// The invariant under test: v1 iff v1 wasn't explicitly
+					// declined and the agent advertises it. CSS state never
+					// enters into it.
+					wantV1 := req.env != "0.4" && v1Advertised
+					wantProtocol := traceProtocolV04
+					wantPath := tracesAPIPath
+					if wantV1 {
+						wantProtocol = traceProtocolV1
+						wantPath = tracesAPIPathV1
+					}
+
+					assert.Equal(t, wantProtocol, tr.config.effectiveTraceProtocol())
+					assert.Equal(t, agent.URL()+wantPath, tr.config.ddTransport.endpoint(tr.config.effectiveTraceProtocol()))
+
+					w := newAgentTraceWriter(tr.config, newPrioritySampler(), &statsdtest.TestStatsdClient{})
+					assert.Equal(t, wantProtocol, w.payload.protocol())
+				})
+			}
+		}
+	}
+}

--- a/ddtrace/tracer/tracertest_test.go
+++ b/ddtrace/tracer/tracertest_test.go
@@ -8,12 +8,14 @@
 package tracer
 
 import (
+	"bufio"
 	"encoding/binary"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,10 +30,14 @@ import (
 // DecodeMsg (msgp-generated) for v0.4 and the v1 decode machinery
 // (payloadV1.decodeBuffer, decodeTraceChunks, etc.) for v1.0.
 type testAgent struct {
-	server   *httptest.Server
-	mu       sync.Mutex
-	spans    []*Span
-	requests []string
+	server     *httptest.Server
+	mu         sync.Mutex
+	spans      []*Span
+	requests   []string
+	firstBytes []byte
+	// infoBody, when set via SetInfo, overrides the default /info response —
+	// allowing a test to change what the agent advertises between polls.
+	infoBody atomic.Pointer[string]
 }
 
 // startTestAgent creates and starts a mock agent. It is closed automatically
@@ -84,31 +90,63 @@ func (a *testAgent) Requests() []string {
 	return cp
 }
 
+// RequestFirstBytes returns the first msgpack byte of each recorded request's
+// body, in the same order as Requests(). This proves the wire-format shape
+// (map vs array) independently of how lenient a given handler is about it —
+// compare against msgpackMapFix/msgpackMapFix.. and msgpackArrayFix ranges.
+func (a *testAgent) RequestFirstBytes() []byte {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	cp := make([]byte, len(a.firstBytes))
+	copy(cp, a.firstBytes)
+	return cp
+}
+
 // Reset clears all received spans and request records.
 func (a *testAgent) Reset() {
 	a.mu.Lock()
 	a.spans = a.spans[:0]
 	a.requests = a.requests[:0]
+	a.firstBytes = a.firstBytes[:0]
 	a.mu.Unlock()
 }
 
-func (a *testAgent) recordRequest(path string, spans []*Span) {
+// SetInfo overrides the /info response body. Pass "" to restore the default.
+func (a *testAgent) SetInfo(body string) {
+	if body == "" {
+		a.infoBody.Store(nil)
+		return
+	}
+	a.infoBody.Store(&body)
+}
+
+func (a *testAgent) recordRequest(path string, spans []*Span, firstByte byte) {
 	if len(spans) == 0 {
 		return
 	}
 	a.mu.Lock()
 	a.requests = append(a.requests, path)
 	a.spans = append(a.spans, spans...)
+	a.firstBytes = append(a.firstBytes, firstByte)
 	a.mu.Unlock()
 }
 
 func (a *testAgent) handleInfo(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	if body := a.infoBody.Load(); body != nil {
+		w.Write([]byte(*body))
+		return
+	}
 	w.Write([]byte(`{"endpoints":["/v0.4/traces","/v1.0/traces","/v0.6/stats"],"client_drop_p0s":true,"span_events":true,"span_meta_structs":true}`))
 }
 
 func (a *testAgent) handleTracesV04(w http.ResponseWriter, r *http.Request) {
-	reader := msgp.NewReader(r.Body)
+	br := bufio.NewReader(r.Body)
+	var firstByte byte
+	if b, err := br.Peek(1); err == nil && len(b) > 0 {
+		firstByte = b[0]
+	}
+	reader := msgp.NewReader(br)
 	numTraces, err := reader.ReadArrayHeader()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -130,18 +168,23 @@ func (a *testAgent) handleTracesV04(w http.ResponseWriter, r *http.Request) {
 			spans = append(spans, s)
 		}
 	}
-	a.recordRequest(r.URL.Path, spans)
+	a.recordRequest(r.URL.Path, spans, firstByte)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"rate_by_service":{}}`))
 }
 
 func (a *testAgent) handleTracesV1(w http.ResponseWriter, r *http.Request) {
+	br := bufio.NewReader(r.Body)
+	var firstByte byte
+	if b, err := br.Peek(1); err == nil && len(b) > 0 {
+		firstByte = b[0]
+	}
 	// Copy the body directly into the payload buffer rather than buffering the
 	// whole request with io.ReadAll first: payloadV1.Write appends to p.buf,
 	// which decodeBuffer consumes in place, so a separate full-body slice would
 	// just be an extra copy.
 	p := newPayloadV1()
-	if _, err := io.Copy(p, r.Body); err != nil {
+	if _, err := io.Copy(p, br); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -162,7 +205,7 @@ func (a *testAgent) handleTracesV1(w http.ResponseWriter, r *http.Request) {
 			spans = append(spans, s)
 		}
 	}
-	a.recordRequest(r.URL.Path, spans)
+	a.recordRequest(r.URL.Path, spans, firstByte)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"rate_by_service":{}}`))
 }

--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -113,7 +113,7 @@ func (h *agentTraceWriter) wait() { h.wg.Wait() }
 // over-prediction wastes one cycle of transient memory and self-corrects. Pass 0
 // on cold start (no prior cycle data).
 func (h *agentTraceWriter) newPayload(hint int) payload {
-	payload := newPayload(h.config.internalConfig.RequestedTraceProtocol())
+	payload := newPayload(h.config.effectiveTraceProtocol())
 	if payload.protocol() == traceProtocolV04 {
 		if hint > 0 {
 			payload.grow(hint)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -189,9 +190,18 @@ type Config struct {
 	retryInterval time.Duration
 	// logsOTelEnabled controls if the OpenTelemetry Logs SDK pipeline should be enabled
 	logsOTelEnabled bool
-	// traceProtocol is the Datadog trace protocol version (TraceProtocolV04 or TraceProtocolV1).
+	// traceProtocol is the Datadog trace protocol version the user requested
+	// (TraceProtocolV04 or TraceProtocolV1). This is independent of whether the
+	// trace-agent actually supports it — see RequestedTraceProtocol's doc.
 	// Only meaningful when otlpExportMode is false.
 	traceProtocol float64
+	// effectiveTraceProtocolBits is the last value reported via
+	// ReportEffectiveTraceProtocol, stored as float64 bits so repeated reports
+	// of the same value can be deduplicated without inflating config-telemetry
+	// seqIDs on every agent-info poll. Deliberately not under mu: it is written
+	// from the tracer's poll goroutine and must not contend with hot-path reads
+	// of unrelated fields.
+	effectiveTraceProtocolBits atomic.Uint64
 	// otlpExportMode indicates traces should be exported via OTLP rather than
 	// a Datadog protocol.
 	otlpExportMode bool
@@ -1566,6 +1576,10 @@ func (c *Config) RequestedTraceProtocol() float64 {
 	return c.traceProtocol
 }
 
+// SetTraceProtocol sets the requested trace protocol version. It never
+// expresses an agent-capability downgrade: callers that need to report the
+// wire protocol actually in use should call ReportEffectiveTraceProtocol
+// instead, which does not mutate the requested value.
 func (c *Config) SetTraceProtocol(v float64, origin telemetry.Origin, product ...Product) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1578,6 +1592,27 @@ func (c *Config) SetTraceProtocol(v float64, origin telemetry.Origin, product ..
 	// reporting a float64 here made the same telemetry key arrive with two
 	// different types depending on which source last set it.
 	configtelemetry.Report("DD_TRACE_AGENT_PROTOCOL_VERSION", TraceProtocolVersionString(v), origin)
+}
+
+// ReportEffectiveTraceProtocol records the wire protocol version actually in
+// use (the requested protocol, downgraded when the agent lacks support) for
+// DD_TRACE_AGENT_PROTOCOL_VERSION config telemetry. It reports only when the
+// value changes from the last report, so periodic re-evaluation (e.g. on an
+// agent-info poll) cannot inflate config-telemetry seqIDs. It does NOT modify
+// the value returned by RequestedTraceProtocol. Returns true if this call
+// changed the recorded value.
+func (c *Config) ReportEffectiveTraceProtocol(v float64) bool {
+	next := math.Float64bits(v)
+	for {
+		prev := c.effectiveTraceProtocolBits.Load()
+		if prev == next {
+			return false
+		}
+		if c.effectiveTraceProtocolBits.CompareAndSwap(prev, next) {
+			configtelemetry.Report("DD_TRACE_AGENT_PROTOCOL_VERSION", TraceProtocolVersionString(v), telemetry.OriginCalculated)
+			return true
+		}
+	}
 }
 
 func (c *Config) OTLPTraceURL() string {


### PR DESCRIPTION
## What does this PR do?

This is the decoupling layer of the restored review stack:

1. **#5161 (this PR):** decouple trace protocol v1.0 from client-side stats.
2. **#5167:** re-evaluate Agent v1.0 support at runtime, with the associated payload-transition synchronization.
3. **#5168:** diagnose and report the selected trace protocol.

Only this PR is required for the decoupling release. It retains the established startup capability decision: if the Agent advertises `/v1.0/traces` when the tracer starts, disabling client-side stats no longer forces the tracer down to v0.4. If the Agent does not advertise v1 at startup, the tracer still uses v0.4.

The runtime refresh is deliberately separate. A running Agent does not dynamically toggle its trace intake endpoints; a changed capability answer requires reaching a different Agent process, such as during an upgrade, rollback, or load-balanced routing transition. That hardening is useful, but it is not a functional prerequisite for decoupling CSS from trace encoding.

### Why this change

Client-side stats are negotiated separately through the `Datadog-Client-Computed-Stats` header and `/v0.6/stats`. The Agent accepts v1 payloads whether or not the client computed stats, so CSS must not determine the trace wire format.

### Validation

- `go test ./ddtrace/tracer -run "^(TestNewConfigKeepsV1WhenCSSDisabled|TestTraceProtocolDecoupling|TestWithStatsComputation)$" -count=1`
- `git diff --check`

The former combined branch head is retained at `dario.castane/decouple-stack-pre-split-2dd92c82` for recovery.