### PR TITLE
perf(ddtrace/tracer): collapse ContextWithSpan's two context nodes into one

### DIFF
--- a/.gitlab/benchmarks/micro/gitlab-ci.yml
+++ b/.gitlab/benchmarks/micro/gitlab-ci.yml
@@ -79,7 +79,7 @@ microbenchmarks-1:
 microbenchmarks-2:
   extends: .microbenchmarks
   variables:
-    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
+    BENCHMARKS: "BenchmarkStartRequestSpan|BenchmarkStartRequestSpanQueryObfuscation|BenchmarkHttpServeTrace|BenchmarkHttpServeTraceQueryObfuscation|BenchmarkTracerAddSpans|BenchmarkStartSpan|BenchmarkContextWithSpan|BenchmarkSingleSpanRetention|BenchmarkOTelApiWithCustomTags|BenchmarkInjectW3C|BenchmarkExtractW3C|BenchmarkPartialFlushing|BenchmarkSampleWAFSubContext"
     CPUS_PER_BENCHMARK: 1
     REPETITIONS: 10
     GROUP_ID: "group-2"

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -53,14 +53,20 @@ func (c *spanCtx) Value(key any) any {
 	return c.Context.Value(key)
 }
 
-// String lets fmt/%v render a spanCtx as a readable chain — e.g.
-// "context.Background.WithValue(internal.contextKey, Name: ...)" — matching
-// what the two context.WithValue nodes it replaces produced. Embedding
-// context.Context does not promote the parent's String method, since Stringer
-// isn't part of the Context interface, so without this a spanCtx would fall
-// back to a struct dump under %v.
+// String lets fmt/%v render a spanCtx as a readable chain, reproducing the two
+// context.WithValue nodes it replaces: both segments, with the span rendered via
+// its String method. Embedding context.Context does not promote the parent's
+// String method, since Stringer isn't part of the Context interface, so without
+// this a spanCtx would fall back to a struct dump under %v. The nil span is
+// spelled out rather than left to %v because (*Span).Format's nil guard is
+// missing a return, so a nil span routed through %v or %s renders "<nil><nil>".
 func (c *spanCtx) String() string {
-	return fmt.Sprintf("%v.WithValue(%T, %v)", c.Context, internal.ActiveSpanKey, c.span)
+	span := "<nil>"
+	if c.span != nil {
+		span = c.span.String()
+	}
+	return fmt.Sprintf("%v.WithValue(%T, %s).WithValue(%T, %T)",
+		c.Context, internal.ActiveSpanKey, span, activeSpanContextKey{}, c.snapshot)
 }
 
 // ContextWithSpan returns a copy of the given context which includes the span s.

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -7,6 +7,7 @@ package tracer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/options"
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -26,6 +27,42 @@ import (
 // from any snapshot inherited from an ancestor context.
 type activeSpanContextKey struct{}
 
+// spanCtx carries the active *Span and the snapshot of its *SpanContext in a
+// single context node. Two chained context.WithValue nodes would allocate twice
+// for one logical fact; one spanCtx allocates once and answers both keys.
+//
+// A nil span yields a typed-nil for both keys. That is what makes
+// ContextWithSpan(ctx, nil) a true detach: the typed-nil shadows any snapshot an
+// ancestor context left behind, so StartSpanFromContext falls through to
+// SpanFromContext, which also sees the nil span and reports no active span.
+type spanCtx struct {
+	context.Context
+	span     *Span
+	snapshot *SpanContext
+}
+
+func (c *spanCtx) Value(key any) any {
+	if _, ok := key.(activeSpanContextKey); ok {
+		return c.snapshot
+	}
+	// Interface comparison: a differing dynamic type is simply unequal, and
+	// internal.contextKey is a comparable empty struct, so this cannot panic.
+	if key == internal.ActiveSpanKey {
+		return c.span
+	}
+	return c.Context.Value(key)
+}
+
+// String lets fmt/%v render a spanCtx as a readable chain — e.g.
+// "context.Background.WithValue(internal.contextKey, Name: ...)" — matching
+// what the two context.WithValue nodes it replaces produced. Embedding
+// context.Context does not promote the parent's String method, since Stringer
+// isn't part of the Context interface, so without this a spanCtx would fall
+// back to a struct dump under %v.
+func (c *spanCtx) String() string {
+	return fmt.Sprintf("%v.WithValue(%T, %v)", c.Context, internal.ActiveSpanKey, c.span)
+}
+
 // ContextWithSpan returns a copy of the given context which includes the span s.
 // If ctx is nil, a new background context is created to avoid panicking.
 // Passing a nil span detaches ctx from any ambient span, including one
@@ -37,8 +74,10 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 		log.Warn("ContextWithSpan: received nil context, falling back to context.Background()")
 		ctx = context.Background()
 	}
