### PR TITLE
fix(ddtrace/tracer): clear span-context snapshot on ContextWithSpan(ctx, nil)

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -30,7 +30,8 @@ type activeSpanContextKey struct{}
 // If ctx is nil, a new background context is created to avoid panicking.
 // Passing a nil span detaches ctx from any ambient span, including one
 // inherited from an ancestor context, so a subsequent StartSpanFromContext
-// starts a new root span.
+// starts a new root span — unless the caller also passes an explicit parent
+// (e.g. ChildOf) to that call, which is honored as usual.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if ctx == nil {
 		log.Warn("ContextWithSpan: received nil context, falling back to context.Background()")

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -29,7 +29,7 @@ type activeSpanContextKey struct{}
 // ContextWithSpan returns a copy of the given context which includes the span s.
 // If ctx is nil, a new background context is created to avoid panicking.
 // Passing a nil span detaches ctx from any ambient span, including one
-// inherited from an ancestor context, so a subsequent StartSpanFromContext
+// inherited from an ancestor context, so a subsequent [StartSpanFromContext]
 // starts a new root span — unless the caller also passes an explicit parent
 // (e.g. ChildOf) to that call, which is honored as usual.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -21,10 +21,16 @@ import (
 // recycled and its s.context field replaced. This does NOT protect the
 // underlying trace from being finished or flushed; callers must ensure the
 // parent's trace lifetime exceeds child span creation.
+// ContextWithSpan(ctx, nil) clears this snapshot too, not just
+// internal.ActiveSpanKey, so detaching from an ambient span also detaches
+// from any snapshot inherited from an ancestor context.
 type activeSpanContextKey struct{}
 
 // ContextWithSpan returns a copy of the given context which includes the span s.
 // If ctx is nil, a new background context is created to avoid panicking.
+// Passing a nil span detaches ctx from any ambient span, including one
+// inherited from an ancestor context, so a subsequent StartSpanFromContext
+// starts a new root span.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if ctx == nil {
 		log.Warn("ContextWithSpan: received nil context, falling back to context.Background()")
@@ -52,6 +58,11 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if s != nil {
 		// Snapshot the SpanContext so it survives span pool recycling.
 		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, s.Context())
+	} else {
+		// Shadow any snapshot inherited from an ancestor context, otherwise
+		// StartSpanFromContext would keep re-parenting onto it even though
+		// ActiveSpanKey was just cleared above.
+		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, (*SpanContext)(nil))
 	}
 	return contextWithPropagatedLLMSpan(newCtx, s)
 }

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -58,10 +58,13 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if s != nil {
 		// Snapshot the SpanContext so it survives span pool recycling.
 		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, s.Context())
-	} else {
-		// Shadow any snapshot inherited from an ancestor context, otherwise
+	} else if sc, ok := ctx.Value(activeSpanContextKey{}).(*SpanContext); ok && sc != nil {
+		// Shadow a snapshot inherited from an ancestor context, otherwise
 		// StartSpanFromContext would keep re-parenting onto it even though
-		// ActiveSpanKey was just cleared above.
+		// ActiveSpanKey was just cleared above. Only an ancestor that actually
+		// holds a snapshot needs shadowing: ContextWithSpan(ctx, nil) is on the
+		// hot path whenever the tracer is disabled (StartSpan returns nil), so
+		// paying an allocation to shadow nothing would be wasted on every span.
 		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, (*SpanContext)(nil))
 	}
 	return contextWithPropagatedLLMSpan(newCtx, s)