-	// Plain context.WithValue. When built with orchestrion, three aspects in
-	// ddtrace/tracer/orchestrion.yml extend the span's GLS lifecycle:
+	// s and its SpanContext snapshot are carried by a single spanCtx node (see
+	// above) rather than two chained context.WithValue calls. When built with
+	// orchestrion, three aspects in ddtrace/tracer/orchestrion.yml extend the
+	// span's GLS lifecycle:
 	//   - "Span GLS fields": adds two woven fields to Span — __dd_glsPop
 	//     (GLSPopperCell, an atomic pointer to the goroutine-scoped popper) and
 	//     __dd_glsDone (GLSDoneCell, an atomic pointer to the liveness cell marked
@@ -54,20 +93,14 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	//       orchestrion.GLSDeactivate(&s.__dd_glsDone, &s.__dd_glsPop)
 	//     which pops the GLS entry exactly once, only on the goroutine that pushed.
 	// SpanFromContext is extended analogously ("Span SpanFromContext GLS read").
-	// Without orchestrion there is no GLS; this is a plain context.WithValue.
-	newCtx := context.WithValue(ctx, internal.ActiveSpanKey, s)
+	// Without orchestrion there is no GLS; ctx.Value only ever consults the
+	// spanCtx node constructed below.
+	var snapshot *SpanContext
 	if s != nil {
 		// Snapshot the SpanContext so it survives span pool recycling.
-		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, s.Context())
-	} else if sc, ok := ctx.Value(activeSpanContextKey{}).(*SpanContext); ok && sc != nil {
-		// Shadow a snapshot inherited from an ancestor context, otherwise
-		// StartSpanFromContext would keep re-parenting onto it even though
-		// ActiveSpanKey was just cleared above. Only an ancestor that actually
-		// holds a snapshot needs shadowing: ContextWithSpan(ctx, nil) is on the
-		// hot path whenever the tracer is disabled (StartSpan returns nil), so
-		// paying an allocation to shadow nothing would be wasted on every span.
-		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, (*SpanContext)(nil))
+		snapshot = s.Context()
 	}
+	newCtx := &spanCtx{Context: ctx, span: s, snapshot: snapshot}
 	return contextWithPropagatedLLMSpan(newCtx, s)
 }
 

--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -8,6 +8,7 @@ package tracer
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/options"
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -53,6 +54,18 @@ func (c *spanCtx) Value(key any) any {
 	return c.Context.Value(key)
 }
 
+// contextName renders ctx the way the context package's own valueCtx.String
+// does: via its String method when it implements fmt.Stringer, or by its
+// concrete type name otherwise. Routing a non-Stringer ctx through %v instead
+// would fall back to a reflective field dump, which — unlike a type name —
+// can expose whatever an application chose to store in a custom context.
+func contextName(ctx context.Context) string {
+	if s, ok := ctx.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return reflect.TypeOf(ctx).String()
+}
+
 // String lets fmt/%v render a spanCtx as a readable chain, reproducing the two
 // context.WithValue nodes it replaces: both segments, with the span rendered via
 // its String method. Embedding context.Context does not promote the parent's
@@ -65,8 +78,8 @@ func (c *spanCtx) String() string {
 	if c.span != nil {
 		span = c.span.String()
 	}
-	return fmt.Sprintf("%v.WithValue(%T, %s).WithValue(%T, %T)",
-		c.Context, internal.ActiveSpanKey, span, activeSpanContextKey{}, c.snapshot)
+	return fmt.Sprintf("%s.WithValue(%T, %s).WithValue(%T, %T)",
+		contextName(c.Context), internal.ActiveSpanKey, span, activeSpanContextKey{}, c.snapshot)
 }
 
 // ContextWithSpan returns a copy of the given context which includes the span s.

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -290,6 +290,68 @@ func TestContextWithSpanDoubleDetachIdempotent(t *testing.T) {
 		"span started from a double-detached context must not have a parentID")
 }
 
+// TestSpanCtxValue exercises spanCtx.Value directly (via the *spanCtx that
+// ContextWithSpan returns), pinning the four behaviors that make it the
+// load-bearing logic behind ContextWithSpan's detach guarantee: a live span
+// answers both keys, a nil span shadows both keys with a typed nil rather
+// than an absent key, and an unrelated key still falls through to the parent
+// context.
+func TestSpanCtxValue(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	t.Run("live span", func(t *testing.T) {
+		span := StartSpan("op")
+		defer span.Finish()
+
+		ctx := ContextWithSpan(context.Background(), span)
+
+		gotSpan, ok := ctx.Value(internal.ActiveSpanKey).(*Span)
+		assert.True(t, ok)
+		assert.Equal(t, span, gotSpan)
+
+		gotSnapshot, ok := ctx.Value(activeSpanContextKey{}).(*SpanContext)
+		assert.True(t, ok)
+		assert.NotNil(t, gotSnapshot)
+	})
+
+	t.Run("detach", func(t *testing.T) {
+		parent := StartSpan("parent")
+		defer parent.Finish()
+		parentCtx := ContextWithSpan(context.Background(), parent)
+
+		detachedCtx := ContextWithSpan(parentCtx, nil)
+
+		// internal.ActiveSpanKey must resolve to a non-nil interface holding a
+		// typed nil *Span, not an absent key — otherwise Value would fall
+		// through to parentCtx and resurrect the span it was meant to hide.
+		v := detachedCtx.Value(internal.ActiveSpanKey)
+		assert.True(t, v != nil, "interface value must be non-nil (a typed nil *Span)")
+		gotSpan, ok := v.(*Span)
+		assert.True(t, ok)
+		assert.Nil(t, gotSpan)
+
+		// Same two-part check for the snapshotted SpanContext.
+		sv := detachedCtx.Value(activeSpanContextKey{})
+		assert.True(t, sv != nil, "interface value must be non-nil (a typed nil *SpanContext)")
+		gotSnapshot, ok := sv.(*SpanContext)
+		assert.True(t, ok)
+		assert.Nil(t, gotSnapshot)
+	})
+
+	t.Run("unrelated key passthrough", func(t *testing.T) {
+		type unrelatedKey struct{}
+		base := context.WithValue(context.Background(), unrelatedKey{}, "unrelated-value")
+
+		span := StartSpan("op")
+		defer span.Finish()
+		ctx := ContextWithSpan(base, span)
+
+		assert.Equal(t, "unrelated-value", ctx.Value(unrelatedKey{}))
+	})
+}
+
 func TestStartSpanFromNilContext(t *testing.T) {
 	_, _, _, stop, err := startTestTracer(t)
 	assert.Nil(t, err)

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
@@ -288,6 +289,38 @@ func TestContextWithSpanDoubleDetachIdempotent(t *testing.T) {
 		"span started from a double-detached context must not inherit the old trace ID")
 	assert.Zero(t, grandchild.parentID,
 		"span started from a double-detached context must not have a parentID")
+}
+
+// customCtxWithSecret is a context.Context that does not implement
+// fmt.Stringer, used to check that spanCtx.String() falls back to a type
+// name for such a parent rather than a reflective field dump. Embedding the
+// context.Context interface only promotes the interface's own methods
+// (Deadline, Done, Err, Value), not String, so this type is deliberately not
+// a fmt.Stringer.
+type customCtxWithSecret struct {
+	context.Context
+	secret string
+}
+
+// TestSpanCtxString guards the fix for a regression Codex review caught:
+// fmt.Sprintf("%v", ...) on a non-Stringer parent falls back to a reflective
+// dump of its fields, unlike the two chained context.WithValue nodes this
+// type replaces, whose String method renders a non-Stringer parent by type
+// name only (via the context package's internal contextName helper).
+func TestSpanCtxString(t *testing.T) {
+	t.Run("Stringer parent", func(t *testing.T) {
+		ctx := ContextWithSpan(context.Background(), &Span{spanID: 123})
+		s := fmt.Sprint(ctx)
+		assert.Contains(t, s, "context.Background")
+	})
+
+	t.Run("non-Stringer parent falls back to type name, not a field dump", func(t *testing.T) {
+		parent := customCtxWithSecret{Context: context.Background(), secret: "super-secret-value"}
+		ctx := ContextWithSpan(parent, &Span{spanID: 123})
+		s := fmt.Sprint(ctx)
+		assert.Contains(t, s, "customCtxWithSecret")
+		assert.NotContains(t, s, "super-secret-value")
+	})
 }
 
 // TestSpanCtxValue exercises spanCtx.Value directly (via the *spanCtx that