--- a/ddtrace/tracer/context_bench_test.go
+++ b/ddtrace/tracer/context_bench_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BenchmarkContextWithSpan guards the allocation cost of ContextWithSpan's two
-// call shapes: attaching a live span (the common StartSpanFromContext path) and
-// detaching (ContextWithSpan(ctx, nil), see TestStartSpanFromContextDetachRegression).
+// BenchmarkContextWithSpan guards the allocation cost of ContextWithSpan's
+// call shapes: attaching a live span (the common StartSpanFromContext path),
+// detaching a context that carries an ancestor snapshot (ContextWithSpan(ctx,
+// nil), see TestStartSpanFromContextDetachRegression), and detaching a context
+// that carries none — the tracer-disabled hot path that must stay
+// allocation-free (see the "don't shadow a snapshot that isn't there" fix).
 func BenchmarkContextWithSpan(b *testing.B) {
 	_, _, _, stop, err := startTestTracer(b)
 	require.NoError(b, err)
@@ -36,6 +39,14 @@ func BenchmarkContextWithSpan(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			_ = ContextWithSpan(pctx, nil)
+		}
+	})
+
+	b.Run("detach-no-snapshot", func(b *testing.B) {
+		ctx := context.Background()
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = ContextWithSpan(ctx, nil)
 		}
 	})
 }

--- a/ddtrace/tracer/context_bench_test.go
+++ b/ddtrace/tracer/context_bench_test.go
@@ -16,8 +16,10 @@ import (
 // call shapes: attaching a live span (the common StartSpanFromContext path),
 // detaching a context that carries an ancestor snapshot (ContextWithSpan(ctx,
 // nil), see TestStartSpanFromContextDetachRegression), and detaching a context
-// that carries none — the tracer-disabled hot path that must stay
-// allocation-free (see the "don't shadow a snapshot that isn't there" fix).
+// that carries none — the tracer-disabled hot path, which pays one
+// allocation for the unavoidable ActiveSpanKey WithValue but must not pay a
+// second one for the shadow (see the "don't shadow a snapshot that isn't
+// there" fix).
 func BenchmarkContextWithSpan(b *testing.B) {
 	_, _, _, stop, err := startTestTracer(b)
 	require.NoError(b, err)

--- a/ddtrace/tracer/context_bench_test.go
+++ b/ddtrace/tracer/context_bench_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package tracer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkContextWithSpan guards the allocation cost of ContextWithSpan's two
+// call shapes: attaching a live span (the common StartSpanFromContext path) and
+// detaching (ContextWithSpan(ctx, nil), see TestStartSpanFromContextDetachRegression).
+func BenchmarkContextWithSpan(b *testing.B) {
+	_, _, _, stop, err := startTestTracer(b)
+	require.NoError(b, err)
+	defer stop()
+
+	b.Run("live", func(b *testing.B) {
+		s := StartSpan("op")
+		defer s.Finish()
+		ctx := context.Background()
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = ContextWithSpan(ctx, s)
+		}
+	})
+
+	b.Run("detach", func(b *testing.B) {
+		parent, pctx := StartSpanFromContext(context.Background(), "parent")
+		defer parent.Finish()
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = ContextWithSpan(pctx, nil)
+		}
+	})
+}

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -192,12 +192,12 @@ func Test128(t *testing.T) {
 }
 
 // TestStartSpanFromContextDetachRegression guards against a regression introduced between
-// v2.9.1-rc.3 and v2.10.0-rc.4: ContextWithSpan(ctx, nil) is documented as the way to
-// detach from an ambient span while preserving ctx's cancellation/deadline. For a while it
-// only cleared internal.ActiveSpanKey and left behind any activeSpanContextKey{} snapshot
-// that a prior StartSpanFromContext call had already written into an ancestor of ctx.
-// StartSpanFromContext consults that snapshot before falling back to SpanFromContext, so a
-// "detached" context kept silently chaining onto the old parent's trace.
+// v2.9.1-rc.3 and v2.10.0-rc.4: ContextWithSpan(ctx, nil) is the way to detach from an
+// ambient span while preserving ctx's cancellation/deadline. For a while it only cleared
+// internal.ActiveSpanKey and left behind any activeSpanContextKey{} snapshot that a prior
+// StartSpanFromContext call had already written into an ancestor of ctx. StartSpanFromContext
+// consults that snapshot before falling back to SpanFromContext, so a "detached" context kept
+// silently chaining onto the old parent's trace.
 func TestStartSpanFromContextDetachRegression(t *testing.T) {
 	_, _, _, stop, err := startTestTracer(t)
 	assert.NoError(t, err)
@@ -214,8 +214,8 @@ func TestStartSpanFromContextDetachRegression(t *testing.T) {
 	assert.Equal(t, parent.traceID, child.traceID)
 	assert.Equal(t, parent.spanID, child.parentID)
 
-	// Detach per the documented idiom: pass a nil span to keep ctx's cancellation/
-	// deadline but drop the ambient span.
+	// Detach: pass a nil span to keep ctx's cancellation/deadline but drop the
+	// ambient span.
 	detachedCtx := ContextWithSpan(parentCtx, nil)
 
 	// SpanFromContext correctly reports no active span on the detached context.

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -191,6 +191,50 @@ func Test128(t *testing.T) {
 	})
 }
 
+// TestStartSpanFromContextDetachRegression guards against a regression introduced between
+// v2.9.1-rc.3 and v2.10.0-rc.4: ContextWithSpan(ctx, nil) is documented as the way to
+// detach from an ambient span while preserving ctx's cancellation/deadline. For a while it
+// only cleared internal.ActiveSpanKey and left behind any activeSpanContextKey{} snapshot
+// that a prior StartSpanFromContext call had already written into an ancestor of ctx.
+// StartSpanFromContext consults that snapshot before falling back to SpanFromContext, so a
+// "detached" context kept silently chaining onto the old parent's trace.
+func TestStartSpanFromContextDetachRegression(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	// Start a "parent" span the way a long-lived handler would, and get back a
+	// context carrying it.
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+
+	// Sanity check: without detaching, a child does inherit the parent's trace.
+	child, _ := StartSpanFromContext(parentCtx, "child")
+	defer child.Finish()
+	assert.Equal(t, parent.traceID, child.traceID)
+	assert.Equal(t, parent.spanID, child.parentID)
+
+	// Detach per the documented idiom: pass a nil span to keep ctx's cancellation/
+	// deadline but drop the ambient span.
+	detachedCtx := ContextWithSpan(parentCtx, nil)
+
+	// SpanFromContext correctly reports no active span on the detached context.
+	_, ok := SpanFromContext(detachedCtx)
+	assert.False(t, ok, "detached context must not report an active span")
+
+	// StartSpanFromContext must treat detachedCtx as having no parent and start a
+	// fresh root span (new trace, no parentID), not inherit the stale
+	// activeSpanContextKey{} snapshot left behind by the parent's own
+	// StartSpanFromContext call.
+	grandchild, _ := StartSpanFromContext(detachedCtx, "grandchild-should-be-root")
+	defer grandchild.Finish()
+
+	assert.NotEqual(t, parent.traceID, grandchild.traceID,
+		"span started from a detached context must not inherit the old trace ID")
+	assert.Zero(t, grandchild.parentID,
+		"span started from a detached context must not have a parentID")
+}
+
 func TestStartSpanFromNilContext(t *testing.T) {
 	_, _, _, stop, err := startTestTracer(t)
 	assert.Nil(t, err)

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -262,6 +262,34 @@ func TestStartSpanFromContextDetachWithExplicitParent(t *testing.T) {
 		"the detached ambient parent must not leak through despite the explicit ChildOf")
 }
 