### PR DESCRIPTION
### What does this PR do?

`ContextWithSpan` built two chained `context.WithValue` nodes for what is really one logical fact: "this is the active span, and here is the snapshot of its `SpanContext`". This replaces both with a single custom `context.Context` implementation, `spanCtx`, that answers both `internal.ActiveSpanKey` and `activeSpanContextKey{}` from one allocated node.

A nil span now yields a typed-nil for both keys from that one node. That is what makes `ContextWithSpan(ctx, nil)` a true detach — the typed-nil shadows any snapshot an ancestor context left behind, so `StartSpanFromContext` falls through to `SpanFromContext`, which also sees the nil span and reports no active span. This makes the shadow-guard added in #5162 (in both its original unconditional form and its later conditional refinement) unnecessary: no extra allocation, no `else`/`else if` branch, same detach guarantee.

Also added a `String()` method on `spanCtx`. Embedding `context.Context` does not promote the parent's `String()` (Stringer isn't part of the `Context` interface), so without it a `spanCtx` would print as a struct dump under `%v` instead of the readable `context.Background.WithValue(...)`-style chain the two `context.WithValue` nodes it replaces would have produced.

### Stacking on #5162

This is a follow-up to #5162 and is based on its branch, since #5162 hasn't merged yet. #5162 saw active concurrent iteration while this PR was in progress (a conditional refinement to the shadow-guard, a godoc qualifier for an explicit-`ChildOf` edge case, and its own `BenchmarkContextWithSpan`) — this PR has been merged (not rebased, to avoid rewriting already-pushed history) up to #5162's current tip, `85660f647`, and re-verified against it. All of #5162's regression tests keep passing unchanged, including the newest one (`TestStartSpanFromContextDetachWithExplicitParent`) — the typed-nil `snapshot` field reproduces the same detach behavior #5162 built up incrementally, just via one context node instead of a conditionally-second one. #5162's own `BenchmarkContextWithSpan` (added upstream while this PR was in progress) is reused as-is rather than duplicated.

Once #5162 merges to `main`, this PR's base should be retargeted there (or it'll happen automatically via GitHub once #5162's branch is gone).

### Why this is safe