+// TestContextWithSpanDoubleDetachIdempotent guards the shadow branch added
+// alongside TestStartSpanFromContextDetachRegression: shadowing an
+// already-nil snapshot must be a no-op rather than compounding into a second
+// write, so detaching an already-detached context behaves exactly like
+// detaching it once.
+func TestContextWithSpanDoubleDetachIdempotent(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+
+	onceDetached := ContextWithSpan(parentCtx, nil)
+	twiceDetached := ContextWithSpan(onceDetached, nil)
+
+	_, ok := SpanFromContext(twiceDetached)
+	assert.False(t, ok, "double-detached context must not report an active span")
+
+	grandchild, _ := StartSpanFromContext(twiceDetached, "grandchild-should-be-root")
+	defer grandchild.Finish()
+
+	assert.NotEqual(t, parent.traceID, grandchild.traceID,
+		"span started from a double-detached context must not inherit the old trace ID")
+	assert.Zero(t, grandchild.parentID,
+		"span started from a double-detached context must not have a parentID")
+}
+
 func TestStartSpanFromNilContext(t *testing.T) {
 	_, _, _, stop, err := startTestTracer(t)
 	assert.Nil(t, err)

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -235,6 +235,33 @@ func TestStartSpanFromContextDetachRegression(t *testing.T) {
 		"span started from a detached context must not have a parentID")
 }
 
+// TestStartSpanFromContextDetachWithExplicitParent guards the qualifier on
+// ContextWithSpan's root-span promise: detaching only suppresses the ambient
+// parent. A caller that also passes an explicit parent (e.g. ChildOf) to the
+// subsequent StartSpanFromContext call still gets that parent, not a root span.
+func TestStartSpanFromContextDetachWithExplicitParent(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+	detachedCtx := ContextWithSpan(parentCtx, nil)
+
+	explicitParent, _ := StartSpanFromContext(context.Background(), "explicit-parent")
+	defer explicitParent.Finish()
+
+	child, _ := StartSpanFromContext(detachedCtx, "child", ChildOf(explicitParent.Context()))
+	defer child.Finish()
+
+	assert.Equal(t, explicitParent.traceID, child.traceID,
+		"an explicit ChildOf passed alongside a detached context must still be honored")
+	assert.Equal(t, explicitParent.spanID, child.parentID,
+		"an explicit ChildOf passed alongside a detached context must still be honored")
+	assert.NotEqual(t, parent.traceID, child.traceID,
+		"the detached ambient parent must not leak through despite the explicit ChildOf")
+}
+
 func TestStartSpanFromNilContext(t *testing.T) {
 	_, _, _, stop, err := startTestTracer(t)
 	assert.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

`ContextWithSpan(ctx, nil)` — the way to detach from an ambient span while keeping `ctx`'s cancellation/deadline — only cleared `internal.ActiveSpanKey`. It left behind the `activeSpanContextKey{}` snapshot that a prior `StartSpanFromContext` call may have already written into an ancestor context, so `StartSpanFromContext` (which checks that snapshot before falling back to `SpanFromContext`) kept silently re-parenting the "detached" span onto the stale ancestor.

This detach behavior was never actually documented anywhere in dd-trace-go before this PR — it was an emergent side effect of `SpanFromContext`'s long-standing (since 2018) nil-span handling, not a stated contract. This PR is the first to spell it out explicitly, in the godoc on `ContextWithSpan` and `activeSpanContextKey`.

`ContextWithSpan` now shadows `activeSpanContextKey{}` with a nil `*SpanContext` whenever `s == nil`, mirroring what it already does for `ActiveSpanKey`.

### Motivation

`github.com/DataDog/dd-trace-go/v2` bumped from `v2.9.1-rc.3` to `v2.10.0-rc.4` in an internal service, silently breaking a test that relies on `tracer.ContextWithSpan(ctx, nil)` to give each loop iteration its own root trace, detached from an ambient parent span. Bisecting confirmed the regression was introduced by #4440 ("add span pool"), which added the `activeSpanContextKey{}` snapshot to survive span-pool recycling but didn't account for this existing detach pattern.

Verified with a new test, `TestStartSpanFromContextDetachRegression`:
- Passes against `v2.9.1-rc.3`.
- Fails against `v2.10.0-rc.4` and pre-fix `main`, reproducing the regression.
- Passes with this fix applied. Full `ddtrace/tracer` suite and `go vet` stay green.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.