- The `Span ContextWithSpan GLS push` Orchestrion aspect (`ddtrace/tracer/orchestrion.yml`) uses `prepend-statements` on `ContextWithSpan`'s function body, keyed only on the function name and its second argument — it does not reference the `context.WithValue` call itself, so rewriting the function body is safe.
- `internal/orchestrion/context.go`'s `glsContext.Value` calls `g.Context.Value(key)` on whatever it wraps — a custom node type like `spanCtx` is fully transparent to it, exactly like the `context.WithValue` nodes it replaces.
- `spanCtx.Value` returns a non-nil interface holding a nil pointer for a detached span, exactly matching what `context.WithValue(ctx, ActiveSpanKey, (*Span)(nil))` does today — `SpanFromContext`'s existing nil-unwrap check already handles this.
- The `key == internal.ActiveSpanKey` comparison in `spanCtx.Value` can't panic: comparing two interface values with differing dynamic types is simply unequal, and `internal.contextKey` (the key's type) is a comparable empty struct.
- The other writers of `internal.ActiveSpanKey` — `contrib/valyala/fasthttp` (writes into fasthttp's own user-value map) and `childof_precedence_test.go` (builds a plain `context.WithValue` to simulate the GLS shape) — are unaffected.

### Review follow-ups

Two fixup commits landed after the initial review pass and are easy to miss in a stacked diff, so flagging them explicitly:

- **`99e22e83a` fix: make `spanCtx.String()` reproduce the old `WithValue` chain output.** `fmt` prefers `Formatter` over `Stringer`, so `%v` on the embedded `*Span` was invoking `Format` (the log-correlation form) instead of `String` (the old chain's debug dump), and the `activeSpanContextKey` segment was being dropped entirely. Fixed to render the span via its `String()` method explicitly, spell out both `WithValue` segments, and spell out the nil case since `(*Span).Format`'s nil guard is missing a `return` and would otherwise render `"<nil><nil>"`.
- **`4b7ac7fc6` test: add direct coverage for `spanCtx.Value`.** Review found `spanCtx.Value` — the load-bearing logic behind the detach guarantee described above — was only covered transitively via `ContextWithSpan`/`StartSpanFromContext` integration tests, despite the checklist below targeting ~100% coverage on new code. Added `TestSpanCtxValue`, pinning its four behaviors directly: a live span answers both `internal.ActiveSpanKey` and `activeSpanContextKey{}`; `ContextWithSpan(ctx, nil)` shadows both keys with a typed nil — asserting both that the interface value itself is non-nil and that the type-asserted pointer is nil, which is what makes it a shadow rather than an absent key; and an unrelated `context.WithValue` entry on the wrapped context still surfaces through `Value` on the returned context.

### Measurements

Measured on Apple M1 Max, `GOTOOLCHAIN=go1.25.0`, interleaved binary comparison (two compiled test binaries, alternated invocations, `-benchtime=300000x`, `benchstat` over 8 rounds each) against #5162's current tip (`85660f647`, the actual merge-base) as "before":

```
ContextWithSpan/live-10           138.4n ± 2%   105.3n ± 4%  -23.85% (p=0.000 n=8)
ContextWithSpan/detach-10         60.27n ± 2%   24.22n ± 2%  -59.81% (p=0.000 n=8)

ContextWithSpan/live-10           160.00 ± 0%   96.00 ± 0%  -40.00% (p=0.000 n=8)
ContextWithSpan/detach-10          96.00 ± 0%   32.00 ± 0%  -66.67% (p=0.000 n=8)

ContextWithSpan/live-10            3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=8)
ContextWithSpan/detach-10          2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=8)
```

`instrumentation/httptrace.BenchmarkStartRequestSpan` (no-op tracer path), same methodology:

```
StartRequestSpan-10            176.5n ± 5%   167.3n ± 6%  -5.16%  (p=0.010 n=8)
StartRequestSpan-10             208.0 ± 0%   192.0 ± 0%  -7.69%  (p=0.000 n=8)
StartRequestSpan-10             5.000 ± 0%   5.000 ± 0%  ~       (p=1.000 n=8, all samples equal)
```

The allocation count here doesn't drop further because #5162's conditional shadow-guard had already eliminated the second allocation on this particular call path (no ancestor snapshot to shadow); this PR still shaves 16 B/op off it via the smaller single-node representation, with no regression anywhere.

`BenchmarkContextWithSpan` (added upstream by #5162 while this PR was in progress, in `ddtrace/tracer/context_bench_test.go`) is added to the `microbenchmarks-2` CI gate in `.gitlab/benchmarks/micro/gitlab-ci.yml` so these allocation counts are tracked on every PR going forward.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
