### PR TITLE
fix(civisibility): isolate quarantined race test subtrees

### DIFF
--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -1,0 +1,273 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package coverage
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
+// ProcessTestCoverageFile is a serializable per-test coverage delta produced
+// by an isolated test process.
+type ProcessTestCoverageFile struct {
+	Name   string `json:"name"`
+	Bitmap []byte `json:"bitmap,omitempty"`
+}
+
+// ProcessTestCoverage owns one runtime-coverage delta.
+type ProcessTestCoverage struct {
+	coverage     *testCoverage
+	temporaryDir string
+	active       bool
+}
+
+var (
+	processCoverageMu        sync.Mutex
+	processAggregateCoverage *orderedCoverProfile
+)
+
+// BeginProcessTestCoverage starts a coverage delta. Callers serialize covered
+// test bodies because Go's runtime coverage counters are process-global.
+func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
+	if !CanCollect() {
+		return nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	temporaryDir, err := os.MkdirTemp("", "dd-process-coverage-*")
+	if err != nil {
+		log.Debug("civisibility.cov: error creating process coverage directory: %s", err.Error())
+		telemetry.CodeCoverageErrors()
+		return nil
+	}
+	collector := &testCoverage{
+		testFile:             utils.GetRelativePathFromCITagsSourceRoot(testFile),
+		preCoverageFilename:  filepath.Join(temporaryDir, "pre.out"),
+		postCoverageFilename: filepath.Join(temporaryDir, "post.out"),
+	}
+	if err := collector.collectCoverageBeforeTestExecution(); err != nil {
+		log.Debug("civisibility.cov: error getting process coverage file: %s", err.Error())
+		telemetry.CodeCoverageErrors()
+		_ = os.RemoveAll(temporaryDir)
+		return nil
+	}
+	return &ProcessTestCoverage{coverage: collector, temporaryDir: temporaryDir, active: true}
+}
+
+// Finish returns the coverage delta and releases the collector resources.
+func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
+	if c == nil || !c.active {
+		return nil
+	}
+	c.active = false
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	defer func() { _ = os.RemoveAll(c.temporaryDir) }()
+	if err := c.coverage.collectCoverageAfterTestExecution(); err != nil || !c.coverage.loadCoverageData() {
+		return nil
+	}
+	files := make([]ProcessTestCoverageFile, 0, len(c.coverage.filesCovered))
+	for _, file := range c.coverage.filesCovered {
+		files = append(files, ProcessTestCoverageFile{Name: file.name, Bitmap: file.bitmap})
+	}
+	return files
+}
+
+// ProcessCoverageProfile owns the aggregate coverage snapshot captured before
+// an isolated workload starts.
+type ProcessCoverageProfile struct {
+	before *orderedCoverProfile
+}
+
+// BeginProcessCoverageProfile captures the aggregate coverage present before
+// an isolated workload starts.
+func BeginProcessCoverageProfile() (*ProcessCoverageProfile, error) {
+	if !CanComputeCoverageProfile() {
+		return nil, nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	before, err := snapshotProcessCoverageProfile()
+	if err != nil {
+		return nil, err
+	}
+	return &ProcessCoverageProfile{before: before}, nil
+}
+
+// WriteDelta writes only coverage added since BeginProcessCoverageProfile.
+func (p *ProcessCoverageProfile) WriteDelta(path string) error {
+	if p == nil {
+		return nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	after, err := snapshotProcessCoverageProfile()
+	if err != nil {
+		return err
+	}
+	if err := subtractProcessCoverageProfiles(p.before, after); err != nil {
+		return err
+	}
+	return after.writeAtomic(path)
+}
+
+func snapshotProcessCoverageProfile() (*orderedCoverProfile, error) {
+	temporaryDir, err := os.MkdirTemp("", "dd-process-profile-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(temporaryDir) }()
+	path := filepath.Join(temporaryDir, "coverage.out")
+	if _, err := tearDown(path, ""); err != nil {
+		return nil, err
+	}
+	return parseOrderedCoverProfile(path)
+}
+
+func subtractProcessCoverageProfiles(before, after *orderedCoverProfile) error {
+	if before == nil || after == nil {
+		return errors.New("coverage profile missing")
+	}
+	if len(before.lines) == 0 || len(after.lines) == 0 || strings.TrimSpace(before.lines[0].raw) != strings.TrimSpace(after.lines[0].raw) {
+		return errors.New("coverage profile modes differ")
+	}
+	mode := strings.TrimSpace(strings.TrimPrefix(after.lines[0].raw, "mode:"))
+	beforeByBlock := make(map[string]int)
+	for idx := range before.lines {
+		line := &before.lines[idx]
+		if line.block != nil {
+			beforeByBlock[processCoverageBlockKey(line.fileName, line.block)] = line.block.count
+		}
+	}
+	for idx := range after.lines {
+		line := &after.lines[idx]
+		if line.block == nil {
+			continue
+		}
+		beforeCount := beforeByBlock[processCoverageBlockKey(line.fileName, line.block)]
+		if mode == "set" {
+			if line.block.count <= beforeCount {
+				line.block.count = 0
+			}
+		} else {
+			line.block.count = max(line.block.count-beforeCount, 0)
+		}
+	}
+	return nil
+}
+
+// MergeProcessCoverageProfile validates and accumulates an isolated process
+// profile. The parent runtime profile is not touched until M.Run has finished;
+// taking its snapshot while tests are still running would lose later coverage.
+func MergeProcessCoverageProfile(childPath string) error {
+	if !CanComputeCoverageProfile() {
+		return nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	child, err := parseOrderedCoverProfile(childPath)
+	if err != nil {
+		return err
+	}
+	if processAggregateCoverage == nil {
+		processAggregateCoverage = child
+		return nil
+	}
+	return mergeProcessCoverageProfiles(processAggregateCoverage, child)
+}
+
+// FinalizeProcessCoverageProfiles merges all isolated coverage once, after
+// testing.M.Run has produced the parent's final profile. This also updates an
+// explicit -coverprofile because RuntimeCoverageSnapshot selects that file.
+func FinalizeProcessCoverageProfiles() (bool, error) {
+	if !CanComputeCoverageProfile() {
+		return false, nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	if processAggregateCoverage == nil {
+		return false, nil
+	}
+	parentSnapshot, err := RuntimeCoverageSnapshot()
+	if err != nil {
+		return false, err
+	}
+	parent, err := parseOrderedCoverProfile(parentSnapshot.path)
+	if err != nil {
+		return false, err
+	}
+	if err := mergeProcessCoverageProfiles(parent, processAggregateCoverage); err != nil {
+		return false, err
+	}
+	if err := parent.writeAtomic(parentSnapshot.path); err != nil {
+		return false, err
+	}
+	processAggregateCoverage = nil
+	return true, nil
+}
+
+func mergeProcessCoverageProfiles(parent, child *orderedCoverProfile) error {
+	if parent == nil || child == nil {
+		return errors.New("coverage profile missing")
+	}
+	if len(parent.lines) == 0 || len(child.lines) == 0 || strings.TrimSpace(parent.lines[0].raw) != strings.TrimSpace(child.lines[0].raw) {
+		return errors.New("coverage profile modes differ")
+	}
+	mode := strings.TrimSpace(strings.TrimPrefix(parent.lines[0].raw, "mode:"))
+	byBlock := make(map[string]*coverageBlock)
+	for idx := range parent.lines {
+		line := &parent.lines[idx]
+		if line.block != nil {
+			byBlock[processCoverageBlockKey(line.fileName, line.block)] = line.block
+		}
+	}
+	for idx := range child.lines {
+		line := &child.lines[idx]
+		if line.block == nil {
+			continue
+		}
+		key := processCoverageBlockKey(line.fileName, line.block)
+		block := byBlock[key]
+		if block == nil {
+			return errors.New("coverage profile blocks differ")
+		}
+		if mode == "set" {
+			block.count = max(block.count, line.block.count)
+		} else if line.block.count > math.MaxInt-block.count {
+			block.count = math.MaxInt
+		} else {
+			block.count += line.block.count
+		}
+	}
+	return nil
+}
+
+func processCoverageBlockKey(fileName string, block *coverageBlock) string {
+	return fmt.Sprintf("%s:%d.%d,%d.%d %d", fileName, block.startLine, block.startCol, block.endLine, block.endCol, block.numStmt)
+}
+
+// SubmitProcessTestCoverage attaches child-produced coverage to the parent test
+// event identifiers and queues it on the existing coverage writer.
+func SubmitProcessTestCoverage(sessionID, suiteID, testID uint64, files []ProcessTestCoverageFile) {
+	if !CanCollectPerTestCoverage() || covWriter == nil || len(files) == 0 {
+		return
+	}
+	covered := make([]coveredFile, 0, len(files))
+	for _, file := range files {
+		covered = append(covered, coveredFile{name: file.Name, bitmap: file.Bitmap})
+	}
+	telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
+	(&testCoverage{sessionID: sessionID, suiteID: suiteID, testID: testID, filesCovered: covered}).submitCoverageData()
+}

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -28,8 +28,10 @@ type ProcessTestCoverageFile struct {
 
 // ProcessTestCoverage owns one runtime-coverage delta.
 type ProcessTestCoverage struct {
+	testFile     string
 	coverage     *testCoverage
 	temporaryDir string
+	files        []ProcessTestCoverageFile
 	active       bool
 }
 
@@ -44,16 +46,50 @@ func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 	if !CanCollect() {
 		return nil
 	}
+	collector := &ProcessTestCoverage{testFile: testFile}
+	if !collector.resume() {
+		return nil
+	}
+	return collector
+}
+
+// Pause finishes the active coverage segment. A later Resume starts a new
+// baseline so coverage collected while the test is suspended is excluded.
+func (c *ProcessTestCoverage) Pause() {
+	if c == nil || !c.active {
+		return
+	}
+	c.active = false
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	defer func() { _ = os.RemoveAll(c.temporaryDir) }()
+	if err := c.coverage.collectCoverageAfterTestExecution(); err != nil || !c.coverage.loadCoverageData() {
+		return
+	}
+	c.files = mergeProcessTestCoverageFiles(c.files, c.coverage.filesCovered)
+}
+
+// Resume starts another coverage segment after a suspended test resumes.
+func (c *ProcessTestCoverage) Resume() {
+	if c != nil {
+		c.resume()
+	}
+}
+
+func (c *ProcessTestCoverage) resume() bool {
+	if c.active {
+		return true
+	}
 	processCoverageMu.Lock()
 	defer processCoverageMu.Unlock()
 	temporaryDir, err := os.MkdirTemp("", "dd-process-coverage-*")
 	if err != nil {
 		log.Debug("civisibility.cov: error creating process coverage directory: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		return nil
+		return false
 	}
 	collector := &testCoverage{
-		testFile:             utils.GetRelativePathFromCITagsSourceRoot(testFile),
+		testFile:             utils.GetRelativePathFromCITagsSourceRoot(c.testFile),
 		preCoverageFilename:  filepath.Join(temporaryDir, "pre.out"),
 		postCoverageFilename: filepath.Join(temporaryDir, "post.out"),
 	}
@@ -61,28 +97,46 @@ func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 		log.Debug("civisibility.cov: error getting process coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
 		_ = os.RemoveAll(temporaryDir)
-		return nil
+		return false
 	}
-	return &ProcessTestCoverage{coverage: collector, temporaryDir: temporaryDir, active: true}
+	c.coverage = collector
+	c.temporaryDir = temporaryDir
+	c.active = true
+	return true
 }
 
 // Finish returns the coverage delta and releases the collector resources.
 func (c *ProcessTestCoverage) Finish() []ProcessTestCoverageFile {
-	if c == nil || !c.active {
+	if c == nil {
 		return nil
 	}
-	c.active = false
-	processCoverageMu.Lock()
-	defer processCoverageMu.Unlock()
-	defer func() { _ = os.RemoveAll(c.temporaryDir) }()
-	if err := c.coverage.collectCoverageAfterTestExecution(); err != nil || !c.coverage.loadCoverageData() {
-		return nil
-	}
-	files := make([]ProcessTestCoverageFile, 0, len(c.coverage.filesCovered))
-	for _, file := range c.coverage.filesCovered {
-		files = append(files, ProcessTestCoverageFile{Name: file.name, Bitmap: file.bitmap})
-	}
+	c.Pause()
+	files := c.files
+	c.files = nil
 	return files
+}
+
+func mergeProcessTestCoverageFiles(dst []ProcessTestCoverageFile, src []coveredFile) []ProcessTestCoverageFile {
+	indexes := make(map[string]int, len(dst)+len(src))
+	for idx := range dst {
+		indexes[dst[idx].Name] = idx
+	}
+	for _, file := range src {
+		idx, found := indexes[file.name]
+		if !found {
+			indexes[file.name] = len(dst)
+			dst = append(dst, ProcessTestCoverageFile{Name: file.name, Bitmap: file.bitmap})
+			continue
+		}
+		bitmap := &dst[idx].Bitmap
+		if missing := len(file.bitmap) - len(*bitmap); missing > 0 {
+			*bitmap = append(*bitmap, make([]byte, missing)...)
+		}
+		for idx, value := range file.bitmap {
+			(*bitmap)[idx] |= value
+		}
+	}
+	return dst
 }
 
 // ProcessCoverageProfile owns the aggregate coverage snapshot captured before

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -145,6 +145,7 @@ func mergeProcessTestCoverageFiles(dst []ProcessTestCoverageFile, src []coveredF
 // an isolated workload starts.
 type ProcessCoverageProfile struct {
 	before *orderedCoverProfile
+	delta  *orderedCoverProfile
 }
 
 // BeginProcessCoverageProfile captures the aggregate coverage present before
@@ -162,13 +163,22 @@ func BeginProcessCoverageProfile() (*ProcessCoverageProfile, error) {
 	return &ProcessCoverageProfile{before: before}, nil
 }
 
-// WriteDelta writes only coverage added since BeginProcessCoverageProfile.
-func (p *ProcessCoverageProfile) WriteDelta(path string) error {
+// Pause finishes the active aggregate coverage segment. A later Resume starts
+// a new baseline so coverage collected while the workload is suspended is
+// excluded.
+func (p *ProcessCoverageProfile) Pause() error {
 	if p == nil {
 		return nil
 	}
 	processCoverageMu.Lock()
 	defer processCoverageMu.Unlock()
+	return p.pause()
+}
+
+func (p *ProcessCoverageProfile) pause() error {
+	if p.before == nil {
+		return nil
+	}
 	after, err := snapshotProcessCoverageProfile()
 	if err != nil {
 		return err
@@ -176,7 +186,48 @@ func (p *ProcessCoverageProfile) WriteDelta(path string) error {
 	if err := subtractProcessCoverageProfiles(p.before, after); err != nil {
 		return err
 	}
-	return after.writeAtomic(path)
+	if p.delta == nil {
+		p.delta = after
+	} else if err := mergeProcessCoverageProfiles(p.delta, after); err != nil {
+		return err
+	}
+	p.before = nil
+	return nil
+}
+
+// Resume starts another aggregate coverage segment after a suspended workload
+// resumes.
+func (p *ProcessCoverageProfile) Resume() error {
+	if p == nil {
+		return nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	if p.before != nil {
+		return nil
+	}
+	before, err := snapshotProcessCoverageProfile()
+	if err != nil {
+		return err
+	}
+	p.before = before
+	return nil
+}
+
+// WriteDelta writes the aggregate coverage collected across active segments.
+func (p *ProcessCoverageProfile) WriteDelta(path string) error {
+	if p == nil {
+		return nil
+	}
+	processCoverageMu.Lock()
+	defer processCoverageMu.Unlock()
+	if err := p.pause(); err != nil {
+		return err
+	}
+	if p.delta == nil {
+		return errors.New("coverage profile missing")
+	}
+	return p.delta.writeAtomic(path)
 }
 
 func snapshotProcessCoverageProfile() (*orderedCoverProfile, error) {

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -36,8 +36,9 @@ type ProcessTestCoverage struct {
 }
 
 var (
-	processCoverageMu        sync.Mutex
-	processAggregateCoverage *orderedCoverProfile
+	processCoverageMu           sync.Mutex
+	processAggregateCoverage    *orderedCoverProfile
+	processAggregateCoverageErr error
 )
 
 // BeginProcessTestCoverage starts a coverage delta. Callers serialize covered
@@ -231,15 +232,23 @@ func MergeProcessCoverageProfile(childPath string) error {
 	}
 	processCoverageMu.Lock()
 	defer processCoverageMu.Unlock()
+	if processAggregateCoverageErr != nil {
+		return processAggregateCoverageErr
+	}
 	child, err := parseOrderedCoverProfile(childPath)
 	if err != nil {
+		processAggregateCoverageErr = err
 		return err
 	}
 	if processAggregateCoverage == nil {
 		processAggregateCoverage = child
 		return nil
 	}
-	return mergeProcessCoverageProfiles(processAggregateCoverage, child)
+	if err := mergeProcessCoverageProfiles(processAggregateCoverage, child); err != nil {
+		processAggregateCoverageErr = err
+		return err
+	}
+	return nil
 }
 
 // FinalizeProcessCoverageProfiles merges all isolated coverage once, after
@@ -251,6 +260,9 @@ func FinalizeProcessCoverageProfiles() (bool, error) {
 	}
 	processCoverageMu.Lock()
 	defer processCoverageMu.Unlock()
+	if processAggregateCoverageErr != nil {
+		return false, processAggregateCoverageErr
+	}
 	if processAggregateCoverage == nil {
 		return false, nil
 	}

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage.go
@@ -41,8 +41,9 @@ var (
 	processAggregateCoverageErr error
 )
 
-// BeginProcessTestCoverage starts a coverage delta. Callers serialize covered
-// test bodies because Go's runtime coverage counters are process-global.
+// BeginProcessTestCoverage starts a coverage delta. Because Go's runtime
+// coverage counters are process-global, callers must serialize covered test
+// bodies or discard deltas whose bodies overlap.
 func BeginProcessTestCoverage(testFile string) *ProcessTestCoverage {
 	if !CanCollect() {
 		return nil

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package coverage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMergeProcessCoverageProfilesAddsIsolatedCounts(t *testing.T) {
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent.out")
+	childPath := filepath.Join(dir, "child.out")
+	require.NoError(t, os.WriteFile(parentPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 2\npkg/file.go:2.1,2.2 1 0\n"), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 3\npkg/file.go:2.1,2.2 1 1\n"), 0o600))
+	parent, err := parseOrderedCoverProfile(parentPath)
+	require.NoError(t, err)
+	child, err := parseOrderedCoverProfile(childPath)
+	require.NoError(t, err)
+
+	require.NoError(t, mergeProcessCoverageProfiles(parent, child))
+	require.Equal(t, 5, parent.lines[1].block.count)
+	require.Equal(t, 1, parent.lines[2].block.count)
+}
+
+func TestMergeProcessCoverageProfilesRejectsDifferentBlocks(t *testing.T) {
+	parent := processCoverageProfileForTest(t, "count", 1)
+	childPath := filepath.Join(t.TempDir(), "child.out")
+	require.NoError(t, os.WriteFile(childPath, []byte("mode: count\npkg/other.go:1.1,1.2 1 1\n"), 0o600))
+	child, err := parseOrderedCoverProfile(childPath)
+	require.NoError(t, err)
+	require.Error(t, mergeProcessCoverageProfiles(parent, child))
+}
+
+func TestFinalizeProcessCoverageProfilesWaitsForParentProfile(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent.out")
+	firstChildPath := filepath.Join(dir, "first-child.out")
+	secondChildPath := filepath.Join(dir, "second-child.out")
+	require.NoError(t, os.WriteFile(parentPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 2\n"), 0o600))
+	require.NoError(t, os.WriteFile(firstChildPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 3\n"), 0o600))
+	require.NoError(t, os.WriteFile(secondChildPath, []byte("mode: count\npkg/file.go:1.1,1.2 1 4\n"), 0o600))
+	mode = "count"
+	tearDown = func(_, _ string) (string, error) {
+		return "", errors.New("runtime snapshot should already exist")
+	}
+	runtimeSnapshot = &runtimeCoverageSnapshot{path: parentPath}
+
+	require.NoError(t, MergeProcessCoverageProfile(firstChildPath))
+	require.NoError(t, MergeProcessCoverageProfile(secondChildPath))
+	beforeFinalization, err := os.ReadFile(parentPath)
+	require.NoError(t, err)
+	require.Contains(t, string(beforeFinalization), " 2\n")
+
+	merged, err := FinalizeProcessCoverageProfiles()
+	require.NoError(t, err)
+	require.True(t, merged)
+	parent, err := parseOrderedCoverProfile(parentPath)
+	require.NoError(t, err)
+	require.Equal(t, 9, parent.lines[1].block.count)
+
+	merged, err = FinalizeProcessCoverageProfiles()
+	require.NoError(t, err)
+	require.False(t, merged)
+}
+
+func TestProcessCoverageProfileWritesOnlyWorkloadDelta(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() { mode, tearDown = oldMode, oldTearDown })
+	mode = "count"
+	profiles := [][]byte{
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 2\npkg/source.go:2.1,2.2 1 0\n"),
+		[]byte("mode: count\npkg/source.go:1.1,1.2 1 2\npkg/source.go:2.1,2.2 1 3\n"),
+	}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		profile := profiles[snapshots]
+		snapshots++
+		return path, os.WriteFile(path, profile, 0o600)
+	}
+
+	profile, err := BeginProcessCoverageProfile()
+	require.NoError(t, err)
+	output := filepath.Join(t.TempDir(), "delta.out")
+	require.NoError(t, profile.WriteDelta(output))
+
+	delta, err := parseOrderedCoverProfile(output)
+	require.NoError(t, err)
+	require.Equal(t, 0, delta.lines[1].block.count)
+	require.Equal(t, 3, delta.lines[2].block.count)
+	require.Equal(t, 2, snapshots)
+}
+
+func TestSubtractProcessCoverageProfilesUsesModeSemantics(t *testing.T) {
+	for _, tt := range []struct {
+		mode        string
+		beforeCount int
+		afterCount  int
+		want        int
+	}{
+		{mode: "count", beforeCount: 4, afterCount: 7, want: 3},
+		{mode: "atomic", beforeCount: 4, afterCount: 7, want: 3},
+		{mode: "set", beforeCount: 1, afterCount: 1, want: 0},
+		{mode: "set", beforeCount: 0, afterCount: 1, want: 1},
+	} {
+		t.Run(fmt.Sprintf("%s/%d-%d", tt.mode, tt.beforeCount, tt.afterCount), func(t *testing.T) {
+			before := processCoverageProfileForTest(t, tt.mode, tt.beforeCount)
+			after := processCoverageProfileForTest(t, tt.mode, tt.afterCount)
+			require.NoError(t, subtractProcessCoverageProfiles(before, after))
+			require.Equal(t, tt.want, after.lines[1].block.count)
+		})
+	}
+}
+
+func processCoverageProfileForTest(t *testing.T, profileMode string, count int) *orderedCoverProfile {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.out")
+	require.NoError(t, os.WriteFile(path, fmt.Appendf(nil, "mode: %s\npkg/source.go:1.1,1.2 1 %d\n", profileMode, count), 0o600))
+	profile, err := parseOrderedCoverProfile(path)
+	require.NoError(t, err)
+	return profile
+}
+
+func TestProcessTestCoverageSupportsNestedInclusiveCollectors(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() { mode, tearDown = oldMode, oldTearDown })
+	mode = "count"
+	counts := []int{0, 1, 2, 3}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		count := counts[snapshots]
+		snapshots++
+		return path, os.WriteFile(path, fmt.Appendf(nil, "mode: count\npkg/source.go:1.1,1.2 1 %d\n", count), 0o600)
+	}
+
+	outer := BeginProcessTestCoverage("pkg/outer_test.go")
+	inner := BeginProcessTestCoverage("pkg/inner_test.go")
+	require.NotNil(t, outer)
+	require.NotNil(t, inner)
+	innerFiles := inner.Finish()
+	outerFiles := outer.Finish()
+
+	require.Equal(t, 4, snapshots)
+	require.Equal(t, []ProcessTestCoverageFile{{Name: "pkg/inner_test.go"}, {Name: "pkg/source.go", Bitmap: []byte{0x80}}}, innerFiles)
+	require.Equal(t, []ProcessTestCoverageFile{{Name: "pkg/outer_test.go"}, {Name: "pkg/source.go", Bitmap: []byte{0x80}}}, outerFiles)
+}
+
+func TestSubmitProcessTestCoverageUsesParentEventIdentifiers(t *testing.T) {
+	oldMode, oldUpload, oldWriter := mode, coverageUploadEnabled, covWriter
+	t.Cleanup(func() { mode, coverageUploadEnabled, covWriter = oldMode, oldUpload, oldWriter })
+	mode = "count"
+	coverageUploadEnabled = true
+	covWriter = &coverageWriter{payload: newCoveragePayload(), climit: make(chan struct{}, 1)}
+
+	SubmitProcessTestCoverage(11, 22, 33, []ProcessTestCoverageFile{
+		{Name: "pkg/test_file.go"},
+		{Name: "pkg/source.go", Bitmap: []byte{0x03}},
+	})
+
+	var got ciTestCoverages
+	payload, err := io.ReadAll(covWriter.payload)
+	require.NoError(t, err)
+	require.NoError(t, msgp.Decode(bytes.NewReader(payload), &got))
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(11), got[0].SessionID)
+	require.Equal(t, uint64(22), got[0].SuiteID)
+	require.Equal(t, uint64(33), got[0].SpanID)
+}

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -77,6 +77,23 @@ func TestFinalizeProcessCoverageProfilesWaitsForParentProfile(t *testing.T) {
 	require.False(t, merged)
 }
 
+func TestFinalizeProcessCoverageProfilesRetainsInvocationMergeFailure(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+	mode = "count"
+	tearDown = func(_, _ string) (string, error) {
+		return "", errors.New("runtime snapshot must not be published")
+	}
+	childPath := filepath.Join(t.TempDir(), "malformed-child.out")
+	require.NoError(t, os.WriteFile(childPath, []byte("not a coverage profile\n"), 0o600))
+
+	mergeErr := MergeProcessCoverageProfile(childPath)
+	require.Error(t, mergeErr)
+	merged, err := FinalizeProcessCoverageProfiles()
+	require.False(t, merged)
+	require.EqualError(t, err, mergeErr.Error())
+}
+
 func TestProcessCoverageProfileWritesOnlyWorkloadDelta(t *testing.T) {
 	oldMode, oldTearDown := mode, tearDown
 	t.Cleanup(func() { mode, tearDown = oldMode, oldTearDown })

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap"
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 )
@@ -75,6 +76,40 @@ func TestFinalizeProcessCoverageProfilesWaitsForParentProfile(t *testing.T) {
 	merged, err = FinalizeProcessCoverageProfiles()
 	require.NoError(t, err)
 	require.False(t, merged)
+}
+
+func TestFinalizeProcessCoverageProfilesBeforeBackfillPreservesRealCounts(t *testing.T) {
+	ResetForTesting()
+	t.Cleanup(ResetForTesting)
+	dir := t.TempDir()
+	parentPath := filepath.Join(dir, "parent.out")
+	childPath := filepath.Join(dir, "child.out")
+	const profile = "mode: atomic\ngithub.com/example/project/pkg/file.go:1.1,1.2 1 %d\n"
+	require.NoError(t, os.WriteFile(parentPath, []byte(fmt.Sprintf(profile, 0)), 0o600))
+	require.NoError(t, os.WriteFile(childPath, []byte(fmt.Sprintf(profile, 1)), 0o600))
+	mode = "atomic"
+	modulePath = "github.com/example/project"
+	tearDown = func(_, _ string) (string, error) {
+		return "", errors.New("runtime snapshot should already exist")
+	}
+	runtimeSnapshot = &runtimeCoverageSnapshot{path: parentPath}
+
+	require.NoError(t, MergeProcessCoverageProfile(childPath))
+	merged, err := FinalizeProcessCoverageProfiles()
+	require.NoError(t, err)
+	require.True(t, merged)
+	ConfigureBackfill(BackfillInput{
+		BackendCoverage: map[string]*filebitmap.FileBitmap{
+			"pkg/file.go": filebitmap.FromActiveRange(1, 1),
+		},
+		ActualSkips: 1,
+	})
+	result := FinalizeBackfill()
+	require.Empty(t, result.Reason)
+
+	parent, err := parseOrderedCoverProfile(parentPath)
+	require.NoError(t, err)
+	require.Equal(t, 1, parent.lines[1].block.count)
 }
 
 func TestFinalizeProcessCoverageProfilesRetainsInvocationMergeFailure(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -158,6 +158,34 @@ func TestProcessTestCoverageSupportsNestedInclusiveCollectors(t *testing.T) {
 	require.Equal(t, []ProcessTestCoverageFile{{Name: "pkg/outer_test.go"}, {Name: "pkg/source.go", Bitmap: []byte{0x80}}}, outerFiles)
 }
 
+func TestProcessTestCoveragePauseExcludesSuspendedCoverage(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() { mode, tearDown = oldMode, oldTearDown })
+	mode = "count"
+	counts := [][3]int{
+		{0, 0, 0}, // first segment starts
+		{1, 0, 0}, // first segment finishes
+		{1, 1, 0}, // another test runs while this collector is paused
+		{1, 1, 1}, // resumed segment finishes
+	}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		count := counts[snapshots]
+		snapshots++
+		profile := fmt.Appendf(nil, "mode: count\npkg/source.go:1.1,1.2 1 %d\npkg/source.go:2.1,2.2 1 %d\npkg/source.go:3.1,3.2 1 %d\n", count[0], count[1], count[2])
+		return path, os.WriteFile(path, profile, 0o600)
+	}
+
+	collector := BeginProcessTestCoverage("pkg/test_file.go")
+	require.NotNil(t, collector)
+	collector.Pause()
+	collector.Resume()
+	files := collector.Finish()
+
+	require.Equal(t, 4, snapshots)
+	require.Equal(t, []ProcessTestCoverageFile{{Name: "pkg/test_file.go"}, {Name: "pkg/source.go", Bitmap: []byte{0xa0}}}, files)
+}
+
 func TestSubmitProcessTestCoverageUsesParentEventIdentifiers(t *testing.T) {
 	oldMode, oldUpload, oldWriter := mode, coverageUploadEnabled, covWriter
 	t.Cleanup(func() { mode, coverageUploadEnabled, covWriter = oldMode, oldUpload, oldWriter })

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -121,6 +121,39 @@ func TestProcessCoverageProfileWritesOnlyWorkloadDelta(t *testing.T) {
 	require.Equal(t, 2, snapshots)
 }
 
+func TestProcessCoverageProfilePauseExcludesSuspendedCoverage(t *testing.T) {
+	oldMode, oldTearDown := mode, tearDown
+	t.Cleanup(func() { mode, tearDown = oldMode, oldTearDown })
+	mode = "count"
+	counts := [][3]int{
+		{0, 0, 0}, // first segment starts
+		{1, 0, 0}, // first segment finishes
+		{1, 1, 0}, // ancestor work runs while the isolated root is paused
+		{1, 1, 1}, // resumed segment finishes
+	}
+	var snapshots int
+	tearDown = func(path, _ string) (string, error) {
+		count := counts[snapshots]
+		snapshots++
+		profile := fmt.Appendf(nil, "mode: count\npkg/source.go:1.1,1.2 1 %d\npkg/source.go:2.1,2.2 1 %d\npkg/source.go:3.1,3.2 1 %d\n", count[0], count[1], count[2])
+		return path, os.WriteFile(path, profile, 0o600)
+	}
+
+	profile, err := BeginProcessCoverageProfile()
+	require.NoError(t, err)
+	require.NoError(t, profile.Pause())
+	require.NoError(t, profile.Resume())
+	output := filepath.Join(t.TempDir(), "delta.out")
+	require.NoError(t, profile.WriteDelta(output))
+
+	delta, err := parseOrderedCoverProfile(output)
+	require.NoError(t, err)
+	require.Equal(t, 1, delta.lines[1].block.count)
+	require.Equal(t, 0, delta.lines[2].block.count)
+	require.Equal(t, 1, delta.lines[3].block.count)
+	require.Equal(t, 4, snapshots)
+}
+
 func TestSubtractProcessCoverageProfilesUsesModeSemantics(t *testing.T) {
 	for _, tt := range []struct {
 		mode        string

--- a/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
+++ b/internal/civisibility/integrations/gotesting/coverage/process_coverage_test.go
@@ -14,9 +14,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap"
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/filebitmap"
 )
 
 func TestMergeProcessCoverageProfilesAddsIsolatedCounts(t *testing.T) {
@@ -85,8 +86,8 @@ func TestFinalizeProcessCoverageProfilesBeforeBackfillPreservesRealCounts(t *tes
 	parentPath := filepath.Join(dir, "parent.out")
 	childPath := filepath.Join(dir, "child.out")
 	const profile = "mode: atomic\ngithub.com/example/project/pkg/file.go:1.1,1.2 1 %d\n"
-	require.NoError(t, os.WriteFile(parentPath, []byte(fmt.Sprintf(profile, 0)), 0o600))
-	require.NoError(t, os.WriteFile(childPath, []byte(fmt.Sprintf(profile, 1)), 0o600))
+	require.NoError(t, os.WriteFile(parentPath, fmt.Appendf(nil, profile, 0), 0o600))
+	require.NoError(t, os.WriteFile(childPath, fmt.Appendf(nil, profile, 1), 0o600))
 	mode = "atomic"
 	modulePath = "github.com/example/project"
 	tearDown = func(_, _ string) (string, error) {

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -433,6 +433,7 @@ func CleanupRuntimeCoverageSnapshot() {
 func ResetForTesting() {
 	processCoverageMu.Lock()
 	processAggregateCoverage = nil
+	processAggregateCoverageErr = nil
 	processCoverageMu.Unlock()
 
 	coverageStateMu.Lock()

--- a/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
+++ b/internal/civisibility/integrations/gotesting/coverage/test_coverage.go
@@ -431,6 +431,10 @@ func CleanupRuntimeCoverageSnapshot() {
 
 // ResetForTesting clears package globals used by coverage tests.
 func ResetForTesting() {
+	processCoverageMu.Lock()
+	processAggregateCoverage = nil
+	processCoverageMu.Unlock()
+
 	coverageStateMu.Lock()
 	defer coverageStateMu.Unlock()
 
@@ -466,14 +470,20 @@ func (t *testCoverage) CollectCoverageBeforeTestExecution() {
 		return
 	}
 
-	t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
-	_, err := tearDown(t.preCoverageFilename, "")
-	if err != nil {
+	if err := t.collectCoverageBeforeTestExecution(); err != nil {
 		log.Debug("civisibility.cov: error getting coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
 	} else {
 		telemetry.CodeCoverageStarted(testFramework, telemetry.DefaultCoverageLibraryType)
 	}
+}
+
+func (t *testCoverage) collectCoverageBeforeTestExecution() error {
+	if t.preCoverageFilename == "" {
+		t.preCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-pre.out", t.moduleID, t.suiteID, t.testID))
+	}
+	_, err := tearDown(t.preCoverageFilename, "")
+	return err
 }
 
 // CollectCoverageAfterTestExecution collects coverage after test execution.
@@ -502,7 +512,13 @@ func (t *testCoverage) getCoverageData() error {
 		return nil
 	}
 
-	t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
+	return t.collectCoverageAfterTestExecution()
+}
+
+func (t *testCoverage) collectCoverageAfterTestExecution() error {
+	if t.postCoverageFilename == "" {
+		t.postCoverageFilename = filepath.Join(temporaryDir, fmt.Sprintf("%d-%d-%d-post.out", t.moduleID, t.suiteID, t.testID))
+	}
 	_, err := tearDown(t.postCoverageFilename, "")
 	if err != nil {
 		log.Debug("civisibility.cov: error getting coverage file: %s", err.Error())
@@ -514,35 +530,49 @@ func (t *testCoverage) getCoverageData() error {
 
 // processCoverageData processes the coverage data.
 func (t *testCoverage) processCoverageData() {
+	if !t.loadCoverageData() {
+		return
+	}
+	t.submitCoverageData()
+	t.removeCoverageFiles()
+}
+
+func (t *testCoverage) loadCoverageData() bool {
 	if t.preCoverageFilename == "" ||
 		t.postCoverageFilename == "" ||
 		t.preCoverageFilename == t.postCoverageFilename {
 		log.Debug("civisibility.cov: no coverage data to process")
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 	preCoverage, err := parseCoverProfile(t.preCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error parsing pre-coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 	postCoverage, err := parseCoverProfile(t.postCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error parsing post-coverage file: %s", err.Error())
 		telemetry.CodeCoverageErrors()
-		return
+		return false
 	}
 
 	t.filesCovered = getFilesCovered(t.testFile, preCoverage, postCoverage)
+	return true
+}
+
+func (t *testCoverage) submitCoverageData() {
 	telemetry.CodeCoverageFinished(testFramework, telemetry.DefaultCoverageLibraryType)
 	if len(t.filesCovered) == 0 {
 		telemetry.CodeCoverageIsEmpty()
 	}
 
 	covWriter.add(t)
+}
 
-	err = os.Remove(t.preCoverageFilename)
+func (t *testCoverage) removeCoverageFiles() {
+	err := os.Remove(t.preCoverageFilename)
 	if err != nil {
 		log.Debug("civisibility.cov: error removing pre-coverage file: %s", err.Error())
 	}

--- a/internal/civisibility/integrations/gotesting/fixtures/itrbackfill/manual/app/app_test.go
+++ b/internal/civisibility/integrations/gotesting/fixtures/itrbackfill/manual/app/app_test.go
@@ -6,8 +6,11 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/fixtures/itrbackfill/manual/lib"
 )
 
@@ -19,4 +22,17 @@ func TestCoversLib(t *testing.T) {
 
 func TestRunsNormally(t *testing.T) {
 	t.Log("normal test")
+}
+
+func TestAddsIncompatibleProcessCoverage(t *testing.T) {
+	if os.Getenv("DD_ITR_BACKFILL_SCENARIO") != "manual-process-coverage-merge-failure" {
+		t.Skip("fixture scenario only")
+	}
+	profile := filepath.Join(t.TempDir(), "isolated.out")
+	if err := os.WriteFile(profile, []byte("mode: set\nfixture/file.go:1.1,1.2 1 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := coverage.MergeProcessCoverageProfile(profile); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/civisibility/integrations/gotesting/fixtures/itrbackfill/manual/app/main_test.go
+++ b/internal/civisibility/integrations/gotesting/fixtures/itrbackfill/manual/app/main_test.go
@@ -6,6 +6,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -38,6 +39,7 @@ func TestMain(m *testing.M) {
 	expectSkipped := true
 	expectSkippingEnabled := "true"
 	expectPositiveCoverage := true
+	expectCoverageMergeFailure := scenario == "manual-process-coverage-merge-failure"
 	coverage := map[string][]byte{
 		manualLibPath: filebitmap.FromActiveRange(1, 64).ToArray(),
 	}
@@ -55,6 +57,9 @@ func TestMain(m *testing.M) {
 		expectPositiveCoverage = true
 		expectCoverageRequests = true
 	}
+	if expectCoverageMergeFailure {
+		expectCoverageReportRequests = false
+	}
 	server := mockci.Start(settings, tests, coverage)
 	defer server.Close()
 
@@ -70,7 +75,10 @@ func TestMain(m *testing.M) {
 		panic("unexpected ITR tests skipping enabled tag")
 	}
 	coverageValue, hasCoverage := server.SessionCoverage(constants.CodeCoveragePercentageOfTotalLines)
-	if !hasCoverage || (expectPositiveCoverage && coverageValue <= 0) {
+	if expectCoverageMergeFailure && hasCoverage {
+		panic("unexpected session coverage after process coverage merge failure")
+	}
+	if !expectCoverageMergeFailure && (!hasCoverage || (expectPositiveCoverage && coverageValue <= 0)) {
 		panic("unexpected session coverage")
 	}
 	if !expectCoverageRequests && server.CoverageRequests() > 0 {
@@ -112,6 +120,12 @@ func TestMain(m *testing.M) {
 	}
 	if server.EventTypeCount(constants.SpanTypeTestSuite) != 1 {
 		panic("expected exactly one test suite event")
+	}
+	if expectCoverageMergeFailure && exitCode != 1 {
+		panic("expected process coverage merge failure exit code")
+	}
+	if expectCoverageMergeFailure {
+		fmt.Println("process coverage merge failure publication suppressed")
 	}
 	os.Exit(exitCode)
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -83,6 +83,7 @@ type (
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
 		processRetryCoverageMu        *sync.Mutex
+		processRetryCoverageParallel  func() func()
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -1290,6 +1290,10 @@ func runTestCleanup(t *testing.T, result *testCleanupResult) {
 
 func runTestCleanupWithOptions(t *testing.T, result *testCleanupResult, neutralizeNativeParallelRelease bool) {
 	completeParallelSubtests(t, getTestPrivateFields(t), neutralizeNativeParallelRelease)
+	runTestCleanupCallbacks(t, result)
+}
+
+func runTestCleanupCallbacks(t *testing.T, result *testCleanupResult) {
 	result.ran = true
 	done := make(chan struct{})
 	go func() {

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -82,8 +82,7 @@ type (
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
-		processRetryCoverageMu        *sync.Mutex
-		processRetryCoverageParallel  func() func()
+		processRetryParallelPause     func() func()
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -82,6 +82,7 @@ type (
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
+		quarantinedRaceReplay         atomic.Pointer[quarantinedRaceReplayState]
 		processRetryAttemptOwner      string
 		processRetryManagedDescendant bool
 		processRetryParallelPause     func() func()

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -82,6 +82,7 @@ type (
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
+		processRetryCoverageMu        *sync.Mutex
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -85,6 +85,7 @@ type (
 		processRetryAttemptOwner      string
 		processRetryManagedDescendant bool
 		processRetryParallelPause     func() func()
+		processRetryParallelPaused    atomic.Bool
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -47,6 +47,7 @@ type (
 		isEarlyFlakeDetectionEnabled bool // flag to tag if Early Flake Detection is enabled for this execution
 		isFlakyTestRetriesEnabled    bool // flag to tag if Flaky Test Retries is enabled for this execution
 		isItrForcedRun               bool // flag to preserve ITR forced-run state across parent-owned process retries
+		isItrSkipped                 bool
 		flakyRetryBudgetReservation  *flakyRetryBudgetReservation
 		isQuarantined                bool          // flag to check if the test is quarantined
 		isDisabled                   bool          // flag to check if the test is disabled
@@ -79,6 +80,8 @@ type (
 		suppressUserTestBody          bool
 		retryAttemptFinalizer         func(retryAttemptResult)
 		deferredRetryEvent            *deferredProcessRetryEvent
+		quarantinedRaceProcess        *quarantinedRaceProcessContext
+		quarantinedRaceChild          *quarantinedRaceChildState
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function
@@ -131,6 +134,7 @@ type (
 		mRunInvocations            *atomic.Uint64
 		processRetryLaunchTemplate *processRetryLaunchBaseline
 		processRetryCoordinator    *processRetryCoordinator
+		quarantinedRaceProcess     *quarantinedRaceProcessContext
 		efdFaultySessionGuard      earlyFlakeDetectionFaultySession
 		retryAttemptObserveOutput  bool
 	}
@@ -688,6 +692,17 @@ func applyAdditionalFeaturesToTestFunc(
 
 	// get the pointer to use the reference in the wrapper
 	ptrMeta := &meta
+	quarantineProcess := wrapperOpts.quarantinedRaceProcess
+	if quarantineProcess == nil && parentExecMeta != nil {
+		quarantineProcess = parentExecMeta.quarantinedRaceProcess
+	}
+	if selection.path == additionalFeaturePathRetryWrapper && ptrMeta.isQuarantined && quarantineProcess != nil {
+		wrapper := func(t *testing.T) {
+			runQuarantinedRaceProcessIsolation(t, testInfo, parentExecMeta, ptrMeta, quarantineProcess)
+		}
+		setInstrumentationMetadata(runtime.FuncForPC(reflect.ValueOf(wrapper).Pointer()), &instrumentationMetadata{IsInternal: true})
+		return wrapper
+	}
 
 	switch selection.path {
 	case additionalFeaturePathNone:
@@ -1389,6 +1404,9 @@ func propagateTestExecutionMetadataFlags(execMeta *testExecutionMetadata, origin
 	execMeta.isFlakyTestRetriesEnabled = execMeta.isFlakyTestRetriesEnabled || originalExecMeta.isFlakyTestRetriesEnabled
 	if execMeta.flakyRetryBudgetReservation == nil {
 		execMeta.flakyRetryBudgetReservation = originalExecMeta.flakyRetryBudgetReservation
+	}
+	if execMeta.quarantinedRaceProcess == nil {
+		execMeta.quarantinedRaceProcess = originalExecMeta.quarantinedRaceProcess
 	}
 	execMeta.isQuarantined = execMeta.isQuarantined || originalExecMeta.isQuarantined
 	execMeta.isDisabled = execMeta.isDisabled || originalExecMeta.isDisabled

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -82,6 +82,8 @@ type (
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
+		processRetryAttemptOwner      string
+		processRetryManagedDescendant bool
 		processRetryParallelPause     func() func()
 	}
 

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -695,7 +695,7 @@ func instrumentTestingParallel(t *testing.T) (bool, func()) {
 		if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
 			state.startParallelBridge()
 		}
-		if pause := execMeta.processRetryCoverageParallel; pause != nil {
+		if pause := execMeta.processRetryParallelPause; pause != nil {
 			return false, pause()
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 	"time"
-	_ "unsafe" // required blank import to run orchestrion
+	"unsafe"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
@@ -692,12 +692,45 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 //go:linkname instrumentTestingParallel
 func instrumentTestingParallel(t *testing.T) (bool, func()) {
 	if execMeta := getTestMetadata(t); execMeta != nil && execMeta.processRetryOwner != nil {
+		willSuspend := testingParallelWillSuspend(t)
 		if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
-			state.startParallelBridge()
+			// The hook runs before testing.T.Parallel. Start the parent bridge only
+			// when the native method will reach its suspension point; invalid calls
+			// must retain testing's panic instead of waiting for an unused bridge.
+			if willSuspend {
+				state.startParallelBridge()
+			}
 		}
-		if pause := execMeta.processRetryParallelPause; pause != nil {
+		if pause := execMeta.processRetryParallelPause; pause != nil && willSuspend {
 			return false, pause()
 		}
 	}
 	return false, nil
+}
+
+func testingParallelWillSuspend(t *testing.T) bool {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || layout.disabled || !allAvailable(
+		layout.common.isParallel, layout.common.parent.unsafeField, layout.common.barrier, layout.denyParallel,
+	) {
+		return false
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return false
+	}
+	parent := pointerWord(base, layout.common.parent)
+	if parent == nil || *fieldPtr[bool](base, layout.common.isParallel) ||
+		layout.common.isSynctest.available && *fieldPtr[bool](base, layout.common.isSynctest) ||
+		*fieldPtr[chan bool](parent, layout.common.barrier) == nil {
+		return false
+	}
+	switch layout.denyParallel.typ {
+	case reflect.TypeFor[bool]():
+		return !*fieldPtr[bool](unsafe.Pointer(t), layout.denyParallel)
+	case reflect.TypeFor[string]():
+		return *fieldPtr[string](unsafe.Pointer(t), layout.denyParallel) == ""
+	default:
+		return false
+	}
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -685,36 +685,34 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 }
 
 // instrumentTestingParallel reports whether CI Visibility has replaced the
-// native Parallel implementation and returns work to run after native Parallel
-// resumes. Retry attempts use a fresh testing.T, so Parallel remains native
-// after an isolated subtree has notified its parent.
+// native Parallel implementation. Only an isolated quarantined race subtree
+// takes ownership; every other call keeps the existing native fast path.
 //
 //go:linkname instrumentTestingParallel
-func instrumentTestingParallel(t *testing.T) (bool, func()) {
-	if execMeta := getTestMetadata(t); execMeta != nil && execMeta.processRetryOwner != nil {
-		willSuspend := testingParallelWillSuspend(t)
-		if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
-			// The hook runs before testing.T.Parallel. Start the parent bridge only
-			// when the native method will reach its suspension point; invalid calls
-			// must retain testing's panic instead of waiting for an unused bridge.
-			if willSuspend {
-				state.startParallelBridge()
-			}
-		}
-		// Orchestrion can enter this hook through both our T wrapper and the
-		// woven testing.T.Parallel before native testing marks the test parallel.
-		// Only the first entry may own the matching pause/resume pair.
-		if pause := execMeta.processRetryParallelPause; pause != nil && willSuspend && execMeta.processRetryParallelPaused.CompareAndSwap(false, true) {
-			resume := pause()
-			return false, func() {
-				defer execMeta.processRetryParallelPaused.Store(false)
-				if resume != nil {
-					resume()
-				}
-			}
-		}
+func instrumentTestingParallel(t *testing.T) bool {
+	if !quarantinedRaceParallelHookActive {
+		return false
 	}
-	return false, nil
+	execMeta := getTestMetadata(t)
+	if execMeta == nil || execMeta.processRetryParallelPause == nil || execMeta.processRetryParallelPaused.Load() || !testingParallelWillSuspend(t) {
+		return false
+	}
+	if !execMeta.processRetryParallelPaused.CompareAndSwap(false, true) {
+		return false
+	}
+	defer execMeta.processRetryParallelPaused.Store(false)
+
+	if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
+		state.startParallelBridge()
+	}
+	resume := execMeta.processRetryParallelPause()
+	if resume != nil {
+		defer resume()
+	}
+	// Parallel is already woven with this hook. The guard above makes that
+	// nested entry return false so exactly one native call suspends the test.
+	t.Parallel()
+	return true
 }
 
 func testingParallelWillSuspend(t *testing.T) bool {

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -633,7 +633,12 @@ func instrumentTestifySuiteRun(t *testing.T, suite any) {
 	}
 	defer release()
 	if isProcessRetryChild() {
-		return
+		execMeta := getTestMetadata(t)
+		if execMeta == nil || execMeta.quarantinedRaceChild == nil {
+			return
+		}
+		// The isolated subtree still needs the real Testify method for source,
+		// CODEOWNERS, impacted-test, and ITR metadata; it creates no child span.
 	}
 
 	log.Debug("instrumentTestifySuiteRun: instrumenting testify suite run")
@@ -680,11 +685,15 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 }
 
 // instrumentTestingParallel reports whether CI Visibility has replaced the
-// native Parallel implementation. Retry attempts now use a fresh testing.T and
-// bridge the real scheduler directly, so Parallel always remains native here.
+// native Parallel implementation. Retry attempts use a fresh testing.T, so
+// Parallel remains native after an isolated subtree has notified its parent.
 //
 //go:linkname instrumentTestingParallel
 func instrumentTestingParallel(t *testing.T) bool {
-	_ = t
+	if execMeta := getTestMetadata(t); execMeta != nil && execMeta.processRetryOwner != nil {
+		if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
+			state.startParallelBridge()
+		}
+	}
 	return false
 }

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -701,8 +701,17 @@ func instrumentTestingParallel(t *testing.T) (bool, func()) {
 				state.startParallelBridge()
 			}
 		}
-		if pause := execMeta.processRetryParallelPause; pause != nil && willSuspend {
-			return false, pause()
+		// Orchestrion can enter this hook through both our T wrapper and the
+		// woven testing.T.Parallel before native testing marks the test parallel.
+		// Only the first entry may own the matching pause/resume pair.
+		if pause := execMeta.processRetryParallelPause; pause != nil && willSuspend && execMeta.processRetryParallelPaused.CompareAndSwap(false, true) {
+			resume := pause()
+			return false, func() {
+				defer execMeta.processRetryParallelPaused.Store(false)
+				if resume != nil {
+					resume()
+				}
+			}
 		}
 	}
 	return false, nil

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -685,15 +685,19 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 }
 
 // instrumentTestingParallel reports whether CI Visibility has replaced the
-// native Parallel implementation. Retry attempts use a fresh testing.T, so
-// Parallel remains native after an isolated subtree has notified its parent.
+// native Parallel implementation and returns work to run after native Parallel
+// resumes. Retry attempts use a fresh testing.T, so Parallel remains native
+// after an isolated subtree has notified its parent.
 //
 //go:linkname instrumentTestingParallel
-func instrumentTestingParallel(t *testing.T) bool {
+func instrumentTestingParallel(t *testing.T) (bool, func()) {
 	if execMeta := getTestMetadata(t); execMeta != nil && execMeta.processRetryOwner != nil {
 		if state := execMeta.quarantinedRaceChild; state != nil && state.cfg != nil && t.Name() == state.cfg.SelectedRoot {
 			state.startParallelBridge()
 		}
+		if pause := execMeta.processRetryCoverageParallel; pause != nil {
+			return false, pause()
+		}
 	}
-	return false
+	return false, nil
 }

--- a/internal/civisibility/integrations/gotesting/itrbackfillfixture/itrbackfill_fixture_test.go
+++ b/internal/civisibility/integrations/gotesting/itrbackfillfixture/itrbackfill_fixture_test.go
@@ -8,6 +8,7 @@ package itrbackfillfixture
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -24,6 +25,7 @@ func TestITRCoverageBackfillManualFixture(t *testing.T) {
 		name              string
 		extraEnv          []string
 		skipProfileAssert bool
+		expectFailure     bool
 	}{
 		{name: "manual-count"},
 		{name: "manual-codecoverage-disabled", extraEnv: []string{"DD_ITR_BACKFILL_CODE_COVERAGE=false"}},
@@ -31,13 +33,17 @@ func TestITRCoverageBackfillManualFixture(t *testing.T) {
 		{name: "manual-coverage-report-disabled", extraEnv: []string{"DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED=false"}},
 		{name: "manual-partial-coverage", extraEnv: []string{"DD_ITR_BACKFILL_PARTIAL_COVERAGE=true"}, skipProfileAssert: true},
 		{name: "manual-producer-bitmap-upload", skipProfileAssert: true},
+		{name: "manual-process-coverage-merge-failure", skipProfileAssert: true, expectFailure: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			profile := filepath.Join(t.TempDir(), test.name+".out")
-			runFixtureCommand(t, fixtureDir, test.name, profile, goCache, test.extraEnv,
+			output := runFixtureCommand(t, fixtureDir, test.name, profile, goCache, test.extraEnv, test.expectFailure,
 				"go", "test", "-mod=readonly", "./...",
 				"-cover", "-covermode=count", "-coverpkg", "./...",
 				"-count=1", "-coverprofile", profile)
+			if test.expectFailure && !strings.Contains(output, "process coverage merge failure publication suppressed") {
+				t.Fatalf("fixture did not verify failed-merge publication behavior:\n%s", output)
+			}
 			if !test.skipProfileAssert {
 				assertProfileContainsPositiveCounts(t, profile, "fixtures/itrbackfill/manual/lib/lib.go")
 			}
@@ -95,7 +101,7 @@ func TestITRCoverageBackfillOrchestrionFixture(t *testing.T) {
 				args = append(args, "-coverprofile", profile)
 			}
 			args = append(args, test.extraTestArgs...)
-			runFixtureCommand(t, fixtureDir, test.name, profile, goCache, test.extraEnv, args...)
+			runFixtureCommand(t, fixtureDir, test.name, profile, goCache, test.extraEnv, false, args...)
 			if test.withProfile && !test.skipProfileAssert {
 				profilePaths := test.profilePaths
 				if len(profilePaths) == 0 {
@@ -117,7 +123,7 @@ func sharedFixtureGoCache(t *testing.T) string {
 	return goCache
 }
 
-func runFixtureCommand(t *testing.T, fixtureDir, scenario, profile, goCache string, extraEnv []string, args ...string) {
+func runFixtureCommand(t *testing.T, fixtureDir, scenario, profile, goCache string, extraEnv []string, expectFailure bool, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command(args[0], args[1:]...)
@@ -128,7 +134,13 @@ func runFixtureCommand(t *testing.T, fixtureDir, scenario, profile, goCache stri
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
-	if err := cmd.Run(); err != nil {
+	err := cmd.Run()
+	if expectFailure {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			t.Fatalf("fixture command exit = %v, want 1\n%s", err, output.String())
+		}
+	} else if err != nil {
 		t.Fatalf("fixture command failed: %v\n%s", err, output.String())
 	}
 	if profile != "" {
@@ -136,6 +148,7 @@ func runFixtureCommand(t *testing.T, fixtureDir, scenario, profile, goCache stri
 			t.Fatalf("expected coverprofile %s: %v\n%s", profile, err, output.String())
 		}
 	}
+	return output.String()
 }
 
 func isolatedFixtureEnv(t *testing.T, scenario, goCache string) []string {

--- a/internal/civisibility/integrations/gotesting/orchestrion.yml
+++ b/internal/civisibility/integrations/gotesting/orchestrion.yml
@@ -80,7 +80,7 @@ aspects:
             func __dd_civisibility_instrumentSkipNow(tb TB)
             
             //go:linkname __dd_civisibility_instrumentTestingParallel github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestingParallel
-            func __dd_civisibility_instrumentTestingParallel(t *T) bool
+            func __dd_civisibility_instrumentTestingParallel(t *T) (bool, func())
 
       - prepend-statements:
           template: |-
@@ -189,7 +189,11 @@ aspects:
     advice:
       - prepend-statements:
           template: |-
-            if __dd_civisibility_instrumentTestingParallel({{ .Function.Receiver }}) {
+            __dd_civisibility_handled, __dd_civisibility_resume := __dd_civisibility_instrumentTestingParallel({{ .Function.Receiver }})
+            if __dd_civisibility_resume != nil {
+              defer __dd_civisibility_resume()
+            }
+            if __dd_civisibility_handled {
               return
             }
 

--- a/internal/civisibility/integrations/gotesting/orchestrion.yml
+++ b/internal/civisibility/integrations/gotesting/orchestrion.yml
@@ -80,7 +80,7 @@ aspects:
             func __dd_civisibility_instrumentSkipNow(tb TB)
             
             //go:linkname __dd_civisibility_instrumentTestingParallel github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting.instrumentTestingParallel
-            func __dd_civisibility_instrumentTestingParallel(t *T) (bool, func())
+            func __dd_civisibility_instrumentTestingParallel(t *T) bool
 
       - prepend-statements:
           template: |-
@@ -189,11 +189,7 @@ aspects:
     advice:
       - prepend-statements:
           template: |-
-            __dd_civisibility_handled, __dd_civisibility_resume := __dd_civisibility_instrumentTestingParallel({{ .Function.Receiver }})
-            if __dd_civisibility_resume != nil {
-              defer __dd_civisibility_resume()
-            }
-            if __dd_civisibility_handled {
+            if __dd_civisibility_instrumentTestingParallel({{ .Function.Receiver }}) {
               return
             }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_norace.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_norace.go
@@ -1,0 +1,10 @@
+//go:build !race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+func quarantinedRaceProcessSupported() bool { return false }

--- a/internal/civisibility/integrations/gotesting/quarantine_norace.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_norace.go
@@ -7,4 +7,8 @@
 
 package gotesting
 
+const quarantinedRaceParallelHookActive = false
+
 func quarantinedRaceProcessSupported() bool { return false }
+
+func activateQuarantinedRaceParallelHook() {}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -403,6 +403,52 @@ type quarantinedRaceChildState struct {
 	parallelOnce    sync.Once
 	parallelStarted atomic.Bool
 	parallelDone    chan error
+	coverage        quarantinedRaceCoverageCoordinator
+}
+
+type quarantinedRaceCoverageInterval struct {
+	id    uint64
+	name  string
+	valid bool
+}
+
+// quarantinedRaceCoverageCoordinator never serializes user code. Runtime
+// coverage counters are process-global, so overlapping sibling branches cannot
+// be attributed safely; their per-test deltas are discarded instead. Nested
+// collectors remain valid because their inclusive overlap is deterministic.
+type quarantinedRaceCoverageCoordinator struct {
+	mu     sync.Mutex
+	next   uint64
+	active map[uint64]*quarantinedRaceCoverageInterval
+}
+
+func (c *quarantinedRaceCoverageCoordinator) begin(name string) *quarantinedRaceCoverageInterval {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active == nil {
+		c.active = make(map[uint64]*quarantinedRaceCoverageInterval)
+	}
+	c.next++
+	interval := &quarantinedRaceCoverageInterval{id: c.next, name: name, valid: true}
+	for _, current := range c.active {
+		if processRetryNameWithinRoot(name, current.name) || processRetryNameWithinRoot(current.name, name) {
+			continue
+		}
+		current.valid = false
+		interval.valid = false
+	}
+	c.active[interval.id] = interval
+	return interval
+}
+
+func (c *quarantinedRaceCoverageCoordinator) finish(interval *quarantinedRaceCoverageInterval) bool {
+	if interval == nil {
+		return true
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.active, interval.id)
+	return interval.valid
 }
 
 func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRaceChildState {
@@ -563,7 +609,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
 	execMeta.quarantinedRaceChild = state
-	execMeta.processRetryCoverageMu = &sync.Mutex{}
 	if !processRetryNameWithinRoot(name, state.cfg.SelectedRoot) {
 		defer deleteTestMetadata(t)
 		original(t)
@@ -590,24 +635,33 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.isAModifiedTest = directive.Modified || integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc)
 	directive.Modified = execMeta.isAModifiedTest
 	order, start, raceBaseline := state.begin()
+	activeStart := start
+	activeDuration := time.Duration(0)
 	restoreChatty := bufferQuarantinedRaceChildOutput(t)
 	var collector *coverage.ProcessTestCoverage
-	coverageLocked := false
-	if state.cfg.CollectPerTest && source != nil && coverage.CanCollect() {
-		// Runtime coverage counters are global, so siblings must not collect
-		// overlapping deltas. The parent-owned lock serializes concurrent t.Run
-		// calls without blocking nested collectors, which lock their own parent.
-		parent.processRetryCoverageMu.Lock()
-		coverageLocked = true
-		collector = coverage.BeginProcessTestCoverage(source.RuntimePath)
-		// Native Parallel must release t.Run back to the parent. Pause coverage
-		// and release the sibling lock while testing owns that handoff, then
-		// resume both before the covered body continues.
-		execMeta.processRetryCoverageParallel = func() func() {
+	var coverageInterval *quarantinedRaceCoverageInterval
+	coverageValid := true
+	collectCoverage := state.cfg.CollectPerTest && coverage.CanCollect()
+	if collectCoverage {
+		coverageInterval = state.coverage.begin(name)
+		if source != nil {
+			collector = coverage.BeginProcessTestCoverage(source.RuntimePath)
+		}
+	}
+	execMeta.processRetryParallelPause = func() func() {
+		activeDuration += time.Since(activeStart)
+		activeStart = time.Time{}
+		if collector != nil {
 			collector.Pause()
-			parent.processRetryCoverageMu.Unlock()
-			return func() {
-				parent.processRetryCoverageMu.Lock()
+		}
+		coverageValid = state.coverage.finish(coverageInterval) && coverageValid
+		coverageInterval = nil
+		return func() {
+			activeStart = time.Now()
+			if collectCoverage {
+				coverageInterval = state.coverage.begin(name)
+			}
+			if collector != nil {
 				collector.Resume()
 			}
 		}
@@ -647,18 +701,23 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		}
 		state.finishAggregateCoverage(name)
 
-		if coverageLocked {
-			defer parent.processRetryCoverageMu.Unlock()
+		if !activeStart.IsZero() {
+			activeDuration += time.Since(activeStart)
+			activeStart = time.Time{}
 		}
 		files := collector.Finish()
+		coverageValid = state.coverage.finish(coverageInterval) && coverageValid
+		if !coverageValid {
+			files = nil
+		}
 		restoreChatty()
-		finish := time.Now()
+		finish := start.Add(activeDuration)
 		fields := getTestPrivateFields(t)
 		result := processRetrySubtreeResult{
 			TestName:        name,
 			StartUnixNano:   start.UnixNano(),
 			FinishUnixNano:  finish.UnixNano(),
-			DurationNanos:   finish.UnixNano() - start.UnixNano(),
+			DurationNanos:   activeDuration.Nanoseconds(),
 			Failed:          t.Failed(),
 			Skipped:         t.Skipped(),
 			RaceDetected:    processRetrySubtreeRaceDetected(fields, raceBaseline, retryAttemptRaceErrors()),
@@ -961,7 +1020,6 @@ func runQuarantinedRaceProcessIsolation(
 	}
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
 
-attempts:
 	for idx := 0; idx < rootTotal; idx++ {
 		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx, parallelBridge)
 		if processRetryInfrastructureFailure(attempt) {
@@ -978,36 +1036,14 @@ attempts:
 		if cfg.AttemptToFixRetries <= 0 {
 			continue
 		}
-		// Continue independently owned descendant families inside every
-		// enclosing root execution, not as part of the root's retry sequence.
-		for _, result := range attempt.Result.Subtests {
-			if !result.AttemptToFixOwn {
-				continue
-			}
-			continuationCfg, cfgErr := cfg.forSelectedRoot(result.TestName)
-			if cfgErr != nil {
-				failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: cfgErr, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
-				return
-			}
-			for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-				attempt := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx, parallelBridge)
-				if processRetryInfrastructureFailure(attempt) {
-					failQuarantinedRaceIsolation(t, &commonInfo{
-						moduleName: testInfo.moduleName,
-						suiteName:  testInfo.suiteName,
-						testName:   result.TestName,
-						identity:   newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName),
-					}, execMeta, attempt)
-					return
-				}
-				invocations = append(invocations, quarantinedRaceInvocation{
-					cfg: continuationCfg, attempt: attempt, attemptIndex: idx,
-				})
-				if quarantinedRaceFailfastStopsContinuation(attempt) {
-					invocations[len(invocations)-1].finalBecauseOfFailfast = true
-					break attempts
-				}
-			}
+		stop, failed := continueQuarantinedRaceDescendantFamilies(
+			t, testInfo, execMeta, processCtx, lease, cfg, attempt, parallelBridge, &invocations,
+		)
+		if failed {
+			return
+		}
+		if stop {
+			break
 		}
 	}
 
@@ -1016,6 +1052,87 @@ attempts:
 	// Visibility but is intentionally masked from the package result. An
 	// infrastructure error returns above through Fail and is never quarantined.
 	t.SkipNow()
+}
+
+// continueQuarantinedRaceDescendantFamilies completes each independently owned
+// Attempt-to-Fix family before continuing its ancestor. This depth-first order
+// keeps a deeper owner's retry adjacent to the initial execution from the same
+// enclosing invocation, so replay cannot associate it with a later family.
+func continueQuarantinedRaceDescendantFamilies(
+	t *testing.T,
+	testInfo *commonInfo,
+	execMeta *testExecutionMetadata,
+	processCtx *quarantinedRaceProcessContext,
+	lease *processRetryGroupLease,
+	cfg *processRetrySubtreeConfig,
+	attempt processRetryAttemptResult,
+	parallelBridge func() error,
+	invocations *[]quarantinedRaceInvocation,
+) (stop, failed bool) {
+	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
+		continuationCfg, err := cfg.forSelectedRoot(result.TestName)
+		if err != nil {
+			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
+			return false, true
+		}
+		if stop, failed := continueQuarantinedRaceDescendantFamilies(
+			t, testInfo, execMeta, processCtx, lease, continuationCfg, attempt, parallelBridge, invocations,
+		); stop || failed {
+			return stop, failed
+		}
+		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
+			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx, parallelBridge)
+			if processRetryInfrastructureFailure(next) {
+				failQuarantinedRaceIsolation(t, &commonInfo{
+					moduleName: testInfo.moduleName,
+					suiteName:  testInfo.suiteName,
+					testName:   result.TestName,
+					identity:   newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName),
+				}, execMeta, next)
+				return false, true
+			}
+			*invocations = append(*invocations, quarantinedRaceInvocation{
+				cfg: continuationCfg, attempt: next, attemptIndex: idx,
+			})
+			if quarantinedRaceFailfastStopsContinuation(next) {
+				(*invocations)[len(*invocations)-1].finalBecauseOfFailfast = true
+				return true, false
+			}
+			if stop, failed := continueQuarantinedRaceDescendantFamilies(
+				t, testInfo, execMeta, processCtx, lease, continuationCfg, next, parallelBridge, invocations,
+			); stop || failed {
+				return stop, failed
+			}
+		}
+	}
+	return false, false
+}
+
+func directQuarantinedRaceAttemptOwners(results []processRetrySubtreeResult, root string) []processRetrySubtreeResult {
+	ownerNames := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		if result.AttemptToFixOwn && result.TestName != root && processRetryNameWithinRoot(result.TestName, root) {
+			ownerNames[result.TestName] = struct{}{}
+		}
+	}
+	owners := make([]processRetrySubtreeResult, 0, len(ownerNames))
+	for _, result := range results {
+		if _, ok := ownerNames[result.TestName]; !ok {
+			continue
+		}
+		direct := true
+		for ancestor := result.TestName; len(ancestor) > len(root); {
+			ancestor = ancestor[:strings.LastIndexByte(ancestor, '/')]
+			if _, ok := ownerNames[ancestor]; ok {
+				direct = false
+				break
+			}
+		}
+		if direct {
+			owners = append(owners, result)
+		}
+	}
+	return owners
 }
 
 // AttemptToFixRetries is the configured total execution count in the existing

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -513,7 +513,8 @@ func (o *processRetryChildObservation) buildSubtreeResult(result processRetryRes
 	result.ITRForcedRun = root.ITRForcedRun
 	result.Modified = root.Modified
 	result.Subtests = append(results[:rootIndex:rootIndex], results[rootIndex+1:]...)
-	applyProcessRetryControlledSubtreeStatus(&result, controlled)
+	// A controlled terminal on the top-level carrier belongs to an ancestor of
+	// this nested root; the copied root keeps its independently recorded status.
 	return result
 }
 
@@ -709,9 +710,10 @@ func processRetrySubtreeRaceDetected(fields *commonPrivateFields, initialBaselin
 		return true
 	}
 	baseline := initialBaseline
-	if fields != nil && fields.isParallel != nil && *fields.isParallel && fields.lastRaceErrors != nil {
-		// testing.T.Parallel resets this baseline after the test resumes so races
-		// reported while it was paused are not charged to the resumed subtest.
+	if fields != nil && fields.lastRaceErrors != nil {
+		// testing advances this baseline on the reporting test and its ancestors;
+		// Parallel also resets it after resume. In both cases, only newer races
+		// belong to this test unless raceErrorLogged already records its own race.
 		baseline = fields.lastRaceErrors.Load()
 	}
 	return current > baseline
@@ -1152,8 +1154,8 @@ func replayQuarantinedRaceEvent(
 		}
 		counted[result.TestName] = struct{}{}
 	}
-	_, owner := invocation.cfg.resolveDirective(result.TestName)
-	ownsAttemptToFix := owner == result.TestName
+	_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
+	ownsAttemptToFix := attemptOwner == result.TestName
 	prior := outcomes[result.TestName]
 	execMeta := &testExecutionMetadata{
 		identity:                      identity,
@@ -1170,7 +1172,7 @@ func replayQuarantinedRaceEvent(
 		suppressParentRetryMetadata:   true,
 		shouldOrchestrateAttemptToFix: ownsAttemptToFix,
 	}
-	if ownsAttemptToFix {
+	if attemptOwner != "" {
 		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
 		execMeta.isARetry = invocation.attemptIndex > 0
 		execMeta.isLastRetry = invocation.finalBecauseOfFailfast || invocation.attemptIndex == attemptTotal-1
@@ -1196,7 +1198,7 @@ func replayQuarantinedRaceEvent(
 		testName:   result.TestName,
 		identity:   identity,
 	}, execMeta, attempt, nil, nil)
-	if ownsAttemptToFix {
+	if attemptOwner != "" {
 		prior.observe(result.Failed, result.Skipped)
 		outcomes[result.TestName] = prior
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -693,12 +693,17 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			})
 		}
 
-		// Drain user cleanups before snapshotting. The helper also releases and
-		// waits for queued parallel descendants, so the selected root includes
-		// their failures, timing, and coverage. A regular t.Cleanup finalizer would
-		// run after testing has already classified a cleanup panic.
+		// Drain queued parallel descendants before user cleanups so the selected
+		// root includes their failures and coverage. Native testing excludes this
+		// scheduler wait from the parent's duration, but cleanup remains active time.
 		cleanup := &testCleanupResult{}
-		runTestCleanupWithOptions(t, cleanup, true)
+		if !activeStart.IsZero() {
+			activeDuration += time.Since(activeStart)
+			activeStart = time.Time{}
+		}
+		completeParallelSubtests(t, getTestPrivateFields(t), true)
+		activeStart = time.Now()
+		runTestCleanupCallbacks(t, cleanup)
 		if cleanup.panicData != nil {
 			t.Fail()
 			execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
@@ -963,8 +968,6 @@ type quarantinedRaceInvocation struct {
 	cfg          *processRetrySubtreeConfig
 	attempt      processRetryAttemptResult
 	attemptIndex int
-
-	finalBecauseOfFailfast bool
 }
 
 // runQuarantinedRaceProcessIsolation replaces only the selected quarantined
@@ -1040,7 +1043,6 @@ func runQuarantinedRaceProcessIsolation(
 			cfg: cfg, attempt: attempt, attemptIndex: idx,
 		})
 		if quarantinedRaceFailfastStopsContinuation(attempt) {
-			invocations[len(invocations)-1].finalBecauseOfFailfast = true
 			break
 		}
 		if cfg.AttemptToFixRetries <= 0 {
@@ -1105,7 +1107,6 @@ func continueQuarantinedRaceDescendantFamilies(
 				cfg: continuationCfg, attempt: next, attemptIndex: idx,
 			})
 			if quarantinedRaceFailfastStopsContinuation(next) {
-				(*invocations)[len(*invocations)-1].finalBecauseOfFailfast = true
 				return true, false
 			}
 			if stop, failed := continueQuarantinedRaceDescendantFamilies(
@@ -1266,14 +1267,45 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 	if testInfo == nil {
 		return
 	}
-	outcomes := make(map[string]retryOutcomeAccumulator)
-	counted := make(map[string]struct{})
+	type familyKey struct {
+		name       string
+		generation int
+	}
+	type replayEvent struct {
+		invocation   quarantinedRaceInvocation
+		result       processRetrySubtreeResult
+		family       familyKey
+		attemptOwner string
+	}
+	generations := make(map[string]int)
+	lastOccurrence := make(map[familyKey]int)
+	events := make([]replayEvent, 0, len(invocations))
+	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) {
+		_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
+		if attemptOwner != "" && attemptOwner != invocation.cfg.SelectedRoot {
+			// A descendant-owned family starts fresh each time its enclosing
+			// selected root discovers it.
+			generations[result.TestName]++
+		}
+		family := familyKey{name: result.TestName, generation: generations[result.TestName]}
+		lastOccurrence[family] = len(events)
+		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner})
+	}
 	for _, invocation := range invocations {
 		for _, result := range invocation.attempt.Result.Subtests {
-			replayQuarantinedRaceEvent(testInfo, invocation, result, outcomes, counted)
+			appendEvent(invocation, result)
 		}
-		root := processRetrySubtreeRootFromInvocation(invocation)
-		replayQuarantinedRaceEvent(testInfo, invocation, root, outcomes, counted)
+		appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
+	}
+	outcomes := make(map[familyKey]retryOutcomeAccumulator)
+	counted := make(map[string]struct{})
+	for idx, event := range events {
+		prior := outcomes[event.family]
+		replayQuarantinedRaceEvent(testInfo, event.invocation, event.result, event.attemptOwner, lastOccurrence[event.family] == idx, prior, counted)
+		if event.attemptOwner != "" {
+			prior.observe(event.result.Failed, event.result.Skipped)
+			outcomes[event.family] = prior
+		}
 	}
 	module := session.GetOrCreateModule(testInfo.moduleName)
 	suite := module.GetOrCreateSuite(testInfo.suiteName)
@@ -1297,7 +1329,9 @@ func replayQuarantinedRaceEvent(
 	testInfo *commonInfo,
 	invocation quarantinedRaceInvocation,
 	result processRetrySubtreeResult,
-	outcomes map[string]retryOutcomeAccumulator,
+	attemptOwner string,
+	lastOccurrence bool,
+	prior retryOutcomeAccumulator,
 	counted map[string]struct{},
 ) {
 	identity := newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName)
@@ -1312,14 +1346,11 @@ func replayQuarantinedRaceEvent(
 		}
 		counted[result.TestName] = struct{}{}
 	}
-	_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
 	ownsAttemptToFix := attemptOwner == result.TestName
-	prior := outcomes[result.TestName]
 	attemptIndex := invocation.attemptIndex
 	if attemptOwner != "" && attemptOwner != invocation.cfg.SelectedRoot {
 		// A descendant that cleared an inherited directive and started its own
 		// family is on its first execution in this enclosing invocation.
-		prior = retryOutcomeAccumulator{}
 		attemptIndex = 0
 	}
 	execMeta := &testExecutionMetadata{
@@ -1340,7 +1371,7 @@ func replayQuarantinedRaceEvent(
 	if attemptOwner != "" {
 		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
 		execMeta.isARetry = attemptIndex > 0
-		execMeta.isLastRetry = invocation.finalBecauseOfFailfast || attemptIndex == attemptTotal-1
+		execMeta.isLastRetry = lastOccurrence
 		execMeta.remainingRetries = int64(attemptTotal - attemptIndex)
 		execMeta.initialRetryCount = int64(invocation.cfg.AttemptToFixRetries)
 		execMeta.initialRetryCountSet = true
@@ -1363,10 +1394,6 @@ func replayQuarantinedRaceEvent(
 		testName:   result.TestName,
 		identity:   identity,
 	}, execMeta, attempt, nil, nil)
-	if attemptOwner != "" {
-		prior.observe(result.Failed, result.Skipped)
-		outcomes[result.TestName] = prior
-	}
 }
 
 func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *processRetrySubtreeConfig) processRetrySubtreeResult {

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -123,6 +123,7 @@ type processRetrySubtreeResult struct {
 	Source          *processRetryTestSource            `json:"source,omitempty"`
 	Coverage        []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
 	order           uint64
+	masked          bool
 }
 
 func newQuarantinedRaceProcessContext(
@@ -327,6 +328,31 @@ func (cfg *processRetrySubtreeConfig) resolveDirective(name string) (processRetr
 	return resolved, attemptOwner
 }
 
+func (cfg *processRetrySubtreeConfig) exactManagedDescendant(name string) bool {
+	if cfg == nil || name == cfg.SelectedRoot {
+		return false
+	}
+	directive, ok := cfg.exactDirective(name)
+	return ok && (directive.Disabled || directive.Quarantined || directive.AttemptToFix)
+}
+
+func (cfg *processRetrySubtreeConfig) withinManagedDescendant(name string) bool {
+	if cfg == nil {
+		return false
+	}
+	for candidate := name; candidate != cfg.SelectedRoot && processRetryNameWithinRoot(candidate, cfg.SelectedRoot); {
+		if cfg.exactManagedDescendant(candidate) {
+			return true
+		}
+		separator := strings.LastIndexByte(candidate, '/')
+		if separator < 0 {
+			break
+		}
+		candidate = candidate[:separator]
+	}
+	return false
+}
+
 func (cfg *processRetrySubtreeConfig) itrDecision(name string, meta processRetrySubtreeDirective, sourceFunc *runtime.Func) (skip, forced bool) {
 	idx, ok := slices.BinarySearchFunc(cfg.ITR, name, func(candidate processRetrySubtreeITR, name string) int {
 		return strings.Compare(candidate.TestName, name)
@@ -405,6 +431,61 @@ type quarantinedRaceChildState struct {
 	parallelStarted atomic.Bool
 	parallelDone    chan error
 	coverage        quarantinedRaceCoverageCoordinator
+	unmaskedFailure atomic.Bool
+}
+
+type quarantinedRaceFailureEntry struct {
+	mu     *sync.RWMutex
+	failed *bool
+	before bool
+}
+
+type quarantinedRaceFailureSnapshot struct {
+	entries []quarantinedRaceFailureEntry
+}
+
+// captureQuarantinedRaceManagedFailure records the native failure bits which an
+// exact managed descendant may set through testing.common.Fail. Restoring them
+// lets the descendant remain failed in CI Visibility without changing its
+// enclosing t.Run result; independently owned failures remain sticky in state.
+func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtreeConfig) *quarantinedRaceFailureSnapshot {
+	if t == nil || cfg == nil || !cfg.exactManagedDescendant(t.Name()) {
+		return nil
+	}
+	layout := getTestingInternalsLayout()
+	if layout == nil || layout.disabled || !layout.testFieldsOK {
+		return nil
+	}
+	snapshot := &quarantinedRaceFailureSnapshot{}
+	for base := commonBaseForTest(t, layout); base != nil; base = pointerWord(base, layout.common.parent) {
+		entry := quarantinedRaceFailureEntry{
+			mu:     fieldPtr[sync.RWMutex](base, layout.common.mu),
+			failed: fieldPtr[bool](base, layout.common.failed),
+		}
+		name := fieldPtr[string](base, layout.common.name)
+		entry.mu.RLock()
+		entry.before = *entry.failed
+		currentName := *name
+		entry.mu.RUnlock()
+		snapshot.entries = append(snapshot.entries, entry)
+		if currentName == cfg.SelectedRoot {
+			runtime.KeepAlive(t)
+			return snapshot
+		}
+	}
+	runtime.KeepAlive(t)
+	return nil
+}
+
+func (snapshot *quarantinedRaceFailureSnapshot) restore(unmaskedFailure bool) {
+	if snapshot == nil {
+		return
+	}
+	for idx, entry := range snapshot.entries {
+		entry.mu.Lock()
+		*entry.failed = entry.before || (idx > 0 && unmaskedFailure)
+		entry.mu.Unlock()
+	}
 }
 
 type quarantinedRaceCoverageInterval struct {
@@ -478,13 +559,18 @@ func (s *quarantinedRaceChildState) finishAggregateCoverage(name string) {
 	s.aggregateFinish.Do(s.finishAggregate)
 }
 
-func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) {
+func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) bool {
 	if s == nil {
-		return
+		return false
+	}
+	unmaskedFailure := result.Failed && !result.masked
+	if unmaskedFailure {
+		s.unmaskedFailure.Store(true)
 	}
 	s.mu.Lock()
 	s.results = append(s.results, result)
 	s.mu.Unlock()
+	return unmaskedFailure
 }
 
 func (s *quarantinedRaceChildState) snapshot() []processRetrySubtreeResult {
@@ -606,6 +692,8 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		return
 	}
 	name := t.Name()
+	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg)
+	maskedByManagedDescendant := state.cfg.withinManagedDescendant(name)
 	execMeta := createTestMetadata(t, nil)
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
@@ -746,6 +834,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			Source:          source,
 			Coverage:        files,
 			order:           order,
+			masked:          maskedByManagedDescendant,
 		}
 		if fields != nil {
 			result.OutputTail, result.OutputTruncated = truncateProcessRetrySubtreeOutput(fields.GetOutput())
@@ -776,7 +865,12 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		default:
 			result.Status = processRetryStatusPass
 		}
-		state.append(result)
+		if state.append(result) {
+			// A managed sibling may concurrently restore its own propagated failure.
+			// Reapply this independently owned failure in either completion order.
+			t.Fail()
+		}
+		failureSnapshot.restore(state.unmaskedFailure.Load())
 		if unexpected && fields != nil && fields.mu != nil && fields.finished != nil {
 			// runtime.Goexit bypasses the normal return to testing.tRunner. The
 			// subtree result is committed, so consume that terminal before the
@@ -1034,7 +1128,7 @@ func runQuarantinedRaceProcessIsolation(
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
 
 	for idx := 0; idx < rootTotal; idx++ {
-		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx, parallelBridge)
+		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, cfg.SelectedRoot, idx, parallelBridge)
 		if processRetryInfrastructureFailure(attempt) {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, attempt)
 			return
@@ -1093,7 +1187,7 @@ func continueQuarantinedRaceDescendantFamilies(
 			return stop, failed
 		}
 		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx, parallelBridge)
+			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, cfg.SelectedRoot, idx, parallelBridge)
 			if processRetryInfrastructureFailure(next) {
 				failQuarantinedRaceIsolation(t, &commonInfo{
 					moduleName: testInfo.moduleName,
@@ -1161,15 +1255,16 @@ func runQuarantinedRaceInvocation(
 	processCtx *quarantinedRaceProcessContext,
 	lease *processRetryGroupLease,
 	cfg *processRetrySubtreeConfig,
+	runRoot string,
 	attemptIndex int,
 	parallelBridge func() error,
 ) processRetryAttemptResult {
 	deadline, deadlineOK := t.Deadline()
 	baseline := captureProcessRetryLaunchBaselineFromTemplate(processCtx.launchTemplate)
-	// The parent already admitted this root. Replacing only this invocation's
-	// selector lets the child re-enter required ancestors without executing a
-	// sibling that happened to match the user's broader -run expression.
-	baseline.argsSnapshot.runSelector = processRetryExactRunPattern(cfg.SelectedRoot)
+	// Initial roots use their exact selector. Descendant-owned ATF continuations
+	// re-enter their enclosing root so parallel scheduling siblings exist, while
+	// cfg.SelectedRoot still limits recording to the managed descendant subtree.
+	baseline.argsSnapshot.runSelector = processRetryExactRunPattern(runRoot)
 	attempt := runProcessRetryAttemptWithBaselineAndShutdown(
 		context.Background(),
 		processRetryChildConfig{
@@ -1282,12 +1377,12 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 	events := make([]replayEvent, 0, len(invocations))
 	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) {
 		_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
-		if attemptOwner != "" && attemptOwner != invocation.cfg.SelectedRoot {
+		if result.TestName == attemptOwner && attemptOwner != invocation.cfg.SelectedRoot {
 			// A descendant-owned family starts fresh each time its enclosing
 			// selected root discovers it.
-			generations[result.TestName]++
+			generations[attemptOwner]++
 		}
-		family := familyKey{name: result.TestName, generation: generations[result.TestName]}
+		family := familyKey{name: result.TestName, generation: generations[attemptOwner]}
 		lastOccurrence[family] = len(events)
 		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner})
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -567,8 +567,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	order, start, raceBaseline := state.begin()
 	restoreChatty := bufferQuarantinedRaceChildOutput(t)
 	var collector *coverage.ProcessTestCoverage
-	var parentBarrier *chan bool
-	var oldParentBarrier chan bool
 	coverageLocked := false
 	if state.cfg.CollectPerTest && source != nil && coverage.CanCollect() {
 		// Runtime coverage counters are global, so siblings must not collect
@@ -576,14 +574,18 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// calls without blocking nested collectors, which lock their own parent.
 		parent.processRetryCoverageMu.Lock()
 		coverageLocked = true
-		// Clearing the barrier makes t.Parallel a no-op for this covered body.
-		// Ancestor/descendant collectors remain inclusive by design.
-		if fields := getTestParentPrivateFields(t); fields != nil && fields.barrier != nil {
-			parentBarrier = fields.barrier
-			oldParentBarrier = *parentBarrier
-			*parentBarrier = nil
-		}
 		collector = coverage.BeginProcessTestCoverage(source.RuntimePath)
+		// Native Parallel must release t.Run back to the parent. Pause coverage
+		// and release the sibling lock while testing owns that handoff, then
+		// resume both before the covered body continues.
+		execMeta.processRetryCoverageParallel = func() func() {
+			collector.Pause()
+			parent.processRetryCoverageMu.Unlock()
+			return func() {
+				parent.processRetryCoverageMu.Lock()
+				collector.Resume()
+			}
+		}
 	}
 
 	bodyReturned := false
@@ -621,9 +623,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			defer parent.processRetryCoverageMu.Unlock()
 		}
 		files := collector.Finish()
-		if parentBarrier != nil {
-			*parentBarrier = oldParentBarrier
-		}
 		restoreChatty()
 		finish := time.Now()
 		fields := getTestPrivateFields(t)

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -57,6 +57,8 @@ type quarantinedRaceProcessContext struct {
 	attemptToFixRetries    int
 	collectPerTestCoverage bool
 	collectAggregate       bool
+	replayMu               sync.Mutex
+	ancestorOutcomes       map[quarantinedRaceReplayIdentity]retryOutcomeAccumulator
 }
 
 type processRetrySubtreeConfig struct {
@@ -68,6 +70,7 @@ type processRetrySubtreeConfig struct {
 	AttemptToFixRetries  int                            `json:"attempt_to_fix_retries,omitempty"`
 	OwnsAttemptToFix     bool                           `json:"owns_attempt_to_fix,omitempty"`
 	AncestorAttemptToFix bool                           `json:"ancestor_attempt_to_fix,omitempty"`
+	AncestorAttemptIndex int                            `json:"ancestor_attempt_index,omitempty"`
 	CollectPerTest       bool                           `json:"collect_per_test_coverage,omitempty"`
 	CollectAggregate     bool                           `json:"collect_aggregate_coverage,omitempty"`
 	ITRCoverageActive    bool                           `json:"itr_coverage_active,omitempty"`
@@ -76,6 +79,8 @@ type processRetrySubtreeConfig struct {
 
 type processRetrySubtreeDirective struct {
 	TestName     string `json:"test_name"`
+	ModuleName   string `json:"module_name,omitempty"`
+	SuiteName    string `json:"suite_name,omitempty"`
 	Disabled     bool   `json:"disabled,omitempty"`
 	Quarantined  bool   `json:"quarantined,omitempty"`
 	AttemptToFix bool   `json:"attempt_to_fix,omitempty"`
@@ -161,7 +166,7 @@ func buildProcessRetrySubtreeConfig(
 	cfg := &processRetrySubtreeConfig{
 		Version:             processRetrySubtreeVersion,
 		SelectedRoot:        identity.FullName,
-		Root:                processRetryDirectiveFromMetadata(identity.FullName, execMeta),
+		Root:                processRetryDirectiveFromMetadata(identity, execMeta),
 		AttemptToFixRetries: ctx.attemptToFixRetries,
 		OwnsAttemptToFix:    execMeta.isAttemptToFix && execMeta.shouldOrchestrateAttemptToFix,
 		CollectPerTest:      ctx.collectPerTestCoverage,
@@ -177,15 +182,21 @@ func buildProcessRetrySubtreeConfig(
 	}
 	if parentExecMeta != nil && parentExecMeta.isAttemptToFix {
 		cfg.AncestorAttemptToFix = true
+		cfg.AncestorAttemptIndex = 0
+		if parentExecMeta.isARetry {
+			cfg.AncestorAttemptIndex = cfg.AttemptToFixRetries - int(parentExecMeta.remainingRetries)
+		}
 	}
 
 	if data := integrations.GetTestManagementTestsData(); subtestFeaturesEnabled && data != nil {
-		if module, ok := data.Modules[identity.ModuleName]; ok {
-			if suite, ok := module.Suites[identity.SuiteName]; ok {
+		for moduleName, module := range data.Modules {
+			for suiteName, suite := range module.Suites {
 				for name, properties := range suite.Tests {
 					if strings.HasPrefix(name, cfg.SelectedRoot+"/") {
 						cfg.Directives = append(cfg.Directives, processRetrySubtreeDirective{
 							TestName:     name,
+							ModuleName:   moduleName,
+							SuiteName:    suiteName,
 							Disabled:     properties.Properties.Disabled,
 							Quarantined:  properties.Properties.Quarantined,
 							AttemptToFix: properties.Properties.AttemptToFix,
@@ -196,7 +207,7 @@ func buildProcessRetrySubtreeConfig(
 		}
 	}
 	slices.SortFunc(cfg.Directives, func(a, b processRetrySubtreeDirective) int {
-		return strings.Compare(a.TestName, b.TestName)
+		return compareProcessRetryDirectives(a, b)
 	})
 
 	itr := currentITRState()
@@ -233,12 +244,17 @@ func buildProcessRetrySubtreeConfig(
 	return cfg, nil
 }
 
-func processRetryDirectiveFromMetadata(name string, meta *testExecutionMetadata) processRetrySubtreeDirective {
+func processRetryDirectiveFromMetadata(identity *testIdentity, meta *testExecutionMetadata) processRetrySubtreeDirective {
+	if identity == nil {
+		return processRetrySubtreeDirective{}
+	}
 	if meta == nil {
-		return processRetrySubtreeDirective{TestName: name}
+		return processRetrySubtreeDirective{TestName: identity.FullName, ModuleName: identity.ModuleName, SuiteName: identity.SuiteName}
 	}
 	return processRetrySubtreeDirective{
-		TestName:     name,
+		TestName:     identity.FullName,
+		ModuleName:   identity.ModuleName,
+		SuiteName:    identity.SuiteName,
 		Disabled:     meta.isDisabled,
 		Quarantined:  meta.isQuarantined,
 		AttemptToFix: meta.isAttemptToFix,
@@ -250,23 +266,32 @@ func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedR
 	if cfg == nil {
 		return nil
 	}
+	rootIsolated := cfg.Root.Quarantined ||
+		cfg.Root.AttemptToFix && (cfg.OwnsAttemptToFix || cfg.AncestorAttemptToFix) && cfg.hasQuarantinedDescendant()
 	if cfg.Version != processRetrySubtreeVersion || cfg.SelectedRoot != selectedRoot ||
 		strings.TrimSpace(cfg.SelectedRoot) == "" || cfg.Root.TestName != cfg.SelectedRoot ||
-		!cfg.Root.Quarantined || cfg.AttemptToFixRetries < 0 ||
+		!rootIsolated || cfg.AttemptToFixRetries < 0 ||
 		len(cfg.Directives) > processRetrySubtreeMaxDirectives || len(cfg.ITR) > processRetrySubtreeMaxDirectives {
 		return errors.New("invalid process retry subtree configuration")
 	}
-	if cfg.OwnsAttemptToFix && !cfg.Root.AttemptToFix || cfg.AncestorAttemptToFix && cfg.OwnsAttemptToFix {
+	if cfg.OwnsAttemptToFix && !cfg.Root.AttemptToFix || cfg.AncestorAttemptToFix && cfg.OwnsAttemptToFix ||
+		cfg.AncestorAttemptIndex < 0 || cfg.AncestorAttemptIndex >= processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries) ||
+		!cfg.AncestorAttemptToFix && cfg.AncestorAttemptIndex != 0 {
 		return errors.New("invalid process retry subtree attempt ownership")
 	}
-	previous := ""
-	for _, directive := range cfg.Directives {
-		if directive.TestName == cfg.SelectedRoot || !processRetryNameWithinRoot(directive.TestName, cfg.SelectedRoot) || directive.TestName <= previous {
+	if strings.TrimSpace(cfg.Root.ModuleName) == "" || strings.TrimSpace(cfg.Root.SuiteName) == "" {
+		return errors.New("invalid process retry subtree root identity")
+	}
+	var previousDirective processRetrySubtreeDirective
+	for idx, directive := range cfg.Directives {
+		if directive.TestName == cfg.SelectedRoot || !processRetryNameWithinRoot(directive.TestName, cfg.SelectedRoot) ||
+			strings.TrimSpace(directive.ModuleName) == "" || strings.TrimSpace(directive.SuiteName) == "" ||
+			idx > 0 && compareProcessRetryDirectives(previousDirective, directive) >= 0 {
 			return errors.New("invalid process retry subtree directive")
 		}
-		previous = directive.TestName
+		previousDirective = directive
 	}
-	previous = ""
+	previous := ""
 	for _, candidate := range cfg.ITR {
 		if !processRetryNameWithinRoot(candidate.TestName, cfg.SelectedRoot) || candidate.TestName <= previous {
 			return errors.New("invalid process retry subtree ITR directive")
@@ -276,6 +301,28 @@ func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedR
 	return nil
 }
 
+func buildDeferredQuarantinedRaceSubtreeConfig(
+	ctx *quarantinedRaceProcessContext,
+	testInfo *commonInfo,
+	execMeta *testExecutionMetadata,
+) (*processRetrySubtreeConfig, error) {
+	settings := integrations.GetSettings()
+	if ctx == nil || execMeta == nil || !execMeta.isAttemptToFix || execMeta.identity == nil ||
+		settings == nil || !settings.SubtestFeaturesEnabled {
+		return nil, nil
+	}
+	cfg, err := buildProcessRetrySubtreeConfig(ctx, testInfo, execMeta, nil)
+	if err != nil || !cfg.hasQuarantinedDescendant() {
+		return nil, err
+	}
+	// The deferred process already is the enclosing Attempt-to-Fix execution.
+	// Capture its quarantined descendants in that process instead of launching
+	// nested children, then let the original parent publish their events.
+	cfg.OwnsAttemptToFix = false
+	cfg.AncestorAttemptToFix = true
+	cfg.AncestorAttemptIndex = 0
+	return cfg, validateProcessRetrySubtreeConfig(cfg, cfg.SelectedRoot)
+}
 func processRetryNameWithinRoot(name, root string) bool {
 	return name == root || strings.HasPrefix(name, root+"/")
 }
@@ -288,9 +335,20 @@ func processRetryExactRunPattern(fullName string) string {
 	return strings.Join(segments, "/")
 }
 
-func (cfg *processRetrySubtreeConfig) exactDirective(name string) (processRetrySubtreeDirective, bool) {
-	idx, ok := slices.BinarySearchFunc(cfg.Directives, name, func(d processRetrySubtreeDirective, name string) int {
-		return strings.Compare(d.TestName, name)
+func compareProcessRetryDirectives(a, b processRetrySubtreeDirective) int {
+	if cmp := strings.Compare(a.ModuleName, b.ModuleName); cmp != 0 {
+		return cmp
+	}
+	if cmp := strings.Compare(a.SuiteName, b.SuiteName); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(a.TestName, b.TestName)
+}
+
+func (cfg *processRetrySubtreeConfig) exactDirective(moduleName, suiteName, name string) (processRetrySubtreeDirective, bool) {
+	target := processRetrySubtreeDirective{ModuleName: moduleName, SuiteName: suiteName, TestName: name}
+	idx, ok := slices.BinarySearchFunc(cfg.Directives, target, func(a, b processRetrySubtreeDirective) int {
+		return compareProcessRetryDirectives(a, b)
 	})
 	if !ok {
 		return processRetrySubtreeDirective{}, false
@@ -298,9 +356,30 @@ func (cfg *processRetrySubtreeConfig) exactDirective(name string) (processRetryS
 	return cfg.Directives[idx], true
 }
 
-func (cfg *processRetrySubtreeConfig) resolveDirective(name string) (processRetrySubtreeDirective, string) {
+func (cfg *processRetrySubtreeConfig) hasQuarantinedDescendant() bool {
+	return cfg != nil && slices.ContainsFunc(cfg.Directives, func(directive processRetrySubtreeDirective) bool {
+		return directive.Quarantined
+	})
+}
+
+func (ctx *quarantinedRaceProcessContext) clearAncestorOutcomes(cfg *processRetrySubtreeConfig) {
+	if ctx == nil || cfg == nil {
+		return
+	}
+	ctx.replayMu.Lock()
+	defer ctx.replayMu.Unlock()
+	for identity := range ctx.ancestorOutcomes {
+		if processRetryNameWithinRoot(identity.testName, cfg.SelectedRoot) {
+			delete(ctx.ancestorOutcomes, identity)
+		}
+	}
+}
+
+func (cfg *processRetrySubtreeConfig) resolveDirective(moduleName, suiteName, name string) (processRetrySubtreeDirective, string) {
 	resolved := cfg.Root
 	resolved.TestName = name
+	resolved.ModuleName = moduleName
+	resolved.SuiteName = suiteName
 	attemptOwner := ""
 	if cfg.OwnsAttemptToFix {
 		attemptOwner = cfg.SelectedRoot
@@ -312,7 +391,7 @@ func (cfg *processRetrySubtreeConfig) resolveDirective(name string) (processRetr
 	parts := strings.Split(name, "/")
 	for idx := len(rootParts) + 1; idx <= len(parts); idx++ {
 		candidate := strings.Join(parts[:idx], "/")
-		exact, ok := cfg.exactDirective(candidate)
+		exact, ok := cfg.exactDirective(moduleName, suiteName, candidate)
 		if !ok {
 			continue
 		}
@@ -331,20 +410,20 @@ func (cfg *processRetrySubtreeConfig) resolveDirective(name string) (processRetr
 	return resolved, attemptOwner
 }
 
-func (cfg *processRetrySubtreeConfig) exactManagedDescendant(name string) bool {
+func (cfg *processRetrySubtreeConfig) exactManagedDescendant(moduleName, suiteName, name string) bool {
 	if cfg == nil || name == cfg.SelectedRoot {
 		return false
 	}
-	directive, ok := cfg.exactDirective(name)
+	directive, ok := cfg.exactDirective(moduleName, suiteName, name)
 	return ok && (directive.Disabled || directive.Quarantined || directive.AttemptToFix)
 }
 
-func (cfg *processRetrySubtreeConfig) withinManagedDescendant(name string) bool {
+func (cfg *processRetrySubtreeConfig) withinManagedDescendant(moduleName, suiteName, name string) bool {
 	if cfg == nil {
 		return false
 	}
 	for candidate := name; candidate != cfg.SelectedRoot && processRetryNameWithinRoot(candidate, cfg.SelectedRoot); {
-		if cfg.exactManagedDescendant(candidate) {
+		if cfg.exactManagedDescendant(moduleName, suiteName, candidate) {
 			return true
 		}
 		separator := strings.LastIndexByte(candidate, '/')
@@ -452,8 +531,8 @@ type quarantinedRaceFailureSnapshot struct {
 // exact managed descendant may set through testing.common.Fail. Restoring them
 // lets the descendant remain failed in CI Visibility without changing its
 // enclosing t.Run result; independently owned failures remain sticky in state.
-func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtreeConfig) *quarantinedRaceFailureSnapshot {
-	if t == nil || cfg == nil || !cfg.exactManagedDescendant(t.Name()) {
+func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtreeConfig, moduleName, suiteName string) *quarantinedRaceFailureSnapshot {
+	if t == nil || cfg == nil || !cfg.exactManagedDescendant(moduleName, suiteName, t.Name()) {
 		return nil
 	}
 	layout := getTestingInternalsLayout()
@@ -576,8 +655,8 @@ func (s *quarantinedRaceChildState) finishAggregateCoverage(name string) {
 	s.aggregateFinish.Do(s.finishAggregate)
 }
 
-func (s *quarantinedRaceChildState) markUnmaskedFailure(name string) {
-	if s == nil || s.cfg == nil || !processRetryNameWithinRoot(name, s.cfg.SelectedRoot) || s.cfg.withinManagedDescendant(name) {
+func (s *quarantinedRaceChildState) markUnmaskedFailure(moduleName, suiteName, name string) {
+	if s == nil || s.cfg == nil || !processRetryNameWithinRoot(name, s.cfg.SelectedRoot) || s.cfg.withinManagedDescendant(moduleName, suiteName, name) {
 		return
 	}
 	s.mu.Lock()
@@ -610,7 +689,7 @@ func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) boo
 	}
 	unmaskedFailure := result.Failed && !result.masked
 	if unmaskedFailure {
-		s.markUnmaskedFailure(result.TestName)
+		s.markUnmaskedFailure(result.ModuleName, result.SuiteName, result.TestName)
 	}
 	s.mu.Lock()
 	s.results = append(s.results, result)
@@ -740,8 +819,16 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		return
 	}
 	name := t.Name()
-	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg)
-	maskedByManagedDescendant := state.cfg.withinManagedDescendant(name)
+	callbackPC := reflect.ValueOf(original).Pointer()
+	moduleName, suiteName := utils.GetModuleAndSuiteName(callbackPC)
+	sourceFunc := runtime.FuncForPC(callbackPC)
+	if testifyData := getTestifyTest(t); testifyData != nil && testifyData.methodFunc != nil {
+		moduleName = testifyData.moduleName
+		suiteName = testifyData.suiteName
+		sourceFunc = testifyData.methodFunc
+	}
+	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg, moduleName, suiteName)
+	maskedByManagedDescendant := state.cfg.withinManagedDescendant(moduleName, suiteName, name)
 	execMeta := createTestMetadata(t, nil)
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
@@ -753,7 +840,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	}
 	state.beginAggregateCoverage(name)
 
-	directive, attemptOwner := state.cfg.resolveDirective(name)
+	directive, attemptOwner := state.cfg.resolveDirective(moduleName, suiteName, name)
 	execMeta.isDisabled = directive.Disabled
 	execMeta.isQuarantined = directive.Quarantined
 	execMeta.isAttemptToFix = directive.AttemptToFix
@@ -763,14 +850,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.hasExplicitAttemptToFix = true
 	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
 
-	callbackPC := reflect.ValueOf(original).Pointer()
-	moduleName, suiteName := utils.GetModuleAndSuiteName(callbackPC)
-	sourceFunc := runtime.FuncForPC(callbackPC)
-	if testifyData := getTestifyTest(t); testifyData != nil && testifyData.methodFunc != nil {
-		moduleName = testifyData.moduleName
-		suiteName = testifyData.suiteName
-		sourceFunc = testifyData.methodFunc
-	}
 	execMeta.identity = newTestIdentity(moduleName, suiteName, name)
 	source := processRetrySourceFromFunc(sourceFunc)
 	execMeta.isAModifiedTest = directive.Modified || integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc)
@@ -852,7 +931,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			// their parent body returns. Parallel managed descendants restored
 			// their propagated bits before releasing it, so a remaining failure
 			// belongs to this unmanaged branch.
-			state.markUnmaskedFailure(name)
+			state.markUnmaskedFailure(moduleName, suiteName, name)
 		}
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
 		activeStart = time.Now()
@@ -1092,7 +1171,7 @@ func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, cfg *pr
 	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
 		return err
 	}
-	directive, owner := cfg.resolveDirective(result.TestName)
+	directive, owner := cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
 	if result.Disabled != directive.Disabled || result.Quarantined != directive.Quarantined ||
 		result.AttemptToFix != directive.AttemptToFix || result.AttemptToFixOwn != (owner == result.TestName) {
 		return fmt.Errorf("%w: subtree directive mismatch", errProcessRetryResultInvalid)
@@ -1237,7 +1316,7 @@ func runQuarantinedRaceProcessIsolation(
 		}
 	}
 
-	replayQuarantinedRaceInvocations(testInfo, invocations)
+	replayQuarantinedRaceInvocations(testInfo, processCtx, invocations)
 	// A valid quarantined failure, panic, or race remains visible in CI
 	// Visibility but is intentionally masked from the package result. An
 	// infrastructure error returns above through Fail and is never quarantined.
@@ -1260,7 +1339,7 @@ func continueQuarantinedRaceDescendantFamilies(
 	invocations *[]quarantinedRaceInvocation,
 ) (stop, failed bool) {
 	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
-		continuationCfg, err := cfg.forSelectedRoot(result.TestName)
+		continuationCfg, err := cfg.forSelectedRoot(result.ModuleName, result.SuiteName, result.TestName)
 		if err != nil {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
 			return false, true
@@ -1438,8 +1517,8 @@ func failQuarantinedRaceIsolation(t *testing.T, testInfo *commonInfo, execMeta *
 	t.Fail()
 }
 
-func (cfg *processRetrySubtreeConfig) forSelectedRoot(name string) (*processRetrySubtreeConfig, error) {
-	directive, _ := cfg.resolveDirective(name)
+func (cfg *processRetrySubtreeConfig) forSelectedRoot(moduleName, suiteName, name string) (*processRetrySubtreeConfig, error) {
+	directive, _ := cfg.resolveDirective(moduleName, suiteName, name)
 	next := &processRetrySubtreeConfig{
 		Version:              processRetrySubtreeVersion,
 		SelectedRoot:         name,
@@ -1464,7 +1543,16 @@ func (cfg *processRetrySubtreeConfig) forSelectedRoot(name string) (*processRetr
 	return next, validateProcessRetrySubtreeConfig(next, name)
 }
 
-func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quarantinedRaceInvocation) {
+func replayQuarantinedRaceInvocations(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, invocations []quarantinedRaceInvocation) {
+	replayQuarantinedRaceResults(testInfo, processCtx, invocations, true)
+}
+
+func replayQuarantinedRaceResults(
+	testInfo *commonInfo,
+	processCtx *quarantinedRaceProcessContext,
+	invocations []quarantinedRaceInvocation,
+	includeRoot bool,
+) {
 	if testInfo == nil {
 		return
 	}
@@ -1477,35 +1565,60 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 		result       processRetrySubtreeResult
 		family       familyKey
 		attemptOwner string
+		inherited    bool
 	}
 	generations := make(map[string]int)
 	lastOccurrence := make(map[familyKey]int)
 	events := make([]replayEvent, 0, len(invocations))
 	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) {
-		_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
+		_, attemptOwner := invocation.cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
 		if result.TestName == attemptOwner && attemptOwner != invocation.cfg.SelectedRoot {
 			// A descendant-owned family starts fresh each time its enclosing
 			// selected root discovers it.
 			generations[attemptOwner]++
 		}
+		inherited := invocation.cfg.AncestorAttemptToFix && result.AttemptToFix && attemptOwner == ""
 		family := familyKey{name: result.TestName, generation: generations[attemptOwner]}
 		lastOccurrence[family] = len(events)
-		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner})
+		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner, inherited: inherited})
 	}
 	for _, invocation := range invocations {
 		for _, result := range invocation.attempt.Result.Subtests {
 			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result))
 		}
-		appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
+		if includeRoot {
+			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
+		}
 	}
 	outcomes := make(map[familyKey]retryOutcomeAccumulator)
 	counted := make(map[quarantinedRaceReplayIdentity]*testIdentity)
 	for idx, event := range events {
 		prior := outcomes[event.family]
-		replayQuarantinedRaceEvent(testInfo, event.invocation, event.result, event.attemptOwner, lastOccurrence[event.family] == idx, prior, counted)
-		if event.attemptOwner != "" {
+		last := lastOccurrence[event.family] == idx
+		identityKey := quarantinedRaceReplayIdentity{moduleName: event.result.ModuleName, suiteName: event.result.SuiteName, testName: event.result.TestName}
+		if event.inherited && processCtx != nil {
+			processCtx.replayMu.Lock()
+			prior = processCtx.ancestorOutcomes[identityKey]
+			processCtx.replayMu.Unlock()
+			last = event.invocation.cfg.AncestorAttemptIndex+1 >= processRetryAttemptToFixExecutionCount(event.invocation.cfg.AttemptToFixRetries)
+		}
+		replayQuarantinedRaceEvent(testInfo, event.invocation, event.result, event.attemptOwner, event.inherited, last, prior, counted)
+		if event.attemptOwner != "" || event.inherited {
 			prior.observe(event.result.Failed, event.result.Skipped)
-			outcomes[event.family] = prior
+			if event.inherited && processCtx != nil {
+				processCtx.replayMu.Lock()
+				if processCtx.ancestorOutcomes == nil {
+					processCtx.ancestorOutcomes = make(map[quarantinedRaceReplayIdentity]retryOutcomeAccumulator)
+				}
+				if last {
+					delete(processCtx.ancestorOutcomes, identityKey)
+				} else {
+					processCtx.ancestorOutcomes[identityKey] = prior
+				}
+				processCtx.replayMu.Unlock()
+			} else {
+				outcomes[event.family] = prior
+			}
 		}
 	}
 	for _, identity := range counted {
@@ -1522,7 +1635,7 @@ func processRetrySubtreeRootFromInvocation(invocation quarantinedRaceInvocation)
 
 func processRetrySubtreeResultWithInvocationOutput(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) processRetrySubtreeResult {
 	if !result.Failed || invocation.attempt.OutputTail == "" ||
-		(result.TestName != invocation.cfg.SelectedRoot && !invocation.cfg.exactManagedDescendant(result.TestName)) {
+		(result.TestName != invocation.cfg.SelectedRoot && !invocation.cfg.exactManagedDescendant(result.ModuleName, result.SuiteName, result.TestName)) {
 		return result
 	}
 	// Direct stdout, stderr, and race reports are absent from testing's buffered
@@ -1537,6 +1650,7 @@ func replayQuarantinedRaceEvent(
 	invocation quarantinedRaceInvocation,
 	result processRetrySubtreeResult,
 	attemptOwner string,
+	inheritedAttempt bool,
 	lastOccurrence bool,
 	prior retryOutcomeAccumulator,
 	counted map[quarantinedRaceReplayIdentity]*testIdentity,
@@ -1563,6 +1677,9 @@ func replayQuarantinedRaceEvent(
 	}
 	ownsAttemptToFix := attemptOwner == result.TestName
 	attemptIndex := invocation.attemptIndex
+	if inheritedAttempt {
+		attemptIndex = invocation.cfg.AncestorAttemptIndex
+	}
 	if attemptOwner != "" && attemptOwner != invocation.cfg.SelectedRoot {
 		// A descendant that cleared an inherited directive and started its own
 		// family is on its first execution in this enclosing invocation.
@@ -1583,7 +1700,7 @@ func replayQuarantinedRaceEvent(
 		suppressParentRetryMetadata:   true,
 		shouldOrchestrateAttemptToFix: ownsAttemptToFix,
 	}
-	if attemptOwner != "" {
+	if attemptOwner != "" || inheritedAttempt {
 		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
 		execMeta.isARetry = attemptIndex > 0
 		execMeta.isLastRetry = lastOccurrence
@@ -1612,7 +1729,7 @@ func replayQuarantinedRaceEvent(
 }
 
 func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *processRetrySubtreeConfig) processRetrySubtreeResult {
-	directive, owner := cfg.resolveDirective(result.TestName)
+	directive, owner := cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
 	return processRetrySubtreeResult{
 		TestName:        result.TestName,
 		ModuleName:      result.ModuleName,

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -478,10 +478,19 @@ func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtree
 }
 
 func (snapshot *quarantinedRaceFailureSnapshot) restore(unmaskedFailure bool) {
+	snapshot.restoreFrom(0, unmaskedFailure)
+}
+
+func (snapshot *quarantinedRaceFailureSnapshot) restoreAncestors(unmaskedFailure bool) {
+	snapshot.restoreFrom(1, unmaskedFailure)
+}
+
+func (snapshot *quarantinedRaceFailureSnapshot) restoreFrom(first int, unmaskedFailure bool) {
 	if snapshot == nil {
 		return
 	}
-	for idx, entry := range snapshot.entries {
+	for idx := first; idx < len(snapshot.entries); idx++ {
+		entry := snapshot.entries[idx]
 		entry.mu.Lock()
 		*entry.failed = entry.before || (idx > 0 && unmaskedFailure)
 		entry.mu.Unlock()
@@ -738,6 +747,10 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		}
 	}
 	execMeta.processRetryParallelPause = func() func() {
+		// Clear any managed failure propagated before t.Parallel releases the
+		// parent. A failure added by the selected root after that release can then
+		// be identified before its parallel descendants resume.
+		failureSnapshot.restoreAncestors(state.unmaskedFailure.Load())
 		activeDuration += time.Since(activeStart)
 		activeStart = time.Time{}
 		// A nested selected root releases its discovery ancestor in Parallel.
@@ -788,6 +801,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		if !activeStart.IsZero() {
 			activeDuration += time.Since(activeStart)
 			activeStart = time.Time{}
+		}
+		if name == state.cfg.SelectedRoot && t.Failed() {
+			state.unmaskedFailure.Store(true)
 		}
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
 		activeStart = time.Now()
@@ -1291,6 +1307,14 @@ func runQuarantinedRaceInvocation(
 			attempt.Err = errors.Join(attempt.Err, fmt.Errorf("aggregate process coverage: %w", err))
 		}
 	}
+	if topLevelName, _ := topLevelTestName(cfg.SelectedRoot); cfg.SelectedRoot != topLevelName &&
+		attempt.Result.Panic && attempt.ExitStatusObserved && attempt.ExitCode != processRetryControlledPanicExitCode {
+		// A nested selected root commits its panic or bare Goexit in the subtree
+		// protocol, while its top-level discovery carrier does not use the
+		// controlled terminal exit code. Normalize that expected carrier exit to
+		// the status required by effectiveProcessRetryStatus.
+		attempt.ExitCode = processRetryControlledPanicExitCode
+	}
 	return attempt
 }
 
@@ -1388,7 +1412,7 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 	}
 	for _, invocation := range invocations {
 		for _, result := range invocation.attempt.Result.Subtests {
-			appendEvent(invocation, result)
+			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result))
 		}
 		appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
 	}
@@ -1411,13 +1435,19 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 
 func processRetrySubtreeRootFromInvocation(invocation quarantinedRaceInvocation) processRetrySubtreeResult {
 	root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
-	if root.Failed && invocation.attempt.OutputTail != "" {
-		// Direct child stdout and stderr are not present in testing's buffered
-		// subtree output. A failed selected root owns the complete process tail.
-		root.OutputTail = invocation.attempt.OutputTail
-		root.OutputTruncated = invocation.attempt.OutputTruncated
+	return processRetrySubtreeResultWithInvocationOutput(invocation, root)
+}
+
+func processRetrySubtreeResultWithInvocationOutput(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) processRetrySubtreeResult {
+	if !result.Failed || invocation.attempt.OutputTail == "" ||
+		(result.TestName != invocation.cfg.SelectedRoot && !invocation.cfg.exactManagedDescendant(result.TestName)) {
+		return result
 	}
-	return root
+	// Direct stdout, stderr, and race reports are absent from testing's buffered
+	// output. Attribute the complete process tail to each failed managed boundary.
+	result.OutputTail = invocation.attempt.OutputTail
+	result.OutputTruncated = invocation.attempt.OutputTruncated
+	return result
 }
 
 func replayQuarantinedRaceEvent(

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -163,7 +163,9 @@ func buildProcessRetrySubtreeConfig(
 		CollectPerTest:      ctx.collectPerTestCoverage,
 		CollectAggregate:    ctx.collectAggregate,
 	}
+	subtestFeaturesEnabled := false
 	if settings := integrations.GetSettings(); settings != nil {
+		subtestFeaturesEnabled = settings.SubtestFeaturesEnabled
 		cfg.ImpactedTestsEnabled = settings.ImpactedTestsEnabled
 		if cfg.ImpactedTestsEnabled {
 			cfg.Root.Modified = cfg.Root.Modified || integrations.IsTestFuncModified(testInfo.testName, testInfo.sourceFunc)
@@ -173,7 +175,7 @@ func buildProcessRetrySubtreeConfig(
 		cfg.AncestorAttemptToFix = true
 	}
 
-	if data := integrations.GetTestManagementTestsData(); data != nil {
+	if data := integrations.GetTestManagementTestsData(); subtestFeaturesEnabled && data != nil {
 		if module, ok := data.Modules[identity.ModuleName]; ok {
 			if suite, ok := module.Suites[identity.SuiteName]; ok {
 				for name, properties := range suite.Tests {
@@ -361,11 +363,25 @@ func processRetrySourceFromFunc(fn *runtime.Func) *processRetryTestSource {
 }
 
 func truncateProcessRetrySubtreeOutput(output []byte) (string, bool) {
-	if len(output) <= processRetrySubtreeOutputMaxBytes {
-		return strings.ToValidUTF8(string(output), "\uFFFD"), false
+	truncated := len(output) > processRetrySubtreeOutputMaxBytes
+	if truncated {
+		output = output[len(output)-processRetrySubtreeOutputMaxBytes:]
 	}
-	tail := output[len(output)-processRetrySubtreeOutputMaxBytes:]
-	return strings.ToValidUTF8(string(tail), "\uFFFD"), true
+	normalized := strings.ToValidUTF8(string(output), "\uFFFD")
+	if processRetryJSONStringFits(normalized, processRetrySubtreeOutputMaxBytes) {
+		return normalized, truncated
+	}
+	runes := []rune(normalized)
+	low, high := 0, len(runes)
+	for low < high {
+		mid := low + (high-low+1)/2
+		if processRetryJSONStringFits(string(runes[len(runes)-mid:]), processRetrySubtreeOutputMaxBytes) {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	return string(runes[len(runes)-low:]), true
 }
 
 type quarantinedRaceChildState struct {
@@ -542,7 +558,37 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		collector = coverage.BeginProcessTestCoverage(source.RuntimePath)
 	}
 
-	t.Cleanup(func() {
+	bodyReturned := false
+	defer func() {
+		panicData := recover()
+		unexpected := panicData == nil && processRetryUnexpectedTestTermination(t, bodyReturned)
+		if panicData != nil || unexpected {
+			if panicData == nil {
+				panicData = unexpectedTestTerminationMessage
+			}
+			execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
+				Type:    "panic",
+				Message: truncateProcessRetryErrorMessage(toString(panicData)),
+				Stack:   truncateProcessRetryErrorStack(utils.GetStacktrace(1)),
+			})
+		}
+
+		// Drain user cleanups before snapshotting. testing.tRunner marks a cleanup
+		// panic only after recursively running earlier cleanups, which would make a
+		// regular t.Cleanup finalizer report the descendant as passing.
+		cleanup := &testCleanupResult{}
+		runTestCleanupWithOptions(t, cleanup, true)
+		if cleanup.panicData != nil {
+			t.Fail()
+			execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
+				Type:    "panic",
+				Message: truncateProcessRetryErrorMessage(toString(cleanup.panicData)),
+				Stack:   truncateProcessRetryErrorStack(cleanup.panicStacktrace),
+			})
+			// The parent replays this recorded panic. Re-panicking here would let
+			// testing terminate the child before it can write the subtree result.
+		}
+
 		if coverageLocked {
 			defer parent.processRetryCoverageMu.Unlock()
 		}
@@ -603,7 +649,11 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		}
 		state.append(result)
 		deleteTestMetadata(t)
-	})
+
+		if panicData != nil && !unexpected {
+			panic(panicData)
+		}
+	}()
 
 	if directive.Disabled && !directive.AttemptToFix {
 		reason := constants.TestDisabledSkipReason
@@ -619,25 +669,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		execMeta.isItrForcedRun = forced
 	}
 
-	bodyReturned := false
-	defer func() {
-		panicData := recover()
-		unexpected := panicData == nil && processRetryUnexpectedTestTermination(t, bodyReturned)
-		if panicData == nil && !unexpected {
-			return
-		}
-		if panicData == nil {
-			panicData = unexpectedTestTerminationMessage
-		}
-		execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
-			Type:    "panic",
-			Message: truncateProcessRetryErrorMessage(toString(panicData)),
-			Stack:   truncateProcessRetryErrorStack(utils.GetStacktrace(1)),
-		})
-		if !unexpected {
-			panic(panicData)
-		}
-	}()
 	original(t)
 	bodyReturned = true
 }
@@ -839,6 +870,7 @@ func runQuarantinedRaceProcessIsolation(
 		rootTotal = processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries)
 	}
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
+	failfastStopped := false
 	for idx := 0; idx < rootTotal; idx++ {
 		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx)
 		if processRetryInfrastructureFailure(attempt) {
@@ -848,9 +880,14 @@ func runQuarantinedRaceProcessIsolation(
 		invocations = append(invocations, quarantinedRaceInvocation{
 			cfg: cfg, attempt: attempt, attemptIndex: idx,
 		})
+		if quarantinedRaceFailfastStopsContinuation(attempt) {
+			failfastStopped = true
+			break
+		}
 	}
 
-	if !cfg.OwnsAttemptToFix && cfg.AttemptToFixRetries > 0 {
+	if !cfg.OwnsAttemptToFix && cfg.AttemptToFixRetries > 0 && !failfastStopped {
+	descendantRetries:
 		for _, result := range invocations[0].attempt.Result.Subtests {
 			if !result.AttemptToFixOwn {
 				continue
@@ -874,6 +911,9 @@ func runQuarantinedRaceProcessIsolation(
 				invocations = append(invocations, quarantinedRaceInvocation{
 					cfg: continuationCfg, attempt: attempt, attemptIndex: idx,
 				})
+				if quarantinedRaceFailfastStopsContinuation(attempt) {
+					break descendantRetries
+				}
 			}
 		}
 	}
@@ -889,6 +929,10 @@ func runQuarantinedRaceProcessIsolation(
 // in-process retry path, despite its historical name.
 func processRetryAttemptToFixExecutionCount(configured int) int {
 	return max(configured, 1)
+}
+
+func quarantinedRaceFailfastStopsContinuation(attempt processRetryAttemptResult) bool {
+	return retryAttemptFailfastEnabled() && effectiveProcessRetryStatus(attempt, false).Failed
 }
 
 func runQuarantinedRaceInvocation(

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -88,8 +88,14 @@ type processRetrySubtreeDirective struct {
 }
 
 type processRetrySubtreeITR struct {
+	SuiteName               string `json:"suite_name"`
 	TestName                string `json:"test_name"`
 	MissingLineCodeCoverage bool   `json:"missing_line_code_coverage,omitempty"`
+}
+
+type processRetryResolvedDirective struct {
+	directive    processRetrySubtreeDirective
+	attemptOwner string
 }
 
 type processRetryTestSource struct {
@@ -214,12 +220,12 @@ func buildProcessRetrySubtreeConfig(
 	if itr != nil {
 		cfg.ITRCoverageActive = itr.coverageActive
 		if itr.response != nil {
-			if tests, ok := itr.response.Skippables[identity.SuiteName]; ok {
+			for suiteName, tests := range itr.response.Skippables {
 				for name, candidates := range tests {
 					if name != cfg.SelectedRoot && !strings.HasPrefix(name, cfg.SelectedRoot+"/") {
 						continue
 					}
-					entry := processRetrySubtreeITR{TestName: name}
+					entry := processRetrySubtreeITR{SuiteName: suiteName, TestName: name}
 					matched := false
 					for _, candidate := range candidates {
 						if strings.TrimSpace(candidate.Parameters) != "" {
@@ -236,7 +242,7 @@ func buildProcessRetrySubtreeConfig(
 		}
 	}
 	slices.SortFunc(cfg.ITR, func(a, b processRetrySubtreeITR) int {
-		return strings.Compare(a.TestName, b.TestName)
+		return compareProcessRetrySubtreeITR(a, b)
 	})
 	if err := validateProcessRetrySubtreeConfig(cfg, cfg.SelectedRoot); err != nil {
 		return nil, err
@@ -291,12 +297,13 @@ func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedR
 		}
 		previousDirective = directive
 	}
-	previous := ""
-	for _, candidate := range cfg.ITR {
-		if !processRetryNameWithinRoot(candidate.TestName, cfg.SelectedRoot) || candidate.TestName <= previous {
+	var previousITR processRetrySubtreeITR
+	for idx, candidate := range cfg.ITR {
+		if strings.TrimSpace(candidate.SuiteName) == "" || !processRetryNameWithinRoot(candidate.TestName, cfg.SelectedRoot) ||
+			idx > 0 && compareProcessRetrySubtreeITR(previousITR, candidate) >= 0 {
 			return errors.New("invalid process retry subtree ITR directive")
 		}
-		previous = candidate.TestName
+		previousITR = candidate
 	}
 	return nil
 }
@@ -345,6 +352,13 @@ func compareProcessRetryDirectives(a, b processRetrySubtreeDirective) int {
 	return strings.Compare(a.TestName, b.TestName)
 }
 
+func compareProcessRetrySubtreeITR(a, b processRetrySubtreeITR) int {
+	if cmp := strings.Compare(a.SuiteName, b.SuiteName); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(a.TestName, b.TestName)
+}
+
 func (cfg *processRetrySubtreeConfig) exactDirective(moduleName, suiteName, name string) (processRetrySubtreeDirective, bool) {
 	target := processRetrySubtreeDirective{ModuleName: moduleName, SuiteName: suiteName, TestName: name}
 	idx, ok := slices.BinarySearchFunc(cfg.Directives, target, func(a, b processRetrySubtreeDirective) int {
@@ -375,39 +389,60 @@ func (ctx *quarantinedRaceProcessContext) clearAncestorOutcomes(cfg *processRetr
 	}
 }
 
-func (cfg *processRetrySubtreeConfig) resolveDirective(moduleName, suiteName, name string) (processRetrySubtreeDirective, string) {
-	resolved := cfg.Root
-	resolved.TestName = name
-	resolved.ModuleName = moduleName
-	resolved.SuiteName = suiteName
-	attemptOwner := ""
+func (cfg *processRetrySubtreeConfig) resolvedRootDirective() processRetryResolvedDirective {
+	resolved := processRetryResolvedDirective{directive: cfg.Root}
 	if cfg.OwnsAttemptToFix {
-		attemptOwner = cfg.SelectedRoot
+		resolved.attemptOwner = cfg.SelectedRoot
 	}
-	if name == cfg.SelectedRoot {
-		return resolved, attemptOwner
+	return resolved
+}
+
+// resolveChildDirective preserves the effective state already resolved for the
+// immediate parent. Callback source files can change at every t.Run boundary,
+// so re-resolving all path components with the child's suite would lose an
+// ancestor directive from another suite.
+func (cfg *processRetrySubtreeConfig) resolveChildDirective(parent processRetryResolvedDirective, moduleName, suiteName, name string) processRetryResolvedDirective {
+	resolved := parent
+	resolved.directive.TestName = name
+	resolved.directive.ModuleName = moduleName
+	resolved.directive.SuiteName = suiteName
+	exact, ok := cfg.exactDirective(moduleName, suiteName, name)
+	if !ok {
+		return resolved
 	}
-	rootParts := strings.Split(cfg.SelectedRoot, "/")
-	parts := strings.Split(name, "/")
-	for idx := len(rootParts) + 1; idx <= len(parts); idx++ {
-		candidate := strings.Join(parts[:idx], "/")
-		exact, ok := cfg.exactDirective(moduleName, suiteName, candidate)
+	resolved.directive.Disabled = resolved.directive.Disabled || exact.Disabled
+	resolved.directive.Quarantined = resolved.directive.Quarantined || exact.Quarantined
+	if exact.AttemptToFix {
+		if !parent.directive.AttemptToFix {
+			resolved.attemptOwner = name
+		}
+		resolved.directive.AttemptToFix = true
+	} else {
+		resolved.directive.AttemptToFix = false
+		resolved.attemptOwner = ""
+	}
+	return resolved
+}
+
+func (cfg *processRetrySubtreeConfig) resolveSubtreeResults(results []processRetrySubtreeResult) ([]processRetryResolvedDirective, error) {
+	resolved := make([]processRetryResolvedDirective, len(results))
+	seen := map[string]processRetryResolvedDirective{cfg.SelectedRoot: cfg.resolvedRootDirective()}
+	for idx, result := range results {
+		if result.TestName == cfg.SelectedRoot || !processRetryNameWithinRoot(result.TestName, cfg.SelectedRoot) {
+			return nil, fmt.Errorf("%w: subtree identity outside selected root", errProcessRetryResultInvalid)
+		}
+		if _, duplicate := seen[result.TestName]; duplicate {
+			return nil, fmt.Errorf("%w: duplicate subtree result", errProcessRetryResultInvalid)
+		}
+		separator := strings.LastIndexByte(result.TestName, '/')
+		parent, ok := seen[result.TestName[:separator]]
 		if !ok {
-			continue
+			return nil, fmt.Errorf("%w: subtree parent result missing", errProcessRetryResultInvalid)
 		}
-		resolved.Disabled = resolved.Disabled || exact.Disabled
-		resolved.Quarantined = resolved.Quarantined || exact.Quarantined
-		if exact.AttemptToFix {
-			if !resolved.AttemptToFix {
-				attemptOwner = candidate
-			}
-			resolved.AttemptToFix = true
-		} else {
-			resolved.AttemptToFix = false
-			attemptOwner = ""
-		}
+		resolved[idx] = cfg.resolveChildDirective(parent, result.ModuleName, result.SuiteName, result.TestName)
+		seen[result.TestName] = resolved[idx]
 	}
-	return resolved, attemptOwner
+	return resolved, nil
 }
 
 func (cfg *processRetrySubtreeConfig) exactManagedDescendant(moduleName, suiteName, name string) bool {
@@ -435,9 +470,10 @@ func (cfg *processRetrySubtreeConfig) withinManagedDescendant(moduleName, suiteN
 	return false
 }
 
-func (cfg *processRetrySubtreeConfig) itrDecision(name string, meta processRetrySubtreeDirective, sourceFunc *runtime.Func) (skip, forced bool) {
-	idx, ok := slices.BinarySearchFunc(cfg.ITR, name, func(candidate processRetrySubtreeITR, name string) int {
-		return strings.Compare(candidate.TestName, name)
+func (cfg *processRetrySubtreeConfig) itrDecision(suiteName, name string, meta processRetrySubtreeDirective, sourceFunc *runtime.Func) (skip, forced bool) {
+	target := processRetrySubtreeITR{SuiteName: suiteName, TestName: name}
+	idx, ok := slices.BinarySearchFunc(cfg.ITR, target, func(a, b processRetrySubtreeITR) int {
+		return compareProcessRetrySubtreeITR(a, b)
 	})
 	if !ok || meta.AttemptToFix || meta.Modified {
 		return false, false
@@ -531,8 +567,8 @@ type quarantinedRaceFailureSnapshot struct {
 // exact managed descendant may set through testing.common.Fail. Restoring them
 // lets the descendant remain failed in CI Visibility without changing its
 // enclosing t.Run result; independently owned failures remain sticky in state.
-func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtreeConfig, moduleName, suiteName string) *quarantinedRaceFailureSnapshot {
-	if t == nil || cfg == nil || !cfg.exactManagedDescendant(moduleName, suiteName, t.Name()) {
+func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtreeConfig, managed bool) *quarantinedRaceFailureSnapshot {
+	if t == nil || cfg == nil || !managed {
 		return nil
 	}
 	layout := getTestingInternalsLayout()
@@ -827,8 +863,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		suiteName = testifyData.suiteName
 		sourceFunc = testifyData.methodFunc
 	}
-	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg, moduleName, suiteName)
-	maskedByManagedDescendant := state.cfg.withinManagedDescendant(moduleName, suiteName, name)
+	managedByDescendant := parent.processRetryManagedDescendant || state.cfg.exactManagedDescendant(moduleName, suiteName, name)
+	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg, managedByDescendant)
+	maskedByManagedDescendant := managedByDescendant
 	execMeta := createTestMetadata(t, nil)
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
@@ -840,7 +877,14 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	}
 	state.beginAggregateCoverage(name)
 
-	directive, attemptOwner := state.cfg.resolveDirective(moduleName, suiteName, name)
+	resolved := state.cfg.resolvedRootDirective()
+	if name != state.cfg.SelectedRoot {
+		resolved = state.cfg.resolveChildDirective(processRetryResolvedDirective{
+			directive:    processRetryDirectiveFromMetadata(parent.identity, parent),
+			attemptOwner: parent.processRetryAttemptOwner,
+		}, moduleName, suiteName, name)
+	}
+	directive, attemptOwner := resolved.directive, resolved.attemptOwner
 	execMeta.isDisabled = directive.Disabled
 	execMeta.isQuarantined = directive.Quarantined
 	execMeta.isAttemptToFix = directive.AttemptToFix
@@ -849,6 +893,8 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.hasExplicitQuarantined = true
 	execMeta.hasExplicitAttemptToFix = true
 	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
+	execMeta.processRetryAttemptOwner = attemptOwner
+	execMeta.processRetryManagedDescendant = managedByDescendant
 
 	execMeta.identity = newTestIdentity(moduleName, suiteName, name)
 	source := processRetrySourceFromFunc(sourceFunc)
@@ -1038,7 +1084,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		execMeta.processRetrySkipReason.Store(&reason)
 		t.SkipNow()
 	}
-	if skip, forced := state.cfg.itrDecision(name, directive, sourceFunc); skip {
+	if skip, forced := state.cfg.itrDecision(suiteName, name, directive, sourceFunc); skip {
 		execMeta.isItrSkipped = true
 		reason := constants.SkippedByITRReason
 		execMeta.processRetrySkipReason.Store(&reason)
@@ -1129,23 +1175,19 @@ func validateProcessRetrySubtreeResultEnvelope(result processRetryResult, expect
 	if len(result.Subtests) > processRetrySubtreeMaxResults {
 		return fmt.Errorf("%w: too many subtree results", errProcessRetryResultInvalid)
 	}
-	seen := make(map[string]struct{}, len(result.Subtests))
-	for _, subtest := range result.Subtests {
-		if subtest.TestName == expected.Subtree.SelectedRoot || !processRetryNameWithinRoot(subtest.TestName, expected.Subtree.SelectedRoot) {
-			return fmt.Errorf("%w: subtree identity outside selected root", errProcessRetryResultInvalid)
-		}
-		if _, duplicate := seen[subtest.TestName]; duplicate {
-			return fmt.Errorf("%w: duplicate subtree result", errProcessRetryResultInvalid)
-		}
-		seen[subtest.TestName] = struct{}{}
-		if err := validateProcessRetrySubtreeResult(subtest, expected.Subtree); err != nil {
+	resolved, err := expected.Subtree.resolveSubtreeResults(result.Subtests)
+	if err != nil {
+		return err
+	}
+	for idx, subtest := range result.Subtests {
+		if err := validateProcessRetrySubtreeResult(subtest, resolved[idx]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, cfg *processRetrySubtreeConfig) error {
+func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, resolved processRetryResolvedDirective) error {
 	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
 		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
 		return fmt.Errorf("%w: invalid subtree timing", errProcessRetryResultInvalid)
@@ -1171,7 +1213,7 @@ func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, cfg *pr
 	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
 		return err
 	}
-	directive, owner := cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
+	directive, owner := resolved.directive, resolved.attemptOwner
 	if result.Disabled != directive.Disabled || result.Quarantined != directive.Quarantined ||
 		result.AttemptToFix != directive.AttemptToFix || result.AttemptToFixOwn != (owner == result.TestName) {
 		return fmt.Errorf("%w: subtree directive mismatch", errProcessRetryResultInvalid)
@@ -1339,7 +1381,7 @@ func continueQuarantinedRaceDescendantFamilies(
 	invocations *[]quarantinedRaceInvocation,
 ) (stop, failed bool) {
 	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
-		continuationCfg, err := cfg.forSelectedRoot(result.ModuleName, result.SuiteName, result.TestName)
+		continuationCfg, err := cfg.forSelectedRoot(result)
 		if err != nil {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
 			return false, true
@@ -1358,12 +1400,7 @@ func continueQuarantinedRaceDescendantFamilies(
 		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
 			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, runRoot, idx, parallelBridge)
 			if processRetryInfrastructureFailure(next) {
-				failQuarantinedRaceIsolation(t, &commonInfo{
-					moduleName: testInfo.moduleName,
-					suiteName:  testInfo.suiteName,
-					testName:   result.TestName,
-					identity:   newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName),
-				}, execMeta, next)
+				failQuarantinedRaceIsolation(t, processRetryCommonInfoFromSubtreeResult(result), execMeta, next)
 				return false, true
 			}
 			*invocations = append(*invocations, quarantinedRaceInvocation{
@@ -1517,30 +1554,42 @@ func failQuarantinedRaceIsolation(t *testing.T, testInfo *commonInfo, execMeta *
 	t.Fail()
 }
 
-func (cfg *processRetrySubtreeConfig) forSelectedRoot(moduleName, suiteName, name string) (*processRetrySubtreeConfig, error) {
-	directive, _ := cfg.resolveDirective(moduleName, suiteName, name)
+func processRetryCommonInfoFromSubtreeResult(result processRetrySubtreeResult) *commonInfo {
+	return &commonInfo{
+		moduleName: result.ModuleName,
+		suiteName:  result.SuiteName,
+		testName:   result.TestName,
+		identity:   newTestIdentity(result.ModuleName, result.SuiteName, result.TestName),
+	}
+}
+
+func (cfg *processRetrySubtreeConfig) forSelectedRoot(result processRetrySubtreeResult) (*processRetrySubtreeConfig, error) {
+	directive := processRetrySubtreeDirective{
+		TestName: result.TestName, ModuleName: result.ModuleName, SuiteName: result.SuiteName,
+		Disabled: result.Disabled, Quarantined: result.Quarantined, AttemptToFix: result.AttemptToFix, Modified: result.Modified,
+	}
 	next := &processRetrySubtreeConfig{
 		Version:              processRetrySubtreeVersion,
-		SelectedRoot:         name,
+		SelectedRoot:         result.TestName,
 		Root:                 directive,
 		AttemptToFixRetries:  cfg.AttemptToFixRetries,
-		OwnsAttemptToFix:     directive.AttemptToFix,
+		OwnsAttemptToFix:     result.AttemptToFixOwn,
 		CollectPerTest:       cfg.CollectPerTest,
 		CollectAggregate:     cfg.CollectAggregate,
 		ITRCoverageActive:    cfg.ITRCoverageActive,
 		ImpactedTestsEnabled: cfg.ImpactedTestsEnabled,
 	}
 	for _, candidate := range cfg.Directives {
-		if candidate.TestName != name && processRetryNameWithinRoot(candidate.TestName, name) {
+		if candidate.TestName != result.TestName && processRetryNameWithinRoot(candidate.TestName, result.TestName) {
 			next.Directives = append(next.Directives, candidate)
 		}
 	}
 	for _, candidate := range cfg.ITR {
-		if processRetryNameWithinRoot(candidate.TestName, name) {
+		if processRetryNameWithinRoot(candidate.TestName, result.TestName) {
 			next.ITR = append(next.ITR, candidate)
 		}
 	}
-	return next, validateProcessRetrySubtreeConfig(next, name)
+	return next, validateProcessRetrySubtreeConfig(next, result.TestName)
 }
 
 func replayQuarantinedRaceInvocations(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, invocations []quarantinedRaceInvocation) {
@@ -1570,8 +1619,8 @@ func replayQuarantinedRaceResults(
 	generations := make(map[string]int)
 	lastOccurrence := make(map[familyKey]int)
 	events := make([]replayEvent, 0, len(invocations))
-	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) {
-		_, attemptOwner := invocation.cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
+	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult, resolved processRetryResolvedDirective) {
+		attemptOwner := resolved.attemptOwner
 		if result.TestName == attemptOwner && attemptOwner != invocation.cfg.SelectedRoot {
 			// A descendant-owned family starts fresh each time its enclosing
 			// selected root discovers it.
@@ -1583,11 +1632,12 @@ func replayQuarantinedRaceResults(
 		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner, inherited: inherited})
 	}
 	for _, invocation := range invocations {
-		for _, result := range invocation.attempt.Result.Subtests {
-			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result))
+		resolved, _ := invocation.cfg.resolveSubtreeResults(invocation.attempt.Result.Subtests)
+		for idx, result := range invocation.attempt.Result.Subtests {
+			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result), resolved[idx])
 		}
 		if includeRoot {
-			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
+			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation), invocation.cfg.resolvedRootDirective())
 		}
 	}
 	outcomes := make(map[familyKey]retryOutcomeAccumulator)
@@ -1729,7 +1779,8 @@ func replayQuarantinedRaceEvent(
 }
 
 func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *processRetrySubtreeConfig) processRetrySubtreeResult {
-	directive, owner := cfg.resolveDirective(result.ModuleName, result.SuiteName, result.TestName)
+	resolved := cfg.resolvedRootDirective()
+	directive, owner := resolved.directive, resolved.attemptOwner
 	return processRetrySubtreeResult{
 		TestName:        result.TestName,
 		ModuleName:      result.ModuleName,

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -559,6 +559,10 @@ type quarantinedRaceChildState struct {
 	unmasked        map[string]struct{}
 }
 
+// This indirection keeps duration accounting on the wall clock in production
+// while allowing tests to supply a logical clock instead of sleeping.
+var quarantinedRaceNow = time.Now
+
 type quarantinedRaceFailureEntry struct {
 	mu     *sync.RWMutex
 	failed *bool
@@ -681,7 +685,7 @@ func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRa
 }
 
 func (s *quarantinedRaceChildState) begin() (uint64, time.Time, int64) {
-	return s.next.Add(1), time.Now(), retryAttemptRaceErrors()
+	return s.next.Add(1), quarantinedRaceNow(), retryAttemptRaceErrors()
 }
 
 func (s *quarantinedRaceChildState) beginAggregateCoverage(name string) {
@@ -928,7 +932,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// parent. A failure added by the selected root after that release can then
 		// be identified before its parallel descendants resume.
 		failureSnapshot.restoreAncestors(state)
-		activeDuration += time.Since(activeStart)
+		activeDuration += quarantinedRaceNow().Sub(activeStart)
 		activeStart = time.Time{}
 		// A nested selected root releases its discovery ancestor in Parallel.
 		// Exclude that ancestor's work from this root's aggregate profile.
@@ -942,7 +946,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		coverageValid = state.coverage.finish(coverageInterval) && coverageValid
 		coverageInterval = nil
 		return func() {
-			activeStart = time.Now()
+			activeStart = quarantinedRaceNow()
 			if resumeAggregate != nil {
 				resumeAggregate()
 			}
@@ -976,7 +980,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// scheduler wait from the parent's duration, but cleanup remains active time.
 		cleanup := &testCleanupResult{}
 		if !activeStart.IsZero() {
-			activeDuration += time.Since(activeStart)
+			activeDuration += quarantinedRaceNow().Sub(activeStart)
 			activeStart = time.Time{}
 		}
 		if !maskedByManagedDescendant && t.Failed() {
@@ -987,9 +991,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			state.markUnmaskedFailure(moduleName, suiteName, name)
 		}
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
-		activeStart = time.Now()
+		activeStart = quarantinedRaceNow()
 		runTestCleanupCallbacks(t, cleanup)
-		activeDuration += time.Since(activeStart)
+		activeDuration += quarantinedRaceNow().Sub(activeStart)
 		activeStart = time.Time{}
 		if cleanup.panicData != nil {
 			t.Fail()

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -678,6 +678,14 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			result.Status = processRetryStatusPass
 		}
 		state.append(result)
+		if unexpected && fields != nil && fields.mu != nil && fields.finished != nil {
+			// runtime.Goexit bypasses the normal return to testing.tRunner. The
+			// subtree result is committed, so consume that terminal before the
+			// native runner can turn it into a process-ending panic.
+			fields.mu.Lock()
+			*fields.finished = true
+			fields.mu.Unlock()
+		}
 		deleteTestMetadata(t)
 
 		// Body panics are valid test results in this child protocol. They were

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1317,6 +1317,7 @@ type quarantinedRacePendingReplay struct {
 }
 
 type quarantinedRaceReplayState struct {
+	mu      sync.Mutex
 	pending map[quarantinedRaceReplayIdentity]quarantinedRacePendingReplay
 	order   []quarantinedRaceReplayIdentity
 }
@@ -1419,7 +1420,11 @@ func runQuarantinedRaceProcessIsolation(
 		}
 	}
 
-	replayQuarantinedRaceInvocations(testInfo, processCtx, invocations)
+	var deferred *quarantinedRaceReplayState
+	if cfg.AncestorAttemptToFix {
+		deferred = quarantinedRaceReplayStateFor(parentExecMeta)
+	}
+	replayQuarantinedRaceResults(testInfo, processCtx, invocations, true, deferred)
 	// A valid quarantined failure, panic, or race remains visible in CI
 	// Visibility but is intentionally masked from the package result. An
 	// infrastructure error returns above through Fail and is never quarantined.
@@ -1454,11 +1459,12 @@ func continueQuarantinedRaceDescendantFamilies(
 		if result.Parallel {
 			// A parallel owner needs the enclosing scheduler siblings recreated.
 			// Serial owners use their exact selector and do not repeat side effects.
-			// Process coverage counters are global, so the owner's aggregate profile
-			// cannot be separated from those scheduling siblings and must be omitted.
+			// Process coverage counters are global, so neither per-test intervals nor
+			// aggregate coverage can be separated from those scheduling siblings.
 			runRoot = cfg.SelectedRoot
-			if continuationCfg.CollectAggregate {
+			if continuationCfg.CollectPerTest || continuationCfg.CollectAggregate {
 				next := *continuationCfg
+				next.CollectPerTest = false
 				next.CollectAggregate = false
 				runCfg = &next
 			}
@@ -1564,11 +1570,6 @@ func runQuarantinedRaceInvocation(
 }
 
 func finalizeQuarantinedRaceInvocation(cfg *processRetrySubtreeConfig, attempt processRetryAttemptResult) processRetryAttemptResult {
-	defer func() {
-		if attempt.Cleanup != nil {
-			attempt.Cleanup()
-		}
-	}()
 	if cfg.CollectAggregate && attempt.Result.Status != "" && attempt.Result.Status != processRetryStatusNotRun {
 		if err := coverage.MergeProcessCoverageProfile(processRetrySubtreeCoveragePath(filepath.Join(attempt.TempDir, "result.json"))); err != nil {
 			attempt.Err = errors.Join(attempt.Err, fmt.Errorf("aggregate process coverage: %w", err))
@@ -1581,6 +1582,10 @@ func finalizeQuarantinedRaceInvocation(cfg *processRetrySubtreeConfig, attempt p
 		// controlled terminal exit code. Normalize that expected carrier exit to
 		// the status required by effectiveProcessRetryStatus.
 		attempt.ExitCode = processRetryControlledPanicExitCode
+	}
+	if attempt.Cleanup != nil {
+		attempt.Cleanup()
+		attempt.Cleanup = nil
 	}
 	return attempt
 }
@@ -1664,10 +1669,6 @@ func (cfg *processRetrySubtreeConfig) forSelectedRoot(result processRetrySubtree
 	return next, validateProcessRetrySubtreeConfig(next, result.TestName)
 }
 
-func replayQuarantinedRaceInvocations(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, invocations []quarantinedRaceInvocation) {
-	replayQuarantinedRaceResults(testInfo, processCtx, invocations, true, nil)
-}
-
 func replayQuarantinedRaceResults(
 	testInfo *commonInfo,
 	processCtx *quarantinedRaceProcessContext,
@@ -1741,6 +1742,8 @@ func replayQuarantinedRaceResults(
 }
 
 func (s *quarantinedRaceReplayState) deferInherited(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, event quarantinedRaceReplayEvent, counted map[quarantinedRaceReplayIdentity]*testIdentity) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.pending == nil {
 		s.pending = make(map[quarantinedRaceReplayIdentity]quarantinedRacePendingReplay)
 	}
@@ -1765,7 +1768,12 @@ func (s *quarantinedRaceReplayState) deferInherited(testInfo *commonInfo, proces
 }
 
 func (s *quarantinedRaceReplayState) finish() {
-	if s == nil || len(s.pending) == 0 {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pending) == 0 {
 		return
 	}
 	counted := make(map[quarantinedRaceReplayIdentity]*testIdentity)
@@ -1779,6 +1787,20 @@ func (s *quarantinedRaceReplayState) finish() {
 	closeQuarantinedRaceReplayCounters(counted)
 	s.pending = nil
 	s.order = nil
+}
+
+func quarantinedRaceReplayStateFor(execMeta *testExecutionMetadata) *quarantinedRaceReplayState {
+	if execMeta == nil {
+		return nil
+	}
+	if state := execMeta.quarantinedRaceReplay.Load(); state != nil {
+		return state
+	}
+	state := &quarantinedRaceReplayState{}
+	if execMeta.quarantinedRaceReplay.CompareAndSwap(nil, state) {
+		return state
+	}
+	return execMeta.quarantinedRaceReplay.Load()
 }
 
 func closeQuarantinedRaceReplayCounters(counted map[quarantinedRaceReplayIdentity]*testIdentity) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -431,12 +431,13 @@ type quarantinedRaceChildState struct {
 	parallelStarted atomic.Bool
 	parallelDone    chan error
 	coverage        quarantinedRaceCoverageCoordinator
-	unmaskedFailure atomic.Bool
+	unmasked        map[string]struct{}
 }
 
 type quarantinedRaceFailureEntry struct {
 	mu     *sync.RWMutex
 	failed *bool
+	name   string
 	before bool
 }
 
@@ -465,10 +466,10 @@ func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtree
 		name := fieldPtr[string](base, layout.common.name)
 		entry.mu.RLock()
 		entry.before = *entry.failed
-		currentName := *name
+		entry.name = *name
 		entry.mu.RUnlock()
 		snapshot.entries = append(snapshot.entries, entry)
-		if currentName == cfg.SelectedRoot {
+		if entry.name == cfg.SelectedRoot {
 			runtime.KeepAlive(t)
 			return snapshot
 		}
@@ -477,22 +478,26 @@ func captureQuarantinedRaceManagedFailure(t *testing.T, cfg *processRetrySubtree
 	return nil
 }
 
-func (snapshot *quarantinedRaceFailureSnapshot) restore(unmaskedFailure bool) {
-	snapshot.restoreFrom(0, unmaskedFailure)
+func (snapshot *quarantinedRaceFailureSnapshot) restore(state *quarantinedRaceChildState) {
+	snapshot.restoreFrom(0, state)
 }
 
-func (snapshot *quarantinedRaceFailureSnapshot) restoreAncestors(unmaskedFailure bool) {
-	snapshot.restoreFrom(1, unmaskedFailure)
+func (snapshot *quarantinedRaceFailureSnapshot) restoreAncestors(state *quarantinedRaceChildState) {
+	snapshot.restoreFrom(1, state)
 }
 
-func (snapshot *quarantinedRaceFailureSnapshot) restoreFrom(first int, unmaskedFailure bool) {
+func (snapshot *quarantinedRaceFailureSnapshot) restoreFrom(first int, state *quarantinedRaceChildState) {
 	if snapshot == nil {
 		return
 	}
 	for idx := first; idx < len(snapshot.entries); idx++ {
 		entry := snapshot.entries[idx]
+		failed := entry.before
+		if idx > 0 {
+			failed = state.hasUnmaskedFailure(entry.name)
+		}
 		entry.mu.Lock()
-		*entry.failed = entry.before || (idx > 0 && unmaskedFailure)
+		*entry.failed = failed
 		entry.mu.Unlock()
 	}
 }
@@ -568,13 +573,41 @@ func (s *quarantinedRaceChildState) finishAggregateCoverage(name string) {
 	s.aggregateFinish.Do(s.finishAggregate)
 }
 
+func (s *quarantinedRaceChildState) markUnmaskedFailure(name string) {
+	if s == nil || s.cfg == nil || !processRetryNameWithinRoot(name, s.cfg.SelectedRoot) || s.cfg.withinManagedDescendant(name) {
+		return
+	}
+	s.mu.Lock()
+	if s.unmasked == nil {
+		s.unmasked = make(map[string]struct{})
+	}
+	for candidate := name; ; {
+		s.unmasked[candidate] = struct{}{}
+		if candidate == s.cfg.SelectedRoot {
+			break
+		}
+		candidate = candidate[:strings.LastIndexByte(candidate, '/')]
+	}
+	s.mu.Unlock()
+}
+
+func (s *quarantinedRaceChildState) hasUnmaskedFailure(name string) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	_, ok := s.unmasked[name]
+	s.mu.Unlock()
+	return ok
+}
+
 func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) bool {
 	if s == nil {
 		return false
 	}
 	unmaskedFailure := result.Failed && !result.masked
 	if unmaskedFailure {
-		s.unmaskedFailure.Store(true)
+		s.markUnmaskedFailure(result.TestName)
 	}
 	s.mu.Lock()
 	s.results = append(s.results, result)
@@ -750,7 +783,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// Clear any managed failure propagated before t.Parallel releases the
 		// parent. A failure added by the selected root after that release can then
 		// be identified before its parallel descendants resume.
-		failureSnapshot.restoreAncestors(state.unmaskedFailure.Load())
+		failureSnapshot.restoreAncestors(state)
 		activeDuration += time.Since(activeStart)
 		activeStart = time.Time{}
 		// A nested selected root releases its discovery ancestor in Parallel.
@@ -802,8 +835,12 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			activeDuration += time.Since(activeStart)
 			activeStart = time.Time{}
 		}
-		if name == state.cfg.SelectedRoot && t.Failed() {
-			state.unmaskedFailure.Store(true)
+		if !maskedByManagedDescendant && t.Failed() {
+			// Serial and concurrently started t.Run calls have returned before
+			// their parent body returns. Parallel managed descendants restored
+			// their propagated bits before releasing it, so a remaining failure
+			// belongs to this unmanaged branch.
+			state.markUnmaskedFailure(name)
 		}
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
 		activeStart = time.Now()
@@ -886,7 +923,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			// Reapply this independently owned failure in either completion order.
 			t.Fail()
 		}
-		failureSnapshot.restore(state.unmaskedFailure.Load())
+		failureSnapshot.restore(state)
 		if unexpected && fields != nil && fields.mu != nil && fields.finished != nil {
 			// runtime.Goexit bypasses the normal return to testing.tRunner. The
 			// subtree result is committed, so consume that terminal before the

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1278,8 +1278,28 @@ type quarantinedRaceContinuationFailure struct {
 }
 
 type quarantinedRaceFamilyKey struct {
-	name       string
+	identity   quarantinedRaceReplayIdentity
 	generation int
+}
+
+func quarantinedRaceFamilyKeyFor(testInfo *commonInfo, result processRetrySubtreeResult, generation int) quarantinedRaceFamilyKey {
+	return quarantinedRaceFamilyKey{
+		identity:   quarantinedRaceReplayIdentityFor(testInfo, result),
+		generation: generation,
+	}
+}
+
+func quarantinedRaceReplayIdentityFor(testInfo *commonInfo, result processRetrySubtreeResult) quarantinedRaceReplayIdentity {
+	moduleName, suiteName := result.ModuleName, result.SuiteName
+	if testInfo != nil {
+		if moduleName == "" {
+			moduleName = testInfo.moduleName
+		}
+		if suiteName == "" {
+			suiteName = testInfo.suiteName
+		}
+	}
+	return quarantinedRaceReplayIdentity{moduleName: moduleName, suiteName: suiteName, testName: result.TestName}
 }
 
 type quarantinedRaceReplayEvent struct {
@@ -1430,13 +1450,21 @@ func continueQuarantinedRaceDescendantFamilies(
 			return stop, failure
 		}
 		runRoot := continuationCfg.SelectedRoot
+		runCfg := continuationCfg
 		if result.Parallel {
 			// A parallel owner needs the enclosing scheduler siblings recreated.
 			// Serial owners use their exact selector and do not repeat side effects.
+			// Process coverage counters are global, so the owner's aggregate profile
+			// cannot be separated from those scheduling siblings and must be omitted.
 			runRoot = cfg.SelectedRoot
+			if continuationCfg.CollectAggregate {
+				next := *continuationCfg
+				next.CollectAggregate = false
+				runCfg = &next
+			}
 		}
 		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-			next := run(continuationCfg, runRoot, idx)
+			next := run(runCfg, runRoot, idx)
 			*invocations = append(*invocations, quarantinedRaceInvocation{
 				cfg: continuationCfg, attempt: next, attemptIndex: idx,
 			})
@@ -1661,7 +1689,7 @@ func replayQuarantinedRaceResults(
 			generations[attemptOwner]++
 		}
 		inherited := invocation.cfg.AncestorAttemptToFix && result.AttemptToFix && attemptOwner == ""
-		family := quarantinedRaceFamilyKey{name: result.TestName, generation: generations[attemptOwner]}
+		family := quarantinedRaceFamilyKeyFor(testInfo, result, generations[attemptOwner])
 		lastOccurrence[family] = len(events)
 		events = append(events, quarantinedRaceReplayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner, inherited: inherited})
 	}
@@ -1679,7 +1707,7 @@ func replayQuarantinedRaceResults(
 	for idx, event := range events {
 		prior := outcomes[event.family]
 		last := lastOccurrence[event.family] == idx
-		identityKey := quarantinedRaceReplayIdentity{moduleName: event.result.ModuleName, suiteName: event.result.SuiteName, testName: event.result.TestName}
+		identityKey := quarantinedRaceReplayIdentityFor(testInfo, event.result)
 		if event.inherited && deferred != nil {
 			deferred.deferInherited(testInfo, processCtx, event, counted)
 			continue
@@ -1719,7 +1747,7 @@ func (s *quarantinedRaceReplayState) deferInherited(testInfo *commonInfo, proces
 	// Deferred ancestor attempts arrive one at a time. Publish the previous
 	// occurrence as non-final and retain only the newest one until group finish
 	// proves the family's actual last occurrence, including disappearance.
-	key := quarantinedRaceReplayIdentity{moduleName: event.result.ModuleName, suiteName: event.result.SuiteName, testName: event.result.TestName}
+	key := quarantinedRaceReplayIdentityFor(testInfo, event.result)
 	prior := retryOutcomeAccumulator{}
 	if pending, ok := s.pending[key]; ok {
 		replayQuarantinedRaceEvent(&pending.testInfo, pending.event.invocation, pending.event.result, pending.event.attemptOwner, true, false, pending.prior, counted)
@@ -1788,15 +1816,9 @@ func replayQuarantinedRaceEvent(
 	prior retryOutcomeAccumulator,
 	counted map[quarantinedRaceReplayIdentity]*testIdentity,
 ) {
-	moduleName, suiteName := result.ModuleName, result.SuiteName
-	if moduleName == "" {
-		moduleName = testInfo.moduleName
-	}
-	if suiteName == "" {
-		suiteName = testInfo.suiteName
-	}
+	identityKey := quarantinedRaceReplayIdentityFor(testInfo, result)
+	moduleName, suiteName := identityKey.moduleName, identityKey.suiteName
 	identity := newTestIdentity(moduleName, suiteName, result.TestName)
-	identityKey := quarantinedRaceReplayIdentity{moduleName: moduleName, suiteName: suiteName, testName: result.TestName}
 	if _, ok := counted[identityKey]; !ok {
 		// The parent already counted a top-level test before entering its
 		// wrapper. Subtests bypass the normal runSubtest path, so only they

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -99,6 +99,8 @@ type processRetryTestSource struct {
 // use the same status contract for the root itself.
 type processRetrySubtreeResult struct {
 	TestName        string                             `json:"test_name"`
+	ModuleName      string                             `json:"module_name"`
+	SuiteName       string                             `json:"suite_name"`
 	Status          processRetryStatus                 `json:"status"`
 	StartUnixNano   int64                              `json:"start_unix_nano"`
 	FinishUnixNano  int64                              `json:"finish_unix_nano"`
@@ -107,6 +109,7 @@ type processRetrySubtreeResult struct {
 	Skipped         bool                               `json:"skipped"`
 	Panic           bool                               `json:"panic"`
 	RaceDetected    bool                               `json:"race_detected,omitempty"`
+	Parallel        bool                               `json:"parallel,omitempty"`
 	Disabled        bool                               `json:"disabled,omitempty"`
 	Quarantined     bool                               `json:"quarantined,omitempty"`
 	AttemptToFix    bool                               `json:"attempt_to_fix,omitempty"`
@@ -692,6 +695,8 @@ func (o *processRetryChildObservation) buildSubtreeResult(result processRetryRes
 	}
 	root := results[rootIndex]
 	result.Status = root.Status
+	result.ModuleName = root.ModuleName
+	result.SuiteName = root.SuiteName
 	result.StartUnixNano = root.StartUnixNano
 	result.FinishUnixNano = root.FinishUnixNano
 	result.DurationNanos = root.DurationNanos
@@ -699,6 +704,7 @@ func (o *processRetryChildObservation) buildSubtreeResult(result processRetryRes
 	result.Skipped = root.Skipped
 	result.Panic = root.Panic
 	result.RaceDetected = root.RaceDetected
+	result.RootParallel = root.Parallel
 	result.ErrorType = root.ErrorType
 	result.ErrorMessage = root.ErrorMessage
 	result.ErrorStack = root.ErrorStack
@@ -748,7 +754,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	state.beginAggregateCoverage(name)
 
 	directive, attemptOwner := state.cfg.resolveDirective(name)
-	execMeta.identity = newTestIdentity("", "", name)
 	execMeta.isDisabled = directive.Disabled
 	execMeta.isQuarantined = directive.Quarantined
 	execMeta.isAttemptToFix = directive.AttemptToFix
@@ -758,10 +763,15 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.hasExplicitAttemptToFix = true
 	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
 
-	sourceFunc := runtime.FuncForPC(reflect.ValueOf(original).Pointer())
+	callbackPC := reflect.ValueOf(original).Pointer()
+	moduleName, suiteName := utils.GetModuleAndSuiteName(callbackPC)
+	sourceFunc := runtime.FuncForPC(callbackPC)
 	if testifyData := getTestifyTest(t); testifyData != nil && testifyData.methodFunc != nil {
+		moduleName = testifyData.moduleName
+		suiteName = testifyData.suiteName
 		sourceFunc = testifyData.methodFunc
 	}
+	execMeta.identity = newTestIdentity(moduleName, suiteName, name)
 	source := processRetrySourceFromFunc(sourceFunc)
 	execMeta.isAModifiedTest = directive.Modified || integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc)
 	directive.Modified = execMeta.isAModifiedTest
@@ -772,6 +782,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	var collector *coverage.ProcessTestCoverage
 	var coverageInterval *quarantinedRaceCoverageInterval
 	coverageValid := true
+	parallel := false
 	collectCoverage := state.cfg.CollectPerTest && coverage.CanCollect()
 	if collectCoverage {
 		coverageInterval = state.coverage.begin(name)
@@ -780,6 +791,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		}
 	}
 	execMeta.processRetryParallelPause = func() func() {
+		parallel = true
 		// Clear any managed failure propagated before t.Parallel releases the
 		// parent. A failure added by the selected root after that release can then
 		// be identified before its parallel descendants resume.
@@ -871,12 +883,15 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		fields := getTestPrivateFields(t)
 		result := processRetrySubtreeResult{
 			TestName:        name,
+			ModuleName:      execMeta.identity.ModuleName,
+			SuiteName:       execMeta.identity.SuiteName,
 			StartUnixNano:   start.UnixNano(),
 			FinishUnixNano:  finish.UnixNano(),
 			DurationNanos:   activeDuration.Nanoseconds(),
 			Failed:          t.Failed(),
 			Skipped:         t.Skipped(),
 			RaceDetected:    processRetrySubtreeRaceDetected(fields, raceBaseline, retryAttemptRaceErrors()),
+			Parallel:        parallel,
 			Disabled:        directive.Disabled,
 			Quarantined:     directive.Quarantined,
 			AttemptToFix:    directive.AttemptToFix,
@@ -1002,7 +1017,7 @@ func bufferQuarantinedRaceChildOutput(t *testing.T) func() {
 
 func validateProcessRetrySubtreeResultEnvelope(result processRetryResult, expected processRetryChildConfig) error {
 	if expected.Subtree == nil {
-		if result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 ||
+		if result.ModuleName != "" || result.SuiteName != "" || result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 ||
 			result.SkippedByITR || result.ITRForcedRun || result.Modified {
 			return fmt.Errorf("%w: unexpected subtree data", errProcessRetryResultInvalid)
 		}
@@ -1010,6 +1025,11 @@ func validateProcessRetrySubtreeResultEnvelope(result processRetryResult, expect
 	}
 	if result.Status == processRetryStatusNotRun {
 		return nil
+	}
+	if result.ModuleName == "" || result.SuiteName == "" ||
+		!processRetryJSONStringFits(result.ModuleName, processRetryErrorMessageMaxBytes) ||
+		!processRetryJSONStringFits(result.SuiteName, processRetryErrorMessageMaxBytes) {
+		return fmt.Errorf("%w: invalid subtree root identity", errProcessRetryResultInvalid)
 	}
 	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
 		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
@@ -1050,6 +1070,11 @@ func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, cfg *pr
 	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
 		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
 		return fmt.Errorf("%w: invalid subtree timing", errProcessRetryResultInvalid)
+	}
+	if result.ModuleName == "" || result.SuiteName == "" ||
+		!processRetryJSONStringFits(result.ModuleName, processRetryErrorMessageMaxBytes) ||
+		!processRetryJSONStringFits(result.SuiteName, processRetryErrorMessageMaxBytes) {
+		return fmt.Errorf("%w: invalid subtree identity", errProcessRetryResultInvalid)
 	}
 	if !processRetryJSONStringFits(result.ErrorType, processRetryErrorTypeMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
@@ -1115,6 +1140,12 @@ type quarantinedRaceInvocation struct {
 	cfg          *processRetrySubtreeConfig
 	attempt      processRetryAttemptResult
 	attemptIndex int
+}
+
+type quarantinedRaceReplayIdentity struct {
+	moduleName string
+	suiteName  string
+	testName   string
 }
 
 // runQuarantinedRaceProcessIsolation replaces only the selected quarantined
@@ -1229,9 +1260,6 @@ func continueQuarantinedRaceDescendantFamilies(
 	invocations *[]quarantinedRaceInvocation,
 ) (stop, failed bool) {
 	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
-		if retryAttemptFailfastEnabled() && result.Failed {
-			return true, false
-		}
 		continuationCfg, err := cfg.forSelectedRoot(result.TestName)
 		if err != nil {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
@@ -1242,8 +1270,14 @@ func continueQuarantinedRaceDescendantFamilies(
 		); stop || failed {
 			return stop, failed
 		}
+		runRoot := continuationCfg.SelectedRoot
+		if result.Parallel {
+			// A parallel owner needs the enclosing scheduler siblings recreated.
+			// Serial owners use their exact selector and do not repeat side effects.
+			runRoot = cfg.SelectedRoot
+		}
 		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, cfg.SelectedRoot, idx, parallelBridge)
+			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, runRoot, idx, parallelBridge)
 			if processRetryInfrastructureFailure(next) {
 				failQuarantinedRaceIsolation(t, &commonInfo{
 					moduleName: testInfo.moduleName,
@@ -1303,7 +1337,15 @@ func processRetryAttemptToFixExecutionCount(configured int) int {
 }
 
 func quarantinedRaceFailfastStopsContinuation(attempt processRetryAttemptResult) bool {
-	return retryAttemptFailfastEnabled() && effectiveProcessRetryStatus(attempt, false).Failed
+	if !retryAttemptFailfastEnabled() {
+		return false
+	}
+	if effectiveProcessRetryStatus(attempt, false).Failed {
+		return true
+	}
+	return slices.ContainsFunc(attempt.Result.Subtests, func(result processRetrySubtreeResult) bool {
+		return result.Failed
+	})
 }
 
 func runQuarantinedRaceInvocation(
@@ -1457,7 +1499,7 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 		appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation))
 	}
 	outcomes := make(map[familyKey]retryOutcomeAccumulator)
-	counted := make(map[string]struct{})
+	counted := make(map[quarantinedRaceReplayIdentity]*testIdentity)
 	for idx, event := range events {
 		prior := outcomes[event.family]
 		replayQuarantinedRaceEvent(testInfo, event.invocation, event.result, event.attemptOwner, lastOccurrence[event.family] == idx, prior, counted)
@@ -1466,9 +1508,9 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 			outcomes[event.family] = prior
 		}
 	}
-	module := session.GetOrCreateModule(testInfo.moduleName)
-	suite := module.GetOrCreateSuite(testInfo.suiteName)
-	for range counted {
+	for _, identity := range counted {
+		module := session.GetOrCreateModule(identity.ModuleName)
+		suite := module.GetOrCreateSuite(identity.SuiteName)
 		checkModuleAndSuite(module, suite)
 	}
 }
@@ -1497,19 +1539,27 @@ func replayQuarantinedRaceEvent(
 	attemptOwner string,
 	lastOccurrence bool,
 	prior retryOutcomeAccumulator,
-	counted map[string]struct{},
+	counted map[quarantinedRaceReplayIdentity]*testIdentity,
 ) {
-	identity := newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName)
-	if _, ok := counted[result.TestName]; !ok {
+	moduleName, suiteName := result.ModuleName, result.SuiteName
+	if moduleName == "" {
+		moduleName = testInfo.moduleName
+	}
+	if suiteName == "" {
+		suiteName = testInfo.suiteName
+	}
+	identity := newTestIdentity(moduleName, suiteName, result.TestName)
+	identityKey := quarantinedRaceReplayIdentity{moduleName: moduleName, suiteName: suiteName, testName: result.TestName}
+	if _, ok := counted[identityKey]; !ok {
 		// The parent already counted a top-level test before entering its
 		// wrapper. Subtests bypass the normal runSubtest path, so only they
 		// need a matching increment; every unique event still needs one
 		// matching checkModuleAndSuite call after replay.
 		if len(identity.Segments) > 1 {
-			addModulesCounters(testInfo.moduleName, 1)
-			addSuitesCounters(testInfo.suiteName, 1)
+			addModulesCounters(moduleName, 1)
+			addSuitesCounters(suiteName, 1)
 		}
-		counted[result.TestName] = struct{}{}
+		counted[identityKey] = identity
 	}
 	ownsAttemptToFix := attemptOwner == result.TestName
 	attemptIndex := invocation.attemptIndex
@@ -1554,8 +1604,8 @@ func replayQuarantinedRaceEvent(
 	}
 	attempt := processRetryAttemptFromSubtreeResult(result)
 	finishProcessRetryTestEvent(&commonInfo{
-		moduleName: testInfo.moduleName,
-		suiteName:  testInfo.suiteName,
+		moduleName: moduleName,
+		suiteName:  suiteName,
 		testName:   result.TestName,
 		identity:   identity,
 	}, execMeta, attempt, nil, nil)
@@ -1565,6 +1615,8 @@ func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *proce
 	directive, owner := cfg.resolveDirective(result.TestName)
 	return processRetrySubtreeResult{
 		TestName:        result.TestName,
+		ModuleName:      result.ModuleName,
+		SuiteName:       result.SuiteName,
 		Status:          normalizedProcessRetrySubtreeStatus(result.Status),
 		StartUnixNano:   result.StartUnixNano,
 		FinishUnixNano:  result.FinishUnixNano,
@@ -1573,6 +1625,7 @@ func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *proce
 		Skipped:         result.Skipped,
 		Panic:           result.Panic,
 		RaceDetected:    result.RaceDetected,
+		Parallel:        result.RootParallel,
 		Disabled:        directive.Disabled,
 		Quarantined:     directive.Quarantined,
 		AttemptToFix:    directive.AttemptToFix,
@@ -1627,6 +1680,8 @@ func processRetryResultFromSubtree(result processRetrySubtreeResult) processRetr
 	return processRetryResult{
 		Version:         1,
 		TestName:        result.TestName,
+		ModuleName:      result.ModuleName,
+		SuiteName:       result.SuiteName,
 		Status:          result.Status,
 		StartUnixNano:   result.StartUnixNano,
 		FinishUnixNano:  result.FinishUnixNano,
@@ -1635,6 +1690,7 @@ func processRetryResultFromSubtree(result processRetrySubtreeResult) processRetr
 		Skipped:         result.Skipped,
 		Panic:           result.Panic,
 		RaceDetected:    result.RaceDetected,
+		RootParallel:    result.Parallel,
 		ErrorType:       result.ErrorType,
 		ErrorMessage:    result.ErrorMessage,
 		ErrorStack:      result.ErrorStack,

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1229,6 +1229,9 @@ func continueQuarantinedRaceDescendantFamilies(
 	invocations *[]quarantinedRaceInvocation,
 ) (stop, failed bool) {
 	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
+		if retryAttemptFailfastEnabled() && result.Failed {
+			return true, false
+		}
 		continuationCfg, err := cfg.forSelectedRoot(result.TestName)
 		if err != nil {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1,0 +1,1143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/impactedtests"
+	"github.com/DataDog/dd-trace-go/v2/internal/locking"
+)
+
+const (
+	processRetrySubtreeVersion        = 1
+	processRetrySubtreeReason         = "quarantined_race"
+	processRetrySubtreeMaxDirectives  = 4 * 1024
+	processRetrySubtreeMaxResults     = 4 * 1024
+	processRetrySubtreeResultMaxBytes = 16 * 1024 * 1024
+	processRetrySubtreeOutputMaxBytes = 8 * 1024
+	processRetrySubtreeWireMaxBytes   = 16 * 1024 * 1024
+)
+
+func processRetryWireMaxBytes(subtree bool) int {
+	if subtree {
+		return processRetrySubtreeWireMaxBytes
+	}
+	return processRetryResultMaxBytes
+}
+
+// quarantinedRaceProcessContext is created only for the explicit process
+// backend. It is carried through test metadata so dynamically discovered
+// subtests can use the M-scoped launch snapshot without a package-global
+// scheduler.
+type quarantinedRaceProcessContext struct {
+	launchTemplate         *processRetryLaunchBaseline
+	mRunEpoch              uint64
+	invocations            *atomic.Uint64
+	attemptToFixRetries    int
+	collectPerTestCoverage bool
+	collectAggregate       bool
+}
+
+type processRetrySubtreeConfig struct {
+	Version              int                            `json:"version"`
+	SelectedRoot         string                         `json:"selected_root"`
+	Root                 processRetrySubtreeDirective   `json:"root"`
+	Directives           []processRetrySubtreeDirective `json:"directives,omitempty"`
+	ITR                  []processRetrySubtreeITR       `json:"itr,omitempty"`
+	AttemptToFixRetries  int                            `json:"attempt_to_fix_retries,omitempty"`
+	OwnsAttemptToFix     bool                           `json:"owns_attempt_to_fix,omitempty"`
+	AncestorAttemptToFix bool                           `json:"ancestor_attempt_to_fix,omitempty"`
+	CollectPerTest       bool                           `json:"collect_per_test_coverage,omitempty"`
+	CollectAggregate     bool                           `json:"collect_aggregate_coverage,omitempty"`
+	ITRCoverageActive    bool                           `json:"itr_coverage_active,omitempty"`
+	ImpactedTestsEnabled bool                           `json:"impacted_tests_enabled,omitempty"`
+}
+
+type processRetrySubtreeDirective struct {
+	TestName     string `json:"test_name"`
+	Disabled     bool   `json:"disabled,omitempty"`
+	Quarantined  bool   `json:"quarantined,omitempty"`
+	AttemptToFix bool   `json:"attempt_to_fix,omitempty"`
+	Modified     bool   `json:"modified,omitempty"`
+}
+
+type processRetrySubtreeITR struct {
+	TestName                string `json:"test_name"`
+	MissingLineCodeCoverage bool   `json:"missing_line_code_coverage,omitempty"`
+}
+
+type processRetryTestSource struct {
+	RuntimePath      string `json:"runtime_path,omitempty"`
+	RuntimeStartLine int    `json:"runtime_start_line,omitempty"`
+	RuntimeEndLine   int    `json:"runtime_end_line,omitempty"`
+	Unskippable      bool   `json:"unskippable,omitempty"`
+}
+
+// processRetrySubtreeResult is the event-shaped payload returned for every
+// descendant of the selected root. The envelope fields in processRetryResult
+// use the same status contract for the root itself.
+type processRetrySubtreeResult struct {
+	TestName        string                             `json:"test_name"`
+	Status          processRetryStatus                 `json:"status"`
+	StartUnixNano   int64                              `json:"start_unix_nano"`
+	FinishUnixNano  int64                              `json:"finish_unix_nano"`
+	DurationNanos   int64                              `json:"duration_nanos"`
+	Failed          bool                               `json:"failed"`
+	Skipped         bool                               `json:"skipped"`
+	Panic           bool                               `json:"panic"`
+	RaceDetected    bool                               `json:"race_detected,omitempty"`
+	Disabled        bool                               `json:"disabled,omitempty"`
+	Quarantined     bool                               `json:"quarantined,omitempty"`
+	AttemptToFix    bool                               `json:"attempt_to_fix,omitempty"`
+	AttemptToFixOwn bool                               `json:"attempt_to_fix_owner,omitempty"`
+	SkippedByITR    bool                               `json:"skipped_by_itr,omitempty"`
+	ITRForcedRun    bool                               `json:"itr_forced_run,omitempty"`
+	Modified        bool                               `json:"modified,omitempty"`
+	ErrorType       string                             `json:"error_type,omitempty"`
+	ErrorMessage    string                             `json:"error_message,omitempty"`
+	ErrorStack      string                             `json:"error_stack,omitempty"`
+	SkipReason      string                             `json:"skip_reason,omitempty"`
+	OutputTail      string                             `json:"output_tail,omitempty"`
+	OutputTruncated bool                               `json:"output_truncated,omitempty"`
+	Source          *processRetryTestSource            `json:"source,omitempty"`
+	Coverage        []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
+	order           uint64
+}
+
+func newQuarantinedRaceProcessContext(
+	launchTemplate *processRetryLaunchBaseline,
+	mRunEpoch uint64,
+	invocations *atomic.Uint64,
+	attemptToFixRetries int,
+) *quarantinedRaceProcessContext {
+	if invocations == nil {
+		return nil
+	}
+	return &quarantinedRaceProcessContext{
+		launchTemplate:         launchTemplate,
+		mRunEpoch:              mRunEpoch,
+		invocations:            invocations,
+		attemptToFixRetries:    max(attemptToFixRetries, 0),
+		collectPerTestCoverage: coverage.CanCollectPerTestCoverage(),
+		collectAggregate:       coverage.CanComputeCoverageProfile(),
+	}
+}
+
+func buildProcessRetrySubtreeConfig(
+	ctx *quarantinedRaceProcessContext,
+	testInfo *commonInfo,
+	execMeta *testExecutionMetadata,
+	parentExecMeta *testExecutionMetadata,
+) (*processRetrySubtreeConfig, error) {
+	if ctx == nil || testInfo == nil || execMeta == nil || execMeta.identity == nil {
+		return nil, errors.New("missing quarantined race process context")
+	}
+	identity := execMeta.identity
+	cfg := &processRetrySubtreeConfig{
+		Version:             processRetrySubtreeVersion,
+		SelectedRoot:        identity.FullName,
+		Root:                processRetryDirectiveFromMetadata(identity.FullName, execMeta),
+		AttemptToFixRetries: ctx.attemptToFixRetries,
+		OwnsAttemptToFix:    execMeta.isAttemptToFix && execMeta.shouldOrchestrateAttemptToFix,
+		CollectPerTest:      ctx.collectPerTestCoverage,
+		CollectAggregate:    ctx.collectAggregate,
+	}
+	if settings := integrations.GetSettings(); settings != nil {
+		cfg.ImpactedTestsEnabled = settings.ImpactedTestsEnabled
+		if cfg.ImpactedTestsEnabled {
+			cfg.Root.Modified = cfg.Root.Modified || integrations.IsTestFuncModified(testInfo.testName, testInfo.sourceFunc)
+		}
+	}
+	if parentExecMeta != nil && parentExecMeta.isAttemptToFix {
+		cfg.AncestorAttemptToFix = true
+	}
+
+	if data := integrations.GetTestManagementTestsData(); data != nil {
+		if module, ok := data.Modules[identity.ModuleName]; ok {
+			if suite, ok := module.Suites[identity.SuiteName]; ok {
+				for name, properties := range suite.Tests {
+					if strings.HasPrefix(name, cfg.SelectedRoot+"/") {
+						cfg.Directives = append(cfg.Directives, processRetrySubtreeDirective{
+							TestName:     name,
+							Disabled:     properties.Properties.Disabled,
+							Quarantined:  properties.Properties.Quarantined,
+							AttemptToFix: properties.Properties.AttemptToFix,
+						})
+					}
+				}
+			}
+		}
+	}
+	slices.SortFunc(cfg.Directives, func(a, b processRetrySubtreeDirective) int {
+		return strings.Compare(a.TestName, b.TestName)
+	})
+
+	itr := currentITRState()
+	if itr != nil {
+		cfg.ITRCoverageActive = itr.coverageActive
+		if itr.response != nil {
+			if tests, ok := itr.response.Skippables[identity.SuiteName]; ok {
+				for name, candidates := range tests {
+					if name != cfg.SelectedRoot && !strings.HasPrefix(name, cfg.SelectedRoot+"/") {
+						continue
+					}
+					entry := processRetrySubtreeITR{TestName: name}
+					matched := false
+					for _, candidate := range candidates {
+						if strings.TrimSpace(candidate.Parameters) != "" {
+							continue
+						}
+						matched = true
+						entry.MissingLineCodeCoverage = entry.MissingLineCodeCoverage || candidate.MissingLineCodeCoverage
+					}
+					if matched {
+						cfg.ITR = append(cfg.ITR, entry)
+					}
+				}
+			}
+		}
+	}
+	slices.SortFunc(cfg.ITR, func(a, b processRetrySubtreeITR) int {
+		return strings.Compare(a.TestName, b.TestName)
+	})
+	if err := validateProcessRetrySubtreeConfig(cfg, cfg.SelectedRoot); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func processRetryDirectiveFromMetadata(name string, meta *testExecutionMetadata) processRetrySubtreeDirective {
+	if meta == nil {
+		return processRetrySubtreeDirective{TestName: name}
+	}
+	return processRetrySubtreeDirective{
+		TestName:     name,
+		Disabled:     meta.isDisabled,
+		Quarantined:  meta.isQuarantined,
+		AttemptToFix: meta.isAttemptToFix,
+		Modified:     meta.isAModifiedTest,
+	}
+}
+
+func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedRoot string) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Version != processRetrySubtreeVersion || cfg.SelectedRoot != selectedRoot ||
+		strings.TrimSpace(cfg.SelectedRoot) == "" || cfg.Root.TestName != cfg.SelectedRoot ||
+		!cfg.Root.Quarantined || cfg.AttemptToFixRetries < 0 ||
+		len(cfg.Directives) > processRetrySubtreeMaxDirectives || len(cfg.ITR) > processRetrySubtreeMaxDirectives {
+		return errors.New("invalid process retry subtree configuration")
+	}
+	if cfg.OwnsAttemptToFix && !cfg.Root.AttemptToFix || cfg.AncestorAttemptToFix && cfg.OwnsAttemptToFix {
+		return errors.New("invalid process retry subtree attempt ownership")
+	}
+	previous := ""
+	for _, directive := range cfg.Directives {
+		if directive.TestName == cfg.SelectedRoot || !processRetryNameWithinRoot(directive.TestName, cfg.SelectedRoot) || directive.TestName <= previous {
+			return errors.New("invalid process retry subtree directive")
+		}
+		previous = directive.TestName
+	}
+	previous = ""
+	for _, candidate := range cfg.ITR {
+		if !processRetryNameWithinRoot(candidate.TestName, cfg.SelectedRoot) || candidate.TestName <= previous {
+			return errors.New("invalid process retry subtree ITR directive")
+		}
+		previous = candidate.TestName
+	}
+	return nil
+}
+
+func processRetryNameWithinRoot(name, root string) bool {
+	return name == root || strings.HasPrefix(name, root+"/")
+}
+
+func processRetryExactRunPattern(fullName string) string {
+	segments := strings.Split(fullName, "/")
+	for idx := range segments {
+		segments[idx] = "^" + regexp.QuoteMeta(segments[idx]) + "$"
+	}
+	return strings.Join(segments, "/")
+}
+
+func (cfg *processRetrySubtreeConfig) exactDirective(name string) (processRetrySubtreeDirective, bool) {
+	idx, ok := slices.BinarySearchFunc(cfg.Directives, name, func(d processRetrySubtreeDirective, name string) int {
+		return strings.Compare(d.TestName, name)
+	})
+	if !ok {
+		return processRetrySubtreeDirective{}, false
+	}
+	return cfg.Directives[idx], true
+}
+
+func (cfg *processRetrySubtreeConfig) resolveDirective(name string) (processRetrySubtreeDirective, string) {
+	resolved := cfg.Root
+	resolved.TestName = name
+	attemptOwner := ""
+	if cfg.OwnsAttemptToFix {
+		attemptOwner = cfg.SelectedRoot
+	}
+	if name == cfg.SelectedRoot {
+		return resolved, attemptOwner
+	}
+	rootParts := strings.Split(cfg.SelectedRoot, "/")
+	parts := strings.Split(name, "/")
+	for idx := len(rootParts) + 1; idx <= len(parts); idx++ {
+		candidate := strings.Join(parts[:idx], "/")
+		exact, ok := cfg.exactDirective(candidate)
+		if !ok {
+			continue
+		}
+		resolved.Disabled = resolved.Disabled || exact.Disabled
+		resolved.Quarantined = resolved.Quarantined || exact.Quarantined
+		if exact.AttemptToFix {
+			if !resolved.AttemptToFix {
+				attemptOwner = candidate
+			}
+			resolved.AttemptToFix = true
+		} else {
+			resolved.AttemptToFix = false
+			attemptOwner = ""
+		}
+	}
+	return resolved, attemptOwner
+}
+
+func (cfg *processRetrySubtreeConfig) itrDecision(name string, meta processRetrySubtreeDirective, sourceFunc *runtime.Func) (skip, forced bool) {
+	idx, ok := slices.BinarySearchFunc(cfg.ITR, name, func(candidate processRetrySubtreeITR, name string) int {
+		return strings.Compare(candidate.TestName, name)
+	})
+	if !ok || meta.AttemptToFix {
+		return false, false
+	}
+	_, _, unskippable := integrations.TestFuncSourceMetadata(sourceFunc)
+	if unskippable {
+		return false, true
+	}
+	if cfg.ITRCoverageActive && cfg.ITR[idx].MissingLineCodeCoverage {
+		return false, false
+	}
+	return true, false
+}
+
+func processRetrySourceFromFunc(fn *runtime.Func) *processRetryTestSource {
+	if fn == nil {
+		return nil
+	}
+	path, line := fn.FileLine(fn.Entry())
+	if path == "" || line <= 0 {
+		return nil
+	}
+	startLine, endLine, unskippable := integrations.TestFuncSourceMetadata(fn)
+	if startLine <= 0 {
+		startLine = line
+	}
+	return &processRetryTestSource{
+		RuntimePath: path, RuntimeStartLine: startLine, RuntimeEndLine: endLine,
+		Unskippable: unskippable,
+	}
+}
+
+func truncateProcessRetrySubtreeOutput(output []byte) (string, bool) {
+	if len(output) <= processRetrySubtreeOutputMaxBytes {
+		return strings.ToValidUTF8(string(output), "\uFFFD"), false
+	}
+	tail := output[len(output)-processRetrySubtreeOutputMaxBytes:]
+	return strings.ToValidUTF8(string(tail), "\uFFFD"), true
+}
+
+type quarantinedRaceChildState struct {
+	cfg      *processRetrySubtreeConfig
+	mu       locking.Mutex
+	next     atomic.Uint64
+	results  []processRetrySubtreeResult
+	impacted *impactedtests.ImpactedTestAnalyzer
+}
+
+func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRaceChildState {
+	state := &quarantinedRaceChildState{cfg: cfg}
+	if cfg != nil && cfg.ImpactedTestsEnabled {
+		state.impacted, _ = impactedtests.NewImpactedTestAnalyzer()
+	}
+	return state
+}
+
+func (s *quarantinedRaceChildState) begin() (uint64, time.Time, int64) {
+	return s.next.Add(1), time.Now(), retryAttemptRaceErrors()
+}
+
+func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.results = append(s.results, result)
+	s.mu.Unlock()
+}
+
+func (s *quarantinedRaceChildState) snapshot() []processRetrySubtreeResult {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	results := append([]processRetrySubtreeResult(nil), s.results...)
+	s.mu.Unlock()
+	slices.SortFunc(results, func(a, b processRetrySubtreeResult) int {
+		return cmp.Compare(a.order, b.order)
+	})
+	for idx := range results {
+		results[idx].order = 0
+	}
+	return results
+}
+
+func processRetrySubtreeCoveragePath(resultPath string) string {
+	return resultPath + ".coverage.out"
+}
+
+func (o *processRetryChildObservation) buildSubtreeResult(result processRetryResult, controlled processRetryStatus) processRetryResult {
+	if o.aggregateErr != nil {
+		return processRetryNotRunResult(o.cfg, "coverage_finalization_failed")
+	}
+	if o.aggregate != nil {
+		if err := o.aggregate.WriteDelta(processRetrySubtreeCoveragePath(o.cfg.ResultPath)); err != nil {
+			return processRetryNotRunResult(o.cfg, "coverage_finalization_failed")
+		}
+	}
+	results := o.subtree.snapshot()
+	topLevelName, _ := topLevelTestName(o.cfg.TestName)
+	if o.cfg.Subtree.SelectedRoot == topLevelName {
+		result.Source = o.source
+		result.SkippedByITR = o.execMeta.isItrSkipped
+		result.ITRForcedRun = o.execMeta.isItrForcedRun
+		result.Modified = o.execMeta.isAModifiedTest
+		if o.coverage != nil {
+			result.Coverage = o.coverage.Finish()
+		}
+		result.Subtests = results
+		result.OutputTail, result.OutputTruncated = truncateProcessRetrySubtreeOutput(o.result.output)
+		applyProcessRetryControlledSubtreeStatus(&result, controlled)
+		return result
+	}
+	rootIndex := -1
+	for idx := range results {
+		if results[idx].TestName == o.cfg.Subtree.SelectedRoot {
+			rootIndex = idx
+			break
+		}
+	}
+	if rootIndex < 0 {
+		return processRetryNotRunResult(o.cfg, "selected_root_not_run")
+	}
+	root := results[rootIndex]
+	result.Status = root.Status
+	result.StartUnixNano = root.StartUnixNano
+	result.FinishUnixNano = root.FinishUnixNano
+	result.DurationNanos = root.DurationNanos
+	result.Failed = root.Failed
+	result.Skipped = root.Skipped
+	result.Panic = root.Panic
+	result.RaceDetected = root.RaceDetected
+	result.ErrorType = root.ErrorType
+	result.ErrorMessage = root.ErrorMessage
+	result.ErrorStack = root.ErrorStack
+	result.SkipReason = root.SkipReason
+	result.OutputTail = root.OutputTail
+	result.OutputTruncated = root.OutputTruncated
+	result.Source = root.Source
+	result.Coverage = root.Coverage
+	result.Subtests = append(results[:rootIndex:rootIndex], results[rootIndex+1:]...)
+	applyProcessRetryControlledSubtreeStatus(&result, controlled)
+	return result
+}
+
+func applyProcessRetryControlledSubtreeStatus(result *processRetryResult, controlled processRetryStatus) {
+	if result == nil || controlled == "" {
+		return
+	}
+	result.Status = controlled
+	result.Failed = true
+	result.Panic = true
+	result.Skipped = false
+	result.SkipReason = ""
+}
+
+func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), parent *testExecutionMetadata) {
+	state := parent.quarantinedRaceChild
+	if state == nil || state.cfg == nil {
+		original(t)
+		return
+	}
+	name := t.Name()
+	execMeta := createTestMetadata(t, nil)
+	execMeta.test = parent.test
+	execMeta.processRetryOwner = parent
+	execMeta.quarantinedRaceChild = state
+	if !processRetryNameWithinRoot(name, state.cfg.SelectedRoot) {
+		defer deleteTestMetadata(t)
+		original(t)
+		return
+	}
+
+	directive, attemptOwner := state.cfg.resolveDirective(name)
+	execMeta.identity = newTestIdentity("", "", name)
+	execMeta.isDisabled = directive.Disabled
+	execMeta.isQuarantined = directive.Quarantined
+	execMeta.isAttemptToFix = directive.AttemptToFix
+	execMeta.isItrForcedRun = false
+	execMeta.hasExplicitDisabled = true
+	execMeta.hasExplicitQuarantined = true
+	execMeta.hasExplicitAttemptToFix = true
+	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
+
+	sourceFunc := runtime.FuncForPC(reflect.ValueOf(original).Pointer())
+	source := processRetrySourceFromFunc(sourceFunc)
+	order, start, raceBaseline := state.begin()
+	restoreChatty := bufferQuarantinedRaceChildOutput(t)
+	var collector *coverage.ProcessTestCoverage
+	var parentBarrier *chan bool
+	var oldParentBarrier chan bool
+	if state.cfg.CollectPerTest && source != nil && coverage.CanCollect() {
+		// Runtime coverage counters are global. Clearing the parent barrier keeps
+		// covered bodies serial, so each event owns a deterministic delta. The
+		// intentional ancestor/descendant overlap represents their logical scopes.
+		if fields := getTestParentPrivateFields(t); fields != nil && fields.barrier != nil {
+			parentBarrier = fields.barrier
+			oldParentBarrier = *parentBarrier
+			*parentBarrier = nil
+		}
+		collector = coverage.BeginProcessTestCoverage(source.RuntimePath)
+	}
+
+	t.Cleanup(func() {
+		files := collector.Finish()
+		if parentBarrier != nil {
+			*parentBarrier = oldParentBarrier
+		}
+		restoreChatty()
+		finish := time.Now()
+		result := processRetrySubtreeResult{
+			TestName:        name,
+			StartUnixNano:   start.UnixNano(),
+			FinishUnixNano:  finish.UnixNano(),
+			DurationNanos:   finish.UnixNano() - start.UnixNano(),
+			Failed:          t.Failed(),
+			Skipped:         t.Skipped(),
+			RaceDetected:    retryAttemptRaceErrors() > raceBaseline,
+			Disabled:        directive.Disabled,
+			Quarantined:     directive.Quarantined,
+			AttemptToFix:    directive.AttemptToFix,
+			AttemptToFixOwn: attemptOwner == name,
+			ITRForcedRun:    execMeta.isItrForcedRun,
+			SkippedByITR:    execMeta.isItrSkipped,
+			Modified:        integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc),
+			Source:          source,
+			Coverage:        files,
+			order:           order,
+		}
+		if fields := getTestPrivateFields(t); fields != nil {
+			result.OutputTail, result.OutputTruncated = truncateProcessRetrySubtreeOutput(fields.GetOutput())
+		}
+		if panicInfo := execMeta.processRetryPanic.Load(); panicInfo != nil {
+			result.Panic = true
+			result.ErrorType = panicInfo.Type
+			result.ErrorMessage = panicInfo.Message
+			result.ErrorStack = panicInfo.Stack
+		} else if errorInfo := execMeta.processRetryError.Load(); errorInfo != nil {
+			result.ErrorType = errorInfo.Type
+			result.ErrorMessage = errorInfo.Message
+			result.ErrorStack = errorInfo.Stack
+		}
+		if skipReason := execMeta.processRetrySkipReason.Load(); skipReason != nil && result.Skipped && !result.Failed {
+			result.SkipReason = *skipReason
+		}
+		if result.RaceDetected || result.Panic {
+			result.Failed = true
+		}
+		switch {
+		case result.Failed:
+			result.Status = processRetryStatusFail
+			result.Skipped = false
+			result.SkipReason = ""
+		case result.Skipped:
+			result.Status = processRetryStatusSkip
+		default:
+			result.Status = processRetryStatusPass
+		}
+		state.append(result)
+		deleteTestMetadata(t)
+	})
+
+	if directive.Disabled && !directive.AttemptToFix {
+		reason := constants.TestDisabledSkipReason
+		execMeta.processRetrySkipReason.Store(&reason)
+		t.SkipNow()
+	}
+	if skip, forced := state.cfg.itrDecision(name, directive, sourceFunc); skip {
+		execMeta.isItrSkipped = true
+		reason := constants.SkippedByITRReason
+		execMeta.processRetrySkipReason.Store(&reason)
+		t.SkipNow()
+	} else {
+		execMeta.isItrForcedRun = forced
+	}
+
+	bodyReturned := false
+	defer func() {
+		panicData := recover()
+		unexpected := panicData == nil && processRetryUnexpectedTestTermination(t, bodyReturned)
+		if panicData == nil && !unexpected {
+			return
+		}
+		if panicData == nil {
+			panicData = unexpectedTestTerminationMessage
+		}
+		execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
+			Type:    "panic",
+			Message: truncateProcessRetryErrorMessage(toString(panicData)),
+			Stack:   truncateProcessRetryErrorStack(utils.GetStacktrace(1)),
+		})
+		if !unexpected {
+			panic(panicData)
+		}
+	}()
+	original(t)
+	bodyReturned = true
+}
+
+func bufferQuarantinedRaceChildOutput(t *testing.T) func() {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || layout.disabled || !layout.chattyOK {
+		return func() {}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return func() {}
+	}
+	mu := fieldPtr[sync.RWMutex](base, layout.common.mu)
+	mu.Lock()
+	chatty := pointerWord(base, layout.common.chatty)
+	if chatty != nil {
+		setPrivatePointerField(layout.common.chatty.typ, fieldRawPtr(base, layout.common.chatty.unsafeField), nil)
+	}
+	mu.Unlock()
+	return func() {
+		if chatty == nil {
+			return
+		}
+		mu.Lock()
+		setPrivatePointerField(layout.common.chatty.typ, fieldRawPtr(base, layout.common.chatty.unsafeField), chatty)
+		mu.Unlock()
+		runtime.KeepAlive(t)
+	}
+}
+
+func validateProcessRetrySubtreeResultEnvelope(result processRetryResult, expected processRetryChildConfig) error {
+	if expected.Subtree == nil {
+		if result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 ||
+			result.SkippedByITR || result.ITRForcedRun || result.Modified {
+			return fmt.Errorf("%w: unexpected subtree data", errProcessRetryResultInvalid)
+		}
+		return nil
+	}
+	if result.Status == processRetryStatusNotRun {
+		return nil
+	}
+	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
+		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
+		return fmt.Errorf("%w: invalid subtree root timing (%d,%d,%d)", errProcessRetryResultInvalid, result.StartUnixNano, result.FinishUnixNano, result.DurationNanos)
+	}
+	if result.OutputTruncated && result.OutputTail == "" {
+		return fmt.Errorf("%w: invalid subtree root output", errProcessRetryResultInvalid)
+	}
+	if result.SkippedByITR && (result.ITRForcedRun || result.Status != processRetryStatusSkip || result.SkipReason != constants.SkippedByITRReason) {
+		return fmt.Errorf("%w: invalid subtree root ITR mirrors", errProcessRetryResultInvalid)
+	}
+	if err := validateProcessRetryTestSource(result.Source); err != nil {
+		return err
+	}
+	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
+		return err
+	}
+	if len(result.Subtests) > processRetrySubtreeMaxResults {
+		return fmt.Errorf("%w: too many subtree results", errProcessRetryResultInvalid)
+	}
+	seen := make(map[string]struct{}, len(result.Subtests))
+	for _, subtest := range result.Subtests {
+		if subtest.TestName == expected.Subtree.SelectedRoot || !processRetryNameWithinRoot(subtest.TestName, expected.Subtree.SelectedRoot) {
+			return fmt.Errorf("%w: subtree identity outside selected root", errProcessRetryResultInvalid)
+		}
+		if _, duplicate := seen[subtest.TestName]; duplicate {
+			return fmt.Errorf("%w: duplicate subtree result", errProcessRetryResultInvalid)
+		}
+		seen[subtest.TestName] = struct{}{}
+		if err := validateProcessRetrySubtreeResult(subtest, expected.Subtree); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProcessRetrySubtreeResult(result processRetrySubtreeResult, cfg *processRetrySubtreeConfig) error {
+	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
+		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
+		return fmt.Errorf("%w: invalid subtree timing", errProcessRetryResultInvalid)
+	}
+	if !processRetryJSONStringFits(result.ErrorType, processRetryErrorTypeMaxBytes) ||
+		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
+		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
+		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) ||
+		!processRetryJSONStringFits(result.OutputTail, processRetrySubtreeOutputMaxBytes) {
+		return fmt.Errorf("%w: subtree metadata field too large", errProcessRetryResultInvalid)
+	}
+	if result.OutputTruncated && result.OutputTail == "" {
+		return fmt.Errorf("%w: invalid subtree output", errProcessRetryResultInvalid)
+	}
+	if err := validateProcessRetryTestSource(result.Source); err != nil {
+		return err
+	}
+	if err := validateProcessRetryCoverageFiles(result.Coverage); err != nil {
+		return err
+	}
+	directive, owner := cfg.resolveDirective(result.TestName)
+	if result.Disabled != directive.Disabled || result.Quarantined != directive.Quarantined ||
+		result.AttemptToFix != directive.AttemptToFix || result.AttemptToFixOwn != (owner == result.TestName) {
+		return fmt.Errorf("%w: subtree directive mismatch", errProcessRetryResultInvalid)
+	}
+	if result.SkippedByITR && (result.ITRForcedRun || result.Status != processRetryStatusSkip || result.SkipReason != constants.SkippedByITRReason) {
+		return fmt.Errorf("%w: invalid subtree ITR mirrors", errProcessRetryResultInvalid)
+	}
+	switch result.Status {
+	case processRetryStatusPass, processRetryStatusSkip:
+	case processRetryStatusFail:
+		if result.Skipped {
+			return fmt.Errorf("%w: invalid subtree fail mirrors", errProcessRetryResultInvalid)
+		}
+	default:
+		return fmt.Errorf("%w: invalid subtree status", errProcessRetryResultInvalid)
+	}
+	return validateProcessRetryResultStatus(processRetryResultFromSubtree(result))
+}
+
+func validateProcessRetryTestSource(source *processRetryTestSource) error {
+	if source == nil {
+		return nil
+	}
+	if source.RuntimePath == "" || source.RuntimeStartLine <= 0 || source.RuntimeEndLine < 0 ||
+		source.RuntimeEndLine > 0 && source.RuntimeEndLine < source.RuntimeStartLine ||
+		!processRetryJSONStringFits(source.RuntimePath, processRetryErrorMessageMaxBytes) {
+		return fmt.Errorf("%w: invalid subtree source", errProcessRetryResultInvalid)
+	}
+	return nil
+}
+
+func validateProcessRetryCoverageFiles(files []coverage.ProcessTestCoverageFile) error {
+	if len(files) > processRetrySubtreeMaxResults {
+		return fmt.Errorf("%w: too many process coverage files", errProcessRetryResultInvalid)
+	}
+	for _, file := range files {
+		if strings.TrimSpace(file.Name) == "" || !processRetryJSONStringFits(file.Name, processRetryErrorMessageMaxBytes) {
+			return fmt.Errorf("%w: invalid process coverage file", errProcessRetryResultInvalid)
+		}
+	}
+	return nil
+}
+
+type quarantinedRaceInvocation struct {
+	cfg          *processRetrySubtreeConfig
+	attempt      processRetryAttemptResult
+	attemptIndex int
+}
+
+// runQuarantinedRaceProcessIsolation replaces only the selected quarantined
+// root. For TestCheckout/card, the parent may still run TestCheckout/paypal,
+// while one child runs card and every descendant beneath it. The parent owns
+// retries and CI Visibility events; the child owns no session or transport.
+func runQuarantinedRaceProcessIsolation(
+	t *testing.T,
+	testInfo *commonInfo,
+	parentExecMeta *testExecutionMetadata,
+	featureMeta *additionalFeatureMetadata,
+	processCtx *quarantinedRaceProcessContext,
+) {
+	t.Helper()
+	execMeta := getTestMetadata(t)
+	createdMetadata := false
+	if execMeta == nil {
+		execMeta = createTestMetadata(t, nil)
+		createdMetadata = true
+	}
+	if createdMetadata {
+		defer deleteTestMetadata(t)
+	}
+	applyAdditionalFeatureMetadataToExecution(execMeta, featureMeta)
+	propagateTestExecutionMetadataFlags(execMeta, parentExecMeta)
+	execMeta.quarantinedRaceProcess = processCtx
+	execMeta.hasAdditionalFeatureWrapper = true
+
+	cfg, err := buildProcessRetrySubtreeConfig(processCtx, testInfo, execMeta, parentExecMeta)
+	if err != nil {
+		failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
+		return
+	}
+	lease, err := acquireProcessRetryGroupLease()
+	if err != nil {
+		failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
+		return
+	}
+	defer lease.release()
+
+	rootTotal := 1
+	if cfg.OwnsAttemptToFix {
+		rootTotal += cfg.AttemptToFixRetries
+	}
+	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
+	for idx := 0; idx < rootTotal; idx++ {
+		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx)
+		if processRetryInfrastructureFailure(attempt) {
+			failQuarantinedRaceIsolation(t, testInfo, execMeta, attempt)
+			return
+		}
+		invocations = append(invocations, quarantinedRaceInvocation{
+			cfg: cfg, attempt: attempt, attemptIndex: idx,
+		})
+	}
+
+	if !cfg.OwnsAttemptToFix && cfg.AttemptToFixRetries > 0 {
+		for _, result := range invocations[0].attempt.Result.Subtests {
+			if !result.AttemptToFixOwn {
+				continue
+			}
+			continuationCfg, cfgErr := cfg.forSelectedRoot(result.TestName)
+			if cfgErr != nil {
+				failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: cfgErr, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
+				return
+			}
+			for idx := 1; idx <= cfg.AttemptToFixRetries; idx++ {
+				attempt := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx)
+				if processRetryInfrastructureFailure(attempt) {
+					failQuarantinedRaceIsolation(t, &commonInfo{
+						moduleName: testInfo.moduleName,
+						suiteName:  testInfo.suiteName,
+						testName:   result.TestName,
+						identity:   newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName),
+					}, execMeta, attempt)
+					return
+				}
+				invocations = append(invocations, quarantinedRaceInvocation{
+					cfg: continuationCfg, attempt: attempt, attemptIndex: idx,
+				})
+			}
+		}
+	}
+
+	replayQuarantinedRaceInvocations(testInfo, invocations)
+	// A valid quarantined failure, panic, or race remains visible in CI
+	// Visibility but is intentionally masked from the package result. An
+	// infrastructure error returns above through Fail and is never quarantined.
+	t.SkipNow()
+}
+
+func runQuarantinedRaceInvocation(
+	t *testing.T,
+	processCtx *quarantinedRaceProcessContext,
+	lease *processRetryGroupLease,
+	cfg *processRetrySubtreeConfig,
+	attemptIndex int,
+) processRetryAttemptResult {
+	deadline, deadlineOK := t.Deadline()
+	baseline := captureProcessRetryLaunchBaselineFromTemplate(processCtx.launchTemplate)
+	// The parent already admitted this root. Replacing only this invocation's
+	// selector lets the child re-enter required ancestors without executing a
+	// sibling that happened to match the user's broader -run expression.
+	baseline.argsSnapshot.runSelector = processRetryExactRunPattern(cfg.SelectedRoot)
+	attempt := runProcessRetryAttemptWithBaselineAndShutdown(
+		context.Background(),
+		processRetryChildConfig{
+			TestName:          cfg.SelectedRoot,
+			Attempt:           attemptIndex + 1,
+			RetryReason:       processRetrySubtreeReason,
+			MRunEpoch:         processCtx.mRunEpoch,
+			InvocationOrdinal: processCtx.invocations.Add(1),
+			Subtree:           cfg,
+		},
+		deadline,
+		deadlineOK,
+		baseline,
+		lease.shutdown,
+	)
+	defer func() {
+		if attempt.Cleanup != nil {
+			attempt.Cleanup()
+		}
+	}()
+	if cfg.CollectAggregate && attempt.Result.Status != "" && attempt.Result.Status != processRetryStatusNotRun {
+		if err := coverage.MergeProcessCoverageProfile(processRetrySubtreeCoveragePath(filepath.Join(attempt.TempDir, "result.json"))); err != nil {
+			attempt.Err = errors.Join(attempt.Err, fmt.Errorf("aggregate process coverage: %w", err))
+		}
+	}
+	if attempt.Result.OutputTail != "" {
+		attempt.OutputTail = attempt.Result.OutputTail
+		attempt.OutputTruncated = attempt.Result.OutputTruncated
+	}
+	return attempt
+}
+
+func processRetryInfrastructureFailure(attempt processRetryAttemptResult) bool {
+	effective := effectiveProcessRetryStatus(attempt, false)
+	if !effective.Failed {
+		return false
+	}
+	switch effective.FailureKind {
+	case "test_fail", "test_panic", "test_race":
+		return false
+	default:
+		return true
+	}
+}
+
+func failQuarantinedRaceIsolation(t *testing.T, testInfo *commonInfo, execMeta *testExecutionMetadata, attempt processRetryAttemptResult) {
+	if attempt.StartTime.IsZero() {
+		attempt.StartTime = time.Now()
+	}
+	if attempt.FinishTime.IsZero() {
+		attempt.FinishTime = attempt.StartTime
+	}
+	execMeta.retryContinuationDecided = true
+	execMeta.retryContinuationAdmitted = false
+	effective := effectiveProcessRetryStatus(attempt, false)
+	t.Logf("CI Visibility quarantined test isolation failed: %s: %v", effective.FailureKind, attempt.Err)
+	if attempt.OutputTail != "" {
+		t.Log(attempt.OutputTail)
+	}
+	if len(testInfo.identity.Segments) > 1 {
+		addModulesCounters(testInfo.moduleName, 1)
+		addSuitesCounters(testInfo.suiteName, 1)
+	}
+	finishProcessRetryTestEvent(testInfo, execMeta, attempt, nil, nil)
+	module := session.GetOrCreateModule(testInfo.moduleName)
+	suite := module.GetOrCreateSuite(testInfo.suiteName)
+	checkModuleAndSuite(module, suite)
+	t.Fail()
+}
+
+func (cfg *processRetrySubtreeConfig) forSelectedRoot(name string) (*processRetrySubtreeConfig, error) {
+	directive, _ := cfg.resolveDirective(name)
+	next := &processRetrySubtreeConfig{
+		Version:              processRetrySubtreeVersion,
+		SelectedRoot:         name,
+		Root:                 directive,
+		AttemptToFixRetries:  cfg.AttemptToFixRetries,
+		OwnsAttemptToFix:     directive.AttemptToFix,
+		CollectPerTest:       cfg.CollectPerTest,
+		CollectAggregate:     cfg.CollectAggregate,
+		ITRCoverageActive:    cfg.ITRCoverageActive,
+		ImpactedTestsEnabled: cfg.ImpactedTestsEnabled,
+	}
+	for _, candidate := range cfg.Directives {
+		if candidate.TestName != name && processRetryNameWithinRoot(candidate.TestName, name) {
+			next.Directives = append(next.Directives, candidate)
+		}
+	}
+	for _, candidate := range cfg.ITR {
+		if processRetryNameWithinRoot(candidate.TestName, name) {
+			next.ITR = append(next.ITR, candidate)
+		}
+	}
+	return next, validateProcessRetrySubtreeConfig(next, name)
+}
+
+func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quarantinedRaceInvocation) {
+	if testInfo == nil {
+		return
+	}
+	outcomes := make(map[string]retryOutcomeAccumulator)
+	counted := make(map[string]struct{})
+	for _, invocation := range invocations {
+		for _, result := range invocation.attempt.Result.Subtests {
+			replayQuarantinedRaceEvent(testInfo, invocation, result, outcomes, counted)
+		}
+		root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
+		replayQuarantinedRaceEvent(testInfo, invocation, root, outcomes, counted)
+	}
+	module := session.GetOrCreateModule(testInfo.moduleName)
+	suite := module.GetOrCreateSuite(testInfo.suiteName)
+	for range counted {
+		checkModuleAndSuite(module, suite)
+	}
+}
+
+func replayQuarantinedRaceEvent(
+	testInfo *commonInfo,
+	invocation quarantinedRaceInvocation,
+	result processRetrySubtreeResult,
+	outcomes map[string]retryOutcomeAccumulator,
+	counted map[string]struct{},
+) {
+	identity := newTestIdentity(testInfo.moduleName, testInfo.suiteName, result.TestName)
+	if _, ok := counted[result.TestName]; !ok {
+		// The parent already counted a top-level test before entering its
+		// wrapper. Subtests bypass the normal runSubtest path, so only they
+		// need a matching increment; every unique event still needs one
+		// matching checkModuleAndSuite call after replay.
+		if len(identity.Segments) > 1 {
+			addModulesCounters(testInfo.moduleName, 1)
+			addSuitesCounters(testInfo.suiteName, 1)
+		}
+		counted[result.TestName] = struct{}{}
+	}
+	_, owner := invocation.cfg.resolveDirective(result.TestName)
+	prior := outcomes[result.TestName]
+	execMeta := &testExecutionMetadata{
+		identity:                      identity,
+		isQuarantined:                 result.Quarantined,
+		isDisabled:                    result.Disabled,
+		isAttemptToFix:                result.AttemptToFix,
+		isItrForcedRun:                result.ITRForcedRun,
+		isItrSkipped:                  result.SkippedByITR,
+		isAModifiedTest:               result.Modified,
+		hasAdditionalFeatureWrapper:   true,
+		hasExplicitQuarantined:        true,
+		hasExplicitDisabled:           true,
+		hasExplicitAttemptToFix:       true,
+		suppressParentRetryMetadata:   true,
+		shouldOrchestrateAttemptToFix: owner != "",
+	}
+	if owner != "" {
+		attemptTotal := invocation.cfg.AttemptToFixRetries + 1
+		execMeta.isARetry = invocation.attemptIndex > 0
+		execMeta.isLastRetry = invocation.attemptIndex == attemptTotal-1
+		execMeta.remainingRetries = int64(attemptTotal - invocation.attemptIndex)
+		execMeta.initialRetryCount = int64(attemptTotal - 1)
+		execMeta.initialRetryCountSet = true
+		execMeta.retryContinuationDecided = true
+		execMeta.retryContinuationAdmitted = !execMeta.isLastRetry
+		execMeta.anyExecutionPassed = prior.anyPassed()
+		execMeta.anyExecutionFailed = prior.anyFailed()
+		execMeta.allAttemptsPassed = prior.allAttemptsPassed()
+		execMeta.allRetriesFailed = execMeta.isARetry && prior.allRetriesFailed()
+	} else {
+		execMeta.retryContinuationDecided = true
+		execMeta.anyExecutionPassed = result.Status == processRetryStatusPass
+		execMeta.anyExecutionFailed = result.Failed
+		execMeta.allAttemptsPassed = result.Status == processRetryStatusPass
+	}
+	attempt := processRetryAttemptFromSubtreeResult(result)
+	finishProcessRetryTestEvent(&commonInfo{
+		moduleName: testInfo.moduleName,
+		suiteName:  testInfo.suiteName,
+		testName:   result.TestName,
+		identity:   identity,
+	}, execMeta, attempt, nil, nil)
+	if owner != "" {
+		prior.observe(result.Failed, result.Skipped)
+		outcomes[result.TestName] = prior
+	}
+}
+
+func processRetrySubtreeResultFromEnvelope(result processRetryResult, cfg *processRetrySubtreeConfig) processRetrySubtreeResult {
+	directive, owner := cfg.resolveDirective(result.TestName)
+	return processRetrySubtreeResult{
+		TestName:        result.TestName,
+		Status:          normalizedProcessRetrySubtreeStatus(result.Status),
+		StartUnixNano:   result.StartUnixNano,
+		FinishUnixNano:  result.FinishUnixNano,
+		DurationNanos:   result.DurationNanos,
+		Failed:          result.Failed,
+		Skipped:         result.Skipped,
+		Panic:           result.Panic,
+		RaceDetected:    result.RaceDetected,
+		Disabled:        directive.Disabled,
+		Quarantined:     directive.Quarantined,
+		AttemptToFix:    directive.AttemptToFix,
+		AttemptToFixOwn: owner == result.TestName,
+		SkippedByITR:    result.SkippedByITR,
+		ITRForcedRun:    result.ITRForcedRun,
+		Modified:        result.Modified,
+		ErrorType:       result.ErrorType,
+		ErrorMessage:    result.ErrorMessage,
+		ErrorStack:      result.ErrorStack,
+		SkipReason:      result.SkipReason,
+		OutputTail:      result.OutputTail,
+		OutputTruncated: result.OutputTruncated,
+		Source:          result.Source,
+		Coverage:        result.Coverage,
+	}
+}
+
+func normalizedProcessRetrySubtreeStatus(status processRetryStatus) processRetryStatus {
+	if isProcessRetryControlledTerminalStatus(status) {
+		return processRetryStatusFail
+	}
+	return status
+}
+
+func processRetryAttemptFromSubtreeResult(result processRetrySubtreeResult) processRetryAttemptResult {
+	converted := processRetryResultFromSubtree(result)
+	outputTail := result.OutputTail
+	if result.OutputTruncated {
+		outputTail = processRetryOutputTruncationMarker + outputTail
+	}
+	attempt := processRetryAttemptResult{
+		Result:             converted,
+		OutputTail:         outputTail,
+		OutputTruncated:    result.OutputTruncated,
+		ExitStatusObserved: true,
+		ExitCode:           0,
+		StartTime:          time.Unix(0, result.StartUnixNano),
+		FinishTime:         time.Unix(0, result.FinishUnixNano),
+	}
+	if result.Failed {
+		attempt.ExitCode = processRetryFailureExitCode
+	}
+	if result.Panic {
+		attempt.ExitCode = processRetryControlledPanicExitCode
+		attempt.ControlledTerminalCommitted = true
+	}
+	return attempt
+}
+
+func processRetryResultFromSubtree(result processRetrySubtreeResult) processRetryResult {
+	return processRetryResult{
+		Version:         1,
+		TestName:        result.TestName,
+		Status:          result.Status,
+		StartUnixNano:   result.StartUnixNano,
+		FinishUnixNano:  result.FinishUnixNano,
+		DurationNanos:   result.DurationNanos,
+		Failed:          result.Failed,
+		Skipped:         result.Skipped,
+		Panic:           result.Panic,
+		RaceDetected:    result.RaceDetected,
+		ErrorType:       result.ErrorType,
+		ErrorMessage:    result.ErrorMessage,
+		ErrorStack:      result.ErrorStack,
+		SkipReason:      result.SkipReason,
+		OutputTail:      result.OutputTail,
+		OutputTruncated: result.OutputTruncated,
+		Source:          result.Source,
+		Coverage:        result.Coverage,
+	}
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -168,6 +168,8 @@ func buildProcessRetrySubtreeConfig(
 	execMeta *testExecutionMetadata,
 	parentExecMeta *testExecutionMetadata,
 ) (*processRetrySubtreeConfig, error) {
+	// Callers validate after applying ownership flags specific to the initial or
+	// deferred isolation path.
 	if ctx == nil || testInfo == nil || execMeta == nil || execMeta.identity == nil {
 		return nil, errors.New("missing quarantined race process context")
 	}
@@ -247,9 +249,6 @@ func buildProcessRetrySubtreeConfig(
 	slices.SortFunc(cfg.ITR, func(a, b processRetrySubtreeITR) int {
 		return compareProcessRetrySubtreeITR(a, b)
 	})
-	if err := validateProcessRetrySubtreeConfig(cfg, cfg.SelectedRoot); err != nil {
-		return nil, err
-	}
 	return cfg, nil
 }
 
@@ -990,6 +989,8 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
 		activeStart = time.Now()
 		runTestCleanupCallbacks(t, cleanup)
+		activeDuration += time.Since(activeStart)
+		activeStart = time.Time{}
 		if cleanup.panicData != nil {
 			t.Fail()
 			execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
@@ -1001,11 +1002,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			// testing terminate the child before it can write the subtree result.
 		}
 		state.finishAggregateCoverage(name)
-
-		if !activeStart.IsZero() {
-			activeDuration += time.Since(activeStart)
-			activeStart = time.Time{}
-		}
 		files := collector.Finish()
 		coverageValid = state.coverage.finish(coverageInterval) && coverageValid
 		if !coverageValid {
@@ -1354,6 +1350,9 @@ func runQuarantinedRaceProcessIsolation(
 	execMeta.hasAdditionalFeatureWrapper = true
 
 	cfg, err := buildProcessRetrySubtreeConfig(processCtx, testInfo, execMeta, parentExecMeta)
+	if err == nil {
+		err = validateProcessRetrySubtreeConfig(cfg, cfg.SelectedRoot)
+	}
 	if err != nil {
 		failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
 		return

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -96,6 +96,9 @@ type processRetrySubtreeITR struct {
 type processRetryResolvedDirective struct {
 	directive    processRetrySubtreeDirective
 	attemptOwner string
+	// managed remains true below the first test-management boundary so the
+	// parent can mask and report the whole isolated descendant subtree.
+	managed bool
 }
 
 type processRetryTestSource struct {
@@ -410,6 +413,7 @@ func (cfg *processRetrySubtreeConfig) resolveChildDirective(parent processRetryR
 	if !ok {
 		return resolved
 	}
+	resolved.managed = resolved.managed || exact.Disabled || exact.Quarantined || exact.AttemptToFix
 	resolved.directive.Disabled = resolved.directive.Disabled || exact.Disabled
 	resolved.directive.Quarantined = resolved.directive.Quarantined || exact.Quarantined
 	if exact.AttemptToFix {
@@ -863,9 +867,6 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		suiteName = testifyData.suiteName
 		sourceFunc = testifyData.methodFunc
 	}
-	managedByDescendant := parent.processRetryManagedDescendant || state.cfg.exactManagedDescendant(moduleName, suiteName, name)
-	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg, managedByDescendant)
-	maskedByManagedDescendant := managedByDescendant
 	execMeta := createTestMetadata(t, nil)
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
@@ -882,9 +883,12 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		resolved = state.cfg.resolveChildDirective(processRetryResolvedDirective{
 			directive:    processRetryDirectiveFromMetadata(parent.identity, parent),
 			attemptOwner: parent.processRetryAttemptOwner,
+			managed:      parent.processRetryManagedDescendant,
 		}, moduleName, suiteName, name)
 	}
 	directive, attemptOwner := resolved.directive, resolved.attemptOwner
+	failureSnapshot := captureQuarantinedRaceManagedFailure(t, state.cfg, resolved.managed)
+	maskedByManagedDescendant := resolved.managed
 	execMeta.isDisabled = directive.Disabled
 	execMeta.isQuarantined = directive.Quarantined
 	execMeta.isAttemptToFix = directive.AttemptToFix
@@ -894,7 +898,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.hasExplicitAttemptToFix = true
 	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
 	execMeta.processRetryAttemptOwner = attemptOwner
-	execMeta.processRetryManagedDescendant = managedByDescendant
+	execMeta.processRetryManagedDescendant = resolved.managed
 
 	execMeta.identity = newTestIdentity(moduleName, suiteName, name)
 	source := processRetrySourceFromFunc(sourceFunc)
@@ -1634,7 +1638,7 @@ func replayQuarantinedRaceResults(
 	for _, invocation := range invocations {
 		resolved, _ := invocation.cfg.resolveSubtreeResults(invocation.attempt.Result.Subtests)
 		for idx, result := range invocation.attempt.Result.Subtests {
-			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result), resolved[idx])
+			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result, resolved[idx]), resolved[idx])
 		}
 		if includeRoot {
 			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation), invocation.cfg.resolvedRootDirective())
@@ -1680,12 +1684,12 @@ func replayQuarantinedRaceResults(
 
 func processRetrySubtreeRootFromInvocation(invocation quarantinedRaceInvocation) processRetrySubtreeResult {
 	root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
-	return processRetrySubtreeResultWithInvocationOutput(invocation, root)
+	return processRetrySubtreeResultWithInvocationOutput(invocation, root, invocation.cfg.resolvedRootDirective())
 }
 
-func processRetrySubtreeResultWithInvocationOutput(invocation quarantinedRaceInvocation, result processRetrySubtreeResult) processRetrySubtreeResult {
+func processRetrySubtreeResultWithInvocationOutput(invocation quarantinedRaceInvocation, result processRetrySubtreeResult, resolved processRetryResolvedDirective) processRetrySubtreeResult {
 	if !result.Failed || invocation.attempt.OutputTail == "" ||
-		(result.TestName != invocation.cfg.SelectedRoot && !invocation.cfg.exactManagedDescendant(result.ModuleName, result.SuiteName, result.TestName)) {
+		result.TestName != invocation.cfg.SelectedRoot && !resolved.managed {
 		return result
 	}
 	// Direct stdout, stderr, and race reports are absent from testing's buffered

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -329,7 +329,7 @@ func (cfg *processRetrySubtreeConfig) itrDecision(name string, meta processRetry
 	idx, ok := slices.BinarySearchFunc(cfg.ITR, name, func(candidate processRetrySubtreeITR, name string) int {
 		return strings.Compare(candidate.TestName, name)
 	})
-	if !ok || meta.AttemptToFix {
+	if !ok || meta.AttemptToFix || meta.Modified {
 		return false, false
 	}
 	_, _, unskippable := integrations.TestFuncSourceMetadata(sourceFunc)
@@ -468,6 +468,9 @@ func (o *processRetryChildObservation) buildSubtreeResult(result processRetryRes
 	result.OutputTruncated = root.OutputTruncated
 	result.Source = root.Source
 	result.Coverage = root.Coverage
+	result.SkippedByITR = root.SkippedByITR
+	result.ITRForcedRun = root.ITRForcedRun
+	result.Modified = root.Modified
 	result.Subtests = append(results[:rootIndex:rootIndex], results[rootIndex+1:]...)
 	applyProcessRetryControlledSubtreeStatus(&result, controlled)
 	return result
@@ -495,6 +498,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.test = parent.test
 	execMeta.processRetryOwner = parent
 	execMeta.quarantinedRaceChild = state
+	execMeta.processRetryCoverageMu = &sync.Mutex{}
 	if !processRetryNameWithinRoot(name, state.cfg.SelectedRoot) {
 		defer deleteTestMetadata(t)
 		original(t)
@@ -514,15 +518,22 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 
 	sourceFunc := runtime.FuncForPC(reflect.ValueOf(original).Pointer())
 	source := processRetrySourceFromFunc(sourceFunc)
+	execMeta.isAModifiedTest = directive.Modified || integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc)
+	directive.Modified = execMeta.isAModifiedTest
 	order, start, raceBaseline := state.begin()
 	restoreChatty := bufferQuarantinedRaceChildOutput(t)
 	var collector *coverage.ProcessTestCoverage
 	var parentBarrier *chan bool
 	var oldParentBarrier chan bool
+	coverageLocked := false
 	if state.cfg.CollectPerTest && source != nil && coverage.CanCollect() {
-		// Runtime coverage counters are global. Clearing the parent barrier keeps
-		// covered bodies serial, so each event owns a deterministic delta. The
-		// intentional ancestor/descendant overlap represents their logical scopes.
+		// Runtime coverage counters are global, so siblings must not collect
+		// overlapping deltas. The parent-owned lock serializes concurrent t.Run
+		// calls without blocking nested collectors, which lock their own parent.
+		parent.processRetryCoverageMu.Lock()
+		coverageLocked = true
+		// Clearing the barrier makes t.Parallel a no-op for this covered body.
+		// Ancestor/descendant collectors remain inclusive by design.
 		if fields := getTestParentPrivateFields(t); fields != nil && fields.barrier != nil {
 			parentBarrier = fields.barrier
 			oldParentBarrier = *parentBarrier
@@ -532,12 +543,16 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	}
 
 	t.Cleanup(func() {
+		if coverageLocked {
+			defer parent.processRetryCoverageMu.Unlock()
+		}
 		files := collector.Finish()
 		if parentBarrier != nil {
 			*parentBarrier = oldParentBarrier
 		}
 		restoreChatty()
 		finish := time.Now()
+		fields := getTestPrivateFields(t)
 		result := processRetrySubtreeResult{
 			TestName:        name,
 			StartUnixNano:   start.UnixNano(),
@@ -545,19 +560,19 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			DurationNanos:   finish.UnixNano() - start.UnixNano(),
 			Failed:          t.Failed(),
 			Skipped:         t.Skipped(),
-			RaceDetected:    retryAttemptRaceErrors() > raceBaseline,
+			RaceDetected:    processRetrySubtreeRaceDetected(fields, raceBaseline, retryAttemptRaceErrors()),
 			Disabled:        directive.Disabled,
 			Quarantined:     directive.Quarantined,
 			AttemptToFix:    directive.AttemptToFix,
 			AttemptToFixOwn: attemptOwner == name,
 			ITRForcedRun:    execMeta.isItrForcedRun,
 			SkippedByITR:    execMeta.isItrSkipped,
-			Modified:        integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc),
+			Modified:        execMeta.isAModifiedTest,
 			Source:          source,
 			Coverage:        files,
 			order:           order,
 		}
-		if fields := getTestPrivateFields(t); fields != nil {
+		if fields != nil {
 			result.OutputTail, result.OutputTruncated = truncateProcessRetrySubtreeOutput(fields.GetOutput())
 		}
 		if panicInfo := execMeta.processRetryPanic.Load(); panicInfo != nil {
@@ -625,6 +640,16 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	}()
 	original(t)
 	bodyReturned = true
+}
+
+func processRetrySubtreeRaceDetected(fields *commonPrivateFields, initialBaseline, current int64) bool {
+	baseline := initialBaseline
+	if fields != nil && fields.isParallel != nil && *fields.isParallel && fields.lastRaceErrors != nil {
+		// testing.T.Parallel resets this baseline after the test resumes so races
+		// reported while it was paused are not charged to the resumed subtest.
+		baseline = fields.lastRaceErrors.Load()
+	}
+	return current > baseline
 }
 
 func bufferQuarantinedRaceChildOutput(t *testing.T) func() {
@@ -811,7 +836,7 @@ func runQuarantinedRaceProcessIsolation(
 
 	rootTotal := 1
 	if cfg.OwnsAttemptToFix {
-		rootTotal += cfg.AttemptToFixRetries
+		rootTotal = processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries)
 	}
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
 	for idx := 0; idx < rootTotal; idx++ {
@@ -835,7 +860,7 @@ func runQuarantinedRaceProcessIsolation(
 				failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: cfgErr, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
 				return
 			}
-			for idx := 1; idx <= cfg.AttemptToFixRetries; idx++ {
+			for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
 				attempt := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx)
 				if processRetryInfrastructureFailure(attempt) {
 					failQuarantinedRaceIsolation(t, &commonInfo{
@@ -858,6 +883,12 @@ func runQuarantinedRaceProcessIsolation(
 	// Visibility but is intentionally masked from the package result. An
 	// infrastructure error returns above through Fail and is never quarantined.
 	t.SkipNow()
+}
+
+// AttemptToFixRetries is the configured total execution count in the existing
+// in-process retry path, despite its historical name.
+func processRetryAttemptToFixExecutionCount(configured int) int {
+	return max(configured, 1)
 }
 
 func runQuarantinedRaceInvocation(
@@ -897,10 +928,6 @@ func runQuarantinedRaceInvocation(
 		if err := coverage.MergeProcessCoverageProfile(processRetrySubtreeCoveragePath(filepath.Join(attempt.TempDir, "result.json"))); err != nil {
 			attempt.Err = errors.Join(attempt.Err, fmt.Errorf("aggregate process coverage: %w", err))
 		}
-	}
-	if attempt.Result.OutputTail != "" {
-		attempt.OutputTail = attempt.Result.OutputTail
-		attempt.OutputTruncated = attempt.Result.OutputTruncated
 	}
 	return attempt
 }
@@ -979,7 +1006,7 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 		for _, result := range invocation.attempt.Result.Subtests {
 			replayQuarantinedRaceEvent(testInfo, invocation, result, outcomes, counted)
 		}
-		root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
+		root := processRetrySubtreeRootFromInvocation(invocation)
 		replayQuarantinedRaceEvent(testInfo, invocation, root, outcomes, counted)
 	}
 	module := session.GetOrCreateModule(testInfo.moduleName)
@@ -987,6 +1014,20 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 	for range counted {
 		checkModuleAndSuite(module, suite)
 	}
+}
+
+func processRetrySubtreeRootFromInvocation(invocation quarantinedRaceInvocation) processRetrySubtreeResult {
+	root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
+	raceDetected := root.RaceDetected || slices.ContainsFunc(invocation.attempt.Result.Subtests, func(result processRetrySubtreeResult) bool {
+		return result.RaceDetected
+	})
+	if raceDetected && invocation.attempt.OutputTail != "" {
+		// The race detector writes its full report directly to child stderr. The
+		// structured subtree result only contains testing's short race message.
+		root.OutputTail = invocation.attempt.OutputTail
+		root.OutputTruncated = invocation.attempt.OutputTruncated
+	}
+	return root
 }
 
 func replayQuarantinedRaceEvent(
@@ -1009,6 +1050,7 @@ func replayQuarantinedRaceEvent(
 		counted[result.TestName] = struct{}{}
 	}
 	_, owner := invocation.cfg.resolveDirective(result.TestName)
+	ownsAttemptToFix := owner == result.TestName
 	prior := outcomes[result.TestName]
 	execMeta := &testExecutionMetadata{
 		identity:                      identity,
@@ -1023,14 +1065,14 @@ func replayQuarantinedRaceEvent(
 		hasExplicitDisabled:           true,
 		hasExplicitAttemptToFix:       true,
 		suppressParentRetryMetadata:   true,
-		shouldOrchestrateAttemptToFix: owner != "",
+		shouldOrchestrateAttemptToFix: ownsAttemptToFix,
 	}
-	if owner != "" {
-		attemptTotal := invocation.cfg.AttemptToFixRetries + 1
+	if ownsAttemptToFix {
+		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
 		execMeta.isARetry = invocation.attemptIndex > 0
 		execMeta.isLastRetry = invocation.attemptIndex == attemptTotal-1
 		execMeta.remainingRetries = int64(attemptTotal - invocation.attemptIndex)
-		execMeta.initialRetryCount = int64(attemptTotal - 1)
+		execMeta.initialRetryCount = int64(invocation.cfg.AttemptToFixRetries)
 		execMeta.initialRetryCountSet = true
 		execMeta.retryContinuationDecided = true
 		execMeta.retryContinuationAdmitted = !execMeta.isLastRetry
@@ -1051,7 +1093,7 @@ func replayQuarantinedRaceEvent(
 		testName:   result.TestName,
 		identity:   identity,
 	}, execMeta, attempt, nil, nil)
-	if owner != "" {
+	if ownsAttemptToFix {
 		prior.observe(result.Failed, result.Skipped)
 		outcomes[result.TestName] = prior
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1277,6 +1277,30 @@ type quarantinedRaceContinuationFailure struct {
 	attempt processRetryAttemptResult
 }
 
+type quarantinedRaceFamilyKey struct {
+	name       string
+	generation int
+}
+
+type quarantinedRaceReplayEvent struct {
+	invocation   quarantinedRaceInvocation
+	result       processRetrySubtreeResult
+	family       quarantinedRaceFamilyKey
+	attemptOwner string
+	inherited    bool
+}
+
+type quarantinedRacePendingReplay struct {
+	testInfo commonInfo
+	event    quarantinedRaceReplayEvent
+	prior    retryOutcomeAccumulator
+}
+
+type quarantinedRaceReplayState struct {
+	pending map[quarantinedRaceReplayIdentity]quarantinedRacePendingReplay
+	order   []quarantinedRaceReplayIdentity
+}
+
 type quarantinedRaceReplayIdentity struct {
 	moduleName string
 	suiteName  string
@@ -1613,7 +1637,7 @@ func (cfg *processRetrySubtreeConfig) forSelectedRoot(result processRetrySubtree
 }
 
 func replayQuarantinedRaceInvocations(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, invocations []quarantinedRaceInvocation) {
-	replayQuarantinedRaceResults(testInfo, processCtx, invocations, true)
+	replayQuarantinedRaceResults(testInfo, processCtx, invocations, true, nil)
 }
 
 func replayQuarantinedRaceResults(
@@ -1621,24 +1645,14 @@ func replayQuarantinedRaceResults(
 	processCtx *quarantinedRaceProcessContext,
 	invocations []quarantinedRaceInvocation,
 	includeTopLevelRoot bool,
+	deferred *quarantinedRaceReplayState,
 ) {
 	if testInfo == nil {
 		return
 	}
-	type familyKey struct {
-		name       string
-		generation int
-	}
-	type replayEvent struct {
-		invocation   quarantinedRaceInvocation
-		result       processRetrySubtreeResult
-		family       familyKey
-		attemptOwner string
-		inherited    bool
-	}
 	generations := make(map[string]int)
-	lastOccurrence := make(map[familyKey]int)
-	events := make([]replayEvent, 0, len(invocations))
+	lastOccurrence := make(map[quarantinedRaceFamilyKey]int)
+	events := make([]quarantinedRaceReplayEvent, 0, len(invocations))
 	appendEvent := func(invocation quarantinedRaceInvocation, result processRetrySubtreeResult, resolved processRetryResolvedDirective) {
 		attemptOwner := resolved.attemptOwner
 		if result.TestName == attemptOwner && attemptOwner != invocation.cfg.SelectedRoot {
@@ -1647,9 +1661,9 @@ func replayQuarantinedRaceResults(
 			generations[attemptOwner]++
 		}
 		inherited := invocation.cfg.AncestorAttemptToFix && result.AttemptToFix && attemptOwner == ""
-		family := familyKey{name: result.TestName, generation: generations[attemptOwner]}
+		family := quarantinedRaceFamilyKey{name: result.TestName, generation: generations[attemptOwner]}
 		lastOccurrence[family] = len(events)
-		events = append(events, replayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner, inherited: inherited})
+		events = append(events, quarantinedRaceReplayEvent{invocation: invocation, result: result, family: family, attemptOwner: attemptOwner, inherited: inherited})
 	}
 	for _, invocation := range invocations {
 		resolved, _ := invocation.cfg.resolveSubtreeResults(invocation.attempt.Result.Subtests)
@@ -1660,12 +1674,16 @@ func replayQuarantinedRaceResults(
 			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation), invocation.cfg.resolvedRootDirective())
 		}
 	}
-	outcomes := make(map[familyKey]retryOutcomeAccumulator)
+	outcomes := make(map[quarantinedRaceFamilyKey]retryOutcomeAccumulator)
 	counted := make(map[quarantinedRaceReplayIdentity]*testIdentity)
 	for idx, event := range events {
 		prior := outcomes[event.family]
 		last := lastOccurrence[event.family] == idx
 		identityKey := quarantinedRaceReplayIdentity{moduleName: event.result.ModuleName, suiteName: event.result.SuiteName, testName: event.result.TestName}
+		if event.inherited && deferred != nil {
+			deferred.deferInherited(testInfo, processCtx, event, counted)
+			continue
+		}
 		if event.inherited && processCtx != nil {
 			processCtx.replayMu.Lock()
 			prior = processCtx.ancestorOutcomes[identityKey]
@@ -1691,6 +1709,51 @@ func replayQuarantinedRaceResults(
 			}
 		}
 	}
+	closeQuarantinedRaceReplayCounters(counted)
+}
+
+func (s *quarantinedRaceReplayState) deferInherited(testInfo *commonInfo, processCtx *quarantinedRaceProcessContext, event quarantinedRaceReplayEvent, counted map[quarantinedRaceReplayIdentity]*testIdentity) {
+	if s.pending == nil {
+		s.pending = make(map[quarantinedRaceReplayIdentity]quarantinedRacePendingReplay)
+	}
+	// Deferred ancestor attempts arrive one at a time. Publish the previous
+	// occurrence as non-final and retain only the newest one until group finish
+	// proves the family's actual last occurrence, including disappearance.
+	key := quarantinedRaceReplayIdentity{moduleName: event.result.ModuleName, suiteName: event.result.SuiteName, testName: event.result.TestName}
+	prior := retryOutcomeAccumulator{}
+	if pending, ok := s.pending[key]; ok {
+		replayQuarantinedRaceEvent(&pending.testInfo, pending.event.invocation, pending.event.result, pending.event.attemptOwner, true, false, pending.prior, counted)
+		prior = pending.prior
+		prior.observe(pending.event.result.Failed, pending.event.result.Skipped)
+	} else {
+		s.order = append(s.order, key)
+		if processCtx != nil {
+			processCtx.replayMu.Lock()
+			prior = processCtx.ancestorOutcomes[key]
+			processCtx.replayMu.Unlock()
+		}
+	}
+	s.pending[key] = quarantinedRacePendingReplay{testInfo: *testInfo, event: event, prior: prior}
+}
+
+func (s *quarantinedRaceReplayState) finish() {
+	if s == nil || len(s.pending) == 0 {
+		return
+	}
+	counted := make(map[quarantinedRaceReplayIdentity]*testIdentity)
+	for _, key := range s.order {
+		pending, ok := s.pending[key]
+		if !ok {
+			continue
+		}
+		replayQuarantinedRaceEvent(&pending.testInfo, pending.event.invocation, pending.event.result, pending.event.attemptOwner, true, true, pending.prior, counted)
+	}
+	closeQuarantinedRaceReplayCounters(counted)
+	s.pending = nil
+	s.order = nil
+}
+
+func closeQuarantinedRaceReplayCounters(counted map[quarantinedRaceReplayIdentity]*testIdentity) {
 	for _, identity := range counted {
 		module := session.GetOrCreateModule(identity.ModuleName)
 		suite := module.GetOrCreateSuite(identity.SuiteName)

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -390,6 +390,8 @@ type quarantinedRaceChildState struct {
 	next            atomic.Uint64
 	results         []processRetrySubtreeResult
 	impacted        *impactedtests.ImpactedTestAnalyzer
+	aggregateOnce   sync.Once
+	beginAggregate  func()
 	parallelBridge  func() error
 	parallelOnce    sync.Once
 	parallelStarted atomic.Bool
@@ -406,6 +408,13 @@ func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRa
 
 func (s *quarantinedRaceChildState) begin() (uint64, time.Time, int64) {
 	return s.next.Add(1), time.Now(), retryAttemptRaceErrors()
+}
+
+func (s *quarantinedRaceChildState) beginAggregateCoverage(name string) {
+	if s == nil || s.cfg == nil || name != s.cfg.SelectedRoot || s.beginAggregate == nil {
+		return
+	}
+	s.aggregateOnce.Do(s.beginAggregate)
 }
 
 func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) {
@@ -546,6 +555,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		original(t)
 		return
 	}
+	state.beginAggregateCoverage(name)
 
 	directive, attemptOwner := state.cfg.resolveDirective(name)
 	execMeta.identity = newTestIdentity("", "", name)
@@ -1131,12 +1141,9 @@ func replayQuarantinedRaceInvocations(testInfo *commonInfo, invocations []quaran
 
 func processRetrySubtreeRootFromInvocation(invocation quarantinedRaceInvocation) processRetrySubtreeResult {
 	root := processRetrySubtreeResultFromEnvelope(invocation.attempt.Result, invocation.cfg)
-	raceDetected := root.RaceDetected || slices.ContainsFunc(invocation.attempt.Result.Subtests, func(result processRetrySubtreeResult) bool {
-		return result.RaceDetected
-	})
-	if raceDetected && invocation.attempt.OutputTail != "" {
-		// The race detector writes its full report directly to child stderr. The
-		// structured subtree result only contains testing's short race message.
+	if root.Failed && invocation.attempt.OutputTail != "" {
+		// Direct child stdout and stderr are not present in testing's buffered
+		// subtree output. A failed selected root owns the complete process tail.
 		root.OutputTail = invocation.attempt.OutputTail
 		root.OutputTruncated = invocation.attempt.OutputTruncated
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -363,19 +363,24 @@ func processRetrySourceFromFunc(fn *runtime.Func) *processRetryTestSource {
 }
 
 func truncateProcessRetrySubtreeOutput(output []byte) (string, bool) {
-	truncated := len(output) > processRetrySubtreeOutputMaxBytes
+	return truncateProcessRetrySubtreeOutputTo(string(output), processRetrySubtreeOutputMaxBytes)
+}
+
+func truncateProcessRetrySubtreeOutputTo(output string, maxBytes int) (string, bool) {
+	maxBytes = max(maxBytes, 0)
+	truncated := len(output) > maxBytes
 	if truncated {
-		output = output[len(output)-processRetrySubtreeOutputMaxBytes:]
+		output = output[len(output)-maxBytes:]
 	}
-	normalized := strings.ToValidUTF8(string(output), "\uFFFD")
-	if processRetryJSONStringFits(normalized, processRetrySubtreeOutputMaxBytes) {
+	normalized := strings.ToValidUTF8(output, "\uFFFD")
+	if processRetryJSONStringFits(normalized, maxBytes) {
 		return normalized, truncated
 	}
 	runes := []rune(normalized)
 	low, high := 0, len(runes)
 	for low < high {
 		mid := low + (high-low+1)/2
-		if processRetryJSONStringFits(string(runes[len(runes)-mid:]), processRetrySubtreeOutputMaxBytes) {
+		if processRetryJSONStringFits(string(runes[len(runes)-mid:]), maxBytes) {
 			low = mid
 		} else {
 			high = mid - 1

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -559,10 +559,6 @@ type quarantinedRaceChildState struct {
 	unmasked        map[string]struct{}
 }
 
-// This indirection keeps duration accounting on the wall clock in production
-// while allowing tests to supply a logical clock instead of sleeping.
-var quarantinedRaceNow = time.Now
-
 type quarantinedRaceFailureEntry struct {
 	mu     *sync.RWMutex
 	failed *bool
@@ -685,7 +681,7 @@ func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRa
 }
 
 func (s *quarantinedRaceChildState) begin() (uint64, time.Time, int64) {
-	return s.next.Add(1), quarantinedRaceNow(), retryAttemptRaceErrors()
+	return s.next.Add(1), time.Now(), retryAttemptRaceErrors()
 }
 
 func (s *quarantinedRaceChildState) beginAggregateCoverage(name string) {
@@ -932,7 +928,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// parent. A failure added by the selected root after that release can then
 		// be identified before its parallel descendants resume.
 		failureSnapshot.restoreAncestors(state)
-		activeDuration += quarantinedRaceNow().Sub(activeStart)
+		activeDuration += time.Since(activeStart)
 		activeStart = time.Time{}
 		// A nested selected root releases its discovery ancestor in Parallel.
 		// Exclude that ancestor's work from this root's aggregate profile.
@@ -946,7 +942,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		coverageValid = state.coverage.finish(coverageInterval) && coverageValid
 		coverageInterval = nil
 		return func() {
-			activeStart = quarantinedRaceNow()
+			activeStart = time.Now()
 			if resumeAggregate != nil {
 				resumeAggregate()
 			}
@@ -980,7 +976,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		// scheduler wait from the parent's duration, but cleanup remains active time.
 		cleanup := &testCleanupResult{}
 		if !activeStart.IsZero() {
-			activeDuration += quarantinedRaceNow().Sub(activeStart)
+			activeDuration += time.Since(activeStart)
 			activeStart = time.Time{}
 		}
 		if !maskedByManagedDescendant && t.Failed() {
@@ -991,9 +987,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			state.markUnmaskedFailure(moduleName, suiteName, name)
 		}
 		completeParallelSubtests(t, getTestPrivateFields(t), true)
-		activeStart = quarantinedRaceNow()
+		activeStart = time.Now()
 		runTestCleanupCallbacks(t, cleanup)
-		activeDuration += quarantinedRaceNow().Sub(activeStart)
+		activeDuration += time.Since(activeStart)
 		activeStart = time.Time{}
 		if cleanup.panicData != nil {
 			t.Fail()

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -596,6 +596,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			if panicData == nil {
 				panicData = unexpectedTestTerminationMessage
 			}
+			t.Fail()
 			execMeta.processRetryPanic.CompareAndSwap(nil, &processRetryErrorInfo{
 				Type:    "panic",
 				Message: truncateProcessRetryErrorMessage(toString(panicData)),
@@ -603,9 +604,10 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			})
 		}
 
-		// Drain user cleanups before snapshotting. testing.tRunner marks a cleanup
-		// panic only after recursively running earlier cleanups, which would make a
-		// regular t.Cleanup finalizer report the descendant as passing.
+		// Drain user cleanups before snapshotting. The helper also releases and
+		// waits for queued parallel descendants, so the selected root includes
+		// their failures, timing, and coverage. A regular t.Cleanup finalizer would
+		// run after testing has already classified a cleanup panic.
 		cleanup := &testCleanupResult{}
 		runTestCleanupWithOptions(t, cleanup, true)
 		if cleanup.panicData != nil {
@@ -677,9 +679,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		state.append(result)
 		deleteTestMetadata(t)
 
-		if panicData != nil && !unexpected {
-			panic(panicData)
-		}
+		// Body panics are valid test results in this child protocol. They were
+		// recorded above and t.Fail propagated them to the selected root; re-panic
+		// would let testing terminate the process before it can write the result.
 	}()
 
 	if directive.Disabled && !directive.AttemptToFix {

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -385,15 +385,19 @@ func truncateProcessRetrySubtreeOutput(output []byte) (string, bool) {
 }
 
 type quarantinedRaceChildState struct {
-	cfg      *processRetrySubtreeConfig
-	mu       locking.Mutex
-	next     atomic.Uint64
-	results  []processRetrySubtreeResult
-	impacted *impactedtests.ImpactedTestAnalyzer
+	cfg             *processRetrySubtreeConfig
+	mu              locking.Mutex
+	next            atomic.Uint64
+	results         []processRetrySubtreeResult
+	impacted        *impactedtests.ImpactedTestAnalyzer
+	parallelBridge  func() error
+	parallelOnce    sync.Once
+	parallelStarted atomic.Bool
+	parallelDone    chan error
 }
 
 func newQuarantinedRaceChildState(cfg *processRetrySubtreeConfig) *quarantinedRaceChildState {
-	state := &quarantinedRaceChildState{cfg: cfg}
+	state := &quarantinedRaceChildState{cfg: cfg, parallelDone: make(chan error, 1)}
 	if cfg != nil && cfg.ImpactedTestsEnabled {
 		state.impacted, _ = impactedtests.NewImpactedTestAnalyzer()
 	}
@@ -427,6 +431,27 @@ func (s *quarantinedRaceChildState) snapshot() []processRetrySubtreeResult {
 		results[idx].order = 0
 	}
 	return results
+}
+
+func (s *quarantinedRaceChildState) startParallelBridge() {
+	if s == nil || s.parallelBridge == nil {
+		return
+	}
+	s.parallelOnce.Do(func() {
+		s.parallelStarted.Store(true)
+		// Do not hold up native Parallel: it must first release the selected
+		// test's child-process parent before the parent-process bridge can resume.
+		go func() {
+			s.parallelDone <- s.parallelBridge()
+		}()
+	})
+}
+
+func (s *quarantinedRaceChildState) waitParallelBridge() error {
+	if s == nil || !s.parallelStarted.Load() {
+		return nil
+	}
+	return <-s.parallelDone
 }
 
 func processRetrySubtreeCoveragePath(resultPath string) string {
@@ -533,6 +558,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.shouldOrchestrateAttemptToFix = attemptOwner == name
 
 	sourceFunc := runtime.FuncForPC(reflect.ValueOf(original).Pointer())
+	if testifyData := getTestifyTest(t); testifyData != nil && testifyData.methodFunc != nil {
+		sourceFunc = testifyData.methodFunc
+	}
 	source := processRetrySourceFromFunc(sourceFunc)
 	execMeta.isAModifiedTest = directive.Modified || integrations.IsTestFuncModifiedWithAnalyzer(state.impacted, name, sourceFunc)
 	directive.Modified = execMeta.isAModifiedTest
@@ -864,6 +892,25 @@ func runQuarantinedRaceProcessIsolation(
 		return
 	}
 	defer lease.release()
+	var parallelGroup *retryAttemptGroup
+	var parallelReason string
+	var parallelOnce sync.Once
+	parallelBridge := func() error {
+		// Serial roots never pay for or depend on the private scheduler bridge.
+		parallelOnce.Do(func() {
+			parallelGroup, parallelReason = newRetryAttemptGroupWithOutputObservation(t, false)
+		})
+		if parallelReason != "" {
+			return fmt.Errorf("quarantined race parallel admission: %s", parallelReason)
+		}
+		parallelGroup.transitionOriginalToParallel()
+		return nil
+	}
+	defer func() {
+		if parallelGroup != nil {
+			parallelGroup.retire()
+		}
+	}()
 
 	rootTotal := 1
 	if cfg.OwnsAttemptToFix {
@@ -872,7 +919,7 @@ func runQuarantinedRaceProcessIsolation(
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
 	failfastStopped := false
 	for idx := 0; idx < rootTotal; idx++ {
-		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx)
+		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx, parallelBridge)
 		if processRetryInfrastructureFailure(attempt) {
 			failQuarantinedRaceIsolation(t, testInfo, execMeta, attempt)
 			return
@@ -898,7 +945,7 @@ func runQuarantinedRaceProcessIsolation(
 				return
 			}
 			for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-				attempt := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx)
+				attempt := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, idx, parallelBridge)
 				if processRetryInfrastructureFailure(attempt) {
 					failQuarantinedRaceIsolation(t, &commonInfo{
 						moduleName: testInfo.moduleName,
@@ -941,6 +988,7 @@ func runQuarantinedRaceInvocation(
 	lease *processRetryGroupLease,
 	cfg *processRetrySubtreeConfig,
 	attemptIndex int,
+	parallelBridge func() error,
 ) processRetryAttemptResult {
 	deadline, deadlineOK := t.Deadline()
 	baseline := captureProcessRetryLaunchBaselineFromTemplate(processCtx.launchTemplate)
@@ -962,6 +1010,7 @@ func runQuarantinedRaceInvocation(
 		deadlineOK,
 		baseline,
 		lease.shutdown,
+		parallelBridge,
 	)
 	defer func() {
 		if attempt.Cleanup != nil {

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -62,19 +62,20 @@ type quarantinedRaceProcessContext struct {
 }
 
 type processRetrySubtreeConfig struct {
-	Version              int                            `json:"version"`
-	SelectedRoot         string                         `json:"selected_root"`
-	Root                 processRetrySubtreeDirective   `json:"root"`
-	Directives           []processRetrySubtreeDirective `json:"directives,omitempty"`
-	ITR                  []processRetrySubtreeITR       `json:"itr,omitempty"`
-	AttemptToFixRetries  int                            `json:"attempt_to_fix_retries,omitempty"`
-	OwnsAttemptToFix     bool                           `json:"owns_attempt_to_fix,omitempty"`
-	AncestorAttemptToFix bool                           `json:"ancestor_attempt_to_fix,omitempty"`
-	AncestorAttemptIndex int                            `json:"ancestor_attempt_index,omitempty"`
-	CollectPerTest       bool                           `json:"collect_per_test_coverage,omitempty"`
-	CollectAggregate     bool                           `json:"collect_aggregate_coverage,omitempty"`
-	ITRCoverageActive    bool                           `json:"itr_coverage_active,omitempty"`
-	ImpactedTestsEnabled bool                           `json:"impacted_tests_enabled,omitempty"`
+	Version                int                            `json:"version"`
+	SelectedRoot           string                         `json:"selected_root"`
+	Root                   processRetrySubtreeDirective   `json:"root"`
+	Directives             []processRetrySubtreeDirective `json:"directives,omitempty"`
+	ITR                    []processRetrySubtreeITR       `json:"itr,omitempty"`
+	AttemptToFixRetries    int                            `json:"attempt_to_fix_retries,omitempty"`
+	OwnsAttemptToFix       bool                           `json:"owns_attempt_to_fix,omitempty"`
+	AncestorAttemptToFix   bool                           `json:"ancestor_attempt_to_fix,omitempty"`
+	DescendantContinuation bool                           `json:"descendant_continuation,omitempty"`
+	AncestorAttemptIndex   int                            `json:"ancestor_attempt_index,omitempty"`
+	CollectPerTest         bool                           `json:"collect_per_test_coverage,omitempty"`
+	CollectAggregate       bool                           `json:"collect_aggregate_coverage,omitempty"`
+	ITRCoverageActive      bool                           `json:"itr_coverage_active,omitempty"`
+	ImpactedTestsEnabled   bool                           `json:"impacted_tests_enabled,omitempty"`
 }
 
 type processRetrySubtreeDirective struct {
@@ -275,7 +276,10 @@ func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedR
 	if cfg == nil {
 		return nil
 	}
-	rootIsolated := cfg.Root.Quarantined ||
+	// A descendant continuation can be a clear ATF owner discovered inside an
+	// already isolated subtree; its validated ownership keeps this opt-in path
+	// from becoming a general process retry mechanism.
+	rootIsolated := cfg.Root.Quarantined || cfg.DescendantContinuation ||
 		cfg.Root.AttemptToFix && (cfg.OwnsAttemptToFix || cfg.AncestorAttemptToFix) && cfg.hasQuarantinedDescendant()
 	if cfg.Version != processRetrySubtreeVersion || cfg.SelectedRoot != selectedRoot ||
 		strings.TrimSpace(cfg.SelectedRoot) == "" || cfg.Root.TestName != cfg.SelectedRoot ||
@@ -284,6 +288,7 @@ func validateProcessRetrySubtreeConfig(cfg *processRetrySubtreeConfig, selectedR
 		return errors.New("invalid process retry subtree configuration")
 	}
 	if cfg.OwnsAttemptToFix && !cfg.Root.AttemptToFix || cfg.AncestorAttemptToFix && cfg.OwnsAttemptToFix ||
+		cfg.DescendantContinuation && (!cfg.OwnsAttemptToFix || !cfg.Root.AttemptToFix) ||
 		cfg.AncestorAttemptIndex < 0 || cfg.AncestorAttemptIndex >= processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries) ||
 		!cfg.AncestorAttemptToFix && cfg.AncestorAttemptIndex != 0 {
 		return errors.New("invalid process retry subtree attempt ownership")
@@ -1267,6 +1272,11 @@ type quarantinedRaceInvocation struct {
 	attemptIndex int
 }
 
+type quarantinedRaceContinuationFailure struct {
+	result  processRetrySubtreeResult
+	attempt processRetryAttemptResult
+}
+
 type quarantinedRaceReplayIdentity struct {
 	moduleName string
 	suiteName  string
@@ -1351,10 +1361,13 @@ func runQuarantinedRaceProcessIsolation(
 		if cfg.AttemptToFixRetries <= 0 {
 			continue
 		}
-		stop, failed := continueQuarantinedRaceDescendantFamilies(
-			t, testInfo, execMeta, processCtx, lease, cfg, attempt, parallelBridge, &invocations,
+		stop, failure := continueQuarantinedRaceDescendantFamilies(
+			cfg, attempt, &invocations, func(continuationCfg *processRetrySubtreeConfig, runRoot string, idx int) processRetryAttemptResult {
+				return runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, runRoot, idx, parallelBridge)
+			},
 		)
-		if failed {
+		if failure != nil {
+			failQuarantinedRaceIsolation(t, processRetryCommonInfoFromSubtreeResult(failure.result), execMeta, failure.attempt)
 			return
 		}
 		if stop {
@@ -1374,26 +1387,23 @@ func runQuarantinedRaceProcessIsolation(
 // keeps a deeper owner's retry adjacent to the initial execution from the same
 // enclosing invocation, so replay cannot associate it with a later family.
 func continueQuarantinedRaceDescendantFamilies(
-	t *testing.T,
-	testInfo *commonInfo,
-	execMeta *testExecutionMetadata,
-	processCtx *quarantinedRaceProcessContext,
-	lease *processRetryGroupLease,
 	cfg *processRetrySubtreeConfig,
 	attempt processRetryAttemptResult,
-	parallelBridge func() error,
 	invocations *[]quarantinedRaceInvocation,
-) (stop, failed bool) {
+	run func(*processRetrySubtreeConfig, string, int) processRetryAttemptResult,
+) (bool, *quarantinedRaceContinuationFailure) {
 	for _, result := range directQuarantinedRaceAttemptOwners(attempt.Result.Subtests, cfg.SelectedRoot) {
 		continuationCfg, err := cfg.forSelectedRoot(result)
 		if err != nil {
-			failQuarantinedRaceIsolation(t, testInfo, execMeta, processRetryAttemptResult{SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: time.Now(), FinishTime: time.Now()})
-			return false, true
+			now := time.Now()
+			return false, &quarantinedRaceContinuationFailure{result: result, attempt: processRetryAttemptResult{
+				SetupFailure: true, Err: err, ExitCode: processRetryExitCodeUnset, StartTime: now, FinishTime: now,
+			}}
 		}
-		if stop, failed := continueQuarantinedRaceDescendantFamilies(
-			t, testInfo, execMeta, processCtx, lease, continuationCfg, attempt, parallelBridge, invocations,
-		); stop || failed {
-			return stop, failed
+		if stop, failure := continueQuarantinedRaceDescendantFamilies(
+			continuationCfg, attempt, invocations, run,
+		); stop || failure != nil {
+			return stop, failure
 		}
 		runRoot := continuationCfg.SelectedRoot
 		if result.Parallel {
@@ -1402,25 +1412,24 @@ func continueQuarantinedRaceDescendantFamilies(
 			runRoot = cfg.SelectedRoot
 		}
 		for idx := 1; idx < processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries); idx++ {
-			next := runQuarantinedRaceInvocation(t, processCtx, lease, continuationCfg, runRoot, idx, parallelBridge)
-			if processRetryInfrastructureFailure(next) {
-				failQuarantinedRaceIsolation(t, processRetryCommonInfoFromSubtreeResult(result), execMeta, next)
-				return false, true
-			}
+			next := run(continuationCfg, runRoot, idx)
 			*invocations = append(*invocations, quarantinedRaceInvocation{
 				cfg: continuationCfg, attempt: next, attemptIndex: idx,
 			})
-			if quarantinedRaceFailfastStopsContinuation(next) {
-				return true, false
+			if processRetryInfrastructureFailure(next) {
+				return false, &quarantinedRaceContinuationFailure{result: result, attempt: next}
 			}
-			if stop, failed := continueQuarantinedRaceDescendantFamilies(
-				t, testInfo, execMeta, processCtx, lease, continuationCfg, next, parallelBridge, invocations,
-			); stop || failed {
-				return stop, failed
+			if quarantinedRaceFailfastStopsContinuation(next) {
+				return true, nil
+			}
+			if stop, failure := continueQuarantinedRaceDescendantFamilies(
+				continuationCfg, next, invocations, run,
+			); stop || failure != nil {
+				return stop, failure
 			}
 		}
 	}
-	return false, false
+	return false, nil
 }
 
 func directQuarantinedRaceAttemptOwners(results []processRetrySubtreeResult, root string) []processRetrySubtreeResult {
@@ -1499,6 +1508,10 @@ func runQuarantinedRaceInvocation(
 		lease.shutdown,
 		parallelBridge,
 	)
+	return finalizeQuarantinedRaceInvocation(cfg, attempt)
+}
+
+func finalizeQuarantinedRaceInvocation(cfg *processRetrySubtreeConfig, attempt processRetryAttemptResult) processRetryAttemptResult {
 	defer func() {
 		if attempt.Cleanup != nil {
 			attempt.Cleanup()
@@ -1573,15 +1586,18 @@ func (cfg *processRetrySubtreeConfig) forSelectedRoot(result processRetrySubtree
 		Disabled: result.Disabled, Quarantined: result.Quarantined, AttemptToFix: result.AttemptToFix, Modified: result.Modified,
 	}
 	next := &processRetrySubtreeConfig{
-		Version:              processRetrySubtreeVersion,
-		SelectedRoot:         result.TestName,
-		Root:                 directive,
-		AttemptToFixRetries:  cfg.AttemptToFixRetries,
-		OwnsAttemptToFix:     result.AttemptToFixOwn,
-		CollectPerTest:       cfg.CollectPerTest,
-		CollectAggregate:     cfg.CollectAggregate,
-		ITRCoverageActive:    cfg.ITRCoverageActive,
-		ImpactedTestsEnabled: cfg.ImpactedTestsEnabled,
+		Version:             processRetrySubtreeVersion,
+		SelectedRoot:        result.TestName,
+		Root:                directive,
+		AttemptToFixRetries: cfg.AttemptToFixRetries,
+		OwnsAttemptToFix:    result.AttemptToFixOwn,
+		// This family was discovered inside an already isolated subtree. Keep
+		// that provenance explicit: the owner need not itself be quarantined.
+		DescendantContinuation: true,
+		CollectPerTest:         cfg.CollectPerTest,
+		CollectAggregate:       cfg.CollectAggregate,
+		ITRCoverageActive:      cfg.ITRCoverageActive,
+		ImpactedTestsEnabled:   cfg.ImpactedTestsEnabled,
 	}
 	for _, candidate := range cfg.Directives {
 		if candidate.TestName != result.TestName && processRetryNameWithinRoot(candidate.TestName, result.TestName) {
@@ -1604,7 +1620,7 @@ func replayQuarantinedRaceResults(
 	testInfo *commonInfo,
 	processCtx *quarantinedRaceProcessContext,
 	invocations []quarantinedRaceInvocation,
-	includeRoot bool,
+	includeTopLevelRoot bool,
 ) {
 	if testInfo == nil {
 		return
@@ -1640,7 +1656,7 @@ func replayQuarantinedRaceResults(
 		for idx, result := range invocation.attempt.Result.Subtests {
 			appendEvent(invocation, processRetrySubtreeResultWithInvocationOutput(invocation, result, resolved[idx]), resolved[idx])
 		}
-		if includeRoot {
+		if includeTopLevelRoot || invocation.cfg.SelectedRoot != testInfo.testName {
 			appendEvent(invocation, processRetrySubtreeRootFromInvocation(invocation), invocation.cfg.resolvedRootDirective())
 		}
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -397,6 +397,8 @@ type quarantinedRaceChildState struct {
 	impacted        *impactedtests.ImpactedTestAnalyzer
 	aggregateOnce   sync.Once
 	beginAggregate  func()
+	aggregateFinish sync.Once
+	finishAggregate func()
 	parallelBridge  func() error
 	parallelOnce    sync.Once
 	parallelStarted atomic.Bool
@@ -420,6 +422,13 @@ func (s *quarantinedRaceChildState) beginAggregateCoverage(name string) {
 		return
 	}
 	s.aggregateOnce.Do(s.beginAggregate)
+}
+
+func (s *quarantinedRaceChildState) finishAggregateCoverage(name string) {
+	if s == nil || s.cfg == nil || name != s.cfg.SelectedRoot || s.finishAggregate == nil {
+		return
+	}
+	s.aggregateFinish.Do(s.finishAggregate)
 }
 
 func (s *quarantinedRaceChildState) append(result processRetrySubtreeResult) {
@@ -636,6 +645,7 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 			// The parent replays this recorded panic. Re-panicking here would let
 			// testing terminate the child before it can write the subtree result.
 		}
+		state.finishAggregateCoverage(name)
 
 		if coverageLocked {
 			defer parent.processRetryCoverageMu.Unlock()
@@ -950,7 +960,8 @@ func runQuarantinedRaceProcessIsolation(
 		rootTotal = processRetryAttemptToFixExecutionCount(cfg.AttemptToFixRetries)
 	}
 	invocations := make([]quarantinedRaceInvocation, 0, rootTotal)
-	failfastStopped := false
+
+attempts:
 	for idx := 0; idx < rootTotal; idx++ {
 		attempt := runQuarantinedRaceInvocation(t, processCtx, lease, cfg, idx, parallelBridge)
 		if processRetryInfrastructureFailure(attempt) {
@@ -962,14 +973,14 @@ func runQuarantinedRaceProcessIsolation(
 		})
 		if quarantinedRaceFailfastStopsContinuation(attempt) {
 			invocations[len(invocations)-1].finalBecauseOfFailfast = true
-			failfastStopped = true
 			break
 		}
-	}
-
-	if !cfg.OwnsAttemptToFix && cfg.AttemptToFixRetries > 0 && !failfastStopped {
-	descendantRetries:
-		for _, result := range invocations[0].attempt.Result.Subtests {
+		if cfg.AttemptToFixRetries <= 0 {
+			continue
+		}
+		// Continue independently owned descendant families inside every
+		// enclosing root execution, not as part of the root's retry sequence.
+		for _, result := range attempt.Result.Subtests {
 			if !result.AttemptToFixOwn {
 				continue
 			}
@@ -994,7 +1005,7 @@ func runQuarantinedRaceProcessIsolation(
 				})
 				if quarantinedRaceFailfastStopsContinuation(attempt) {
 					invocations[len(invocations)-1].finalBecauseOfFailfast = true
-					break descendantRetries
+					break attempts
 				}
 			}
 		}
@@ -1177,6 +1188,13 @@ func replayQuarantinedRaceEvent(
 	_, attemptOwner := invocation.cfg.resolveDirective(result.TestName)
 	ownsAttemptToFix := attemptOwner == result.TestName
 	prior := outcomes[result.TestName]
+	attemptIndex := invocation.attemptIndex
+	if attemptOwner != "" && attemptOwner != invocation.cfg.SelectedRoot {
+		// A descendant that cleared an inherited directive and started its own
+		// family is on its first execution in this enclosing invocation.
+		prior = retryOutcomeAccumulator{}
+		attemptIndex = 0
+	}
 	execMeta := &testExecutionMetadata{
 		identity:                      identity,
 		isQuarantined:                 result.Quarantined,
@@ -1194,9 +1212,9 @@ func replayQuarantinedRaceEvent(
 	}
 	if attemptOwner != "" {
 		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
-		execMeta.isARetry = invocation.attemptIndex > 0
-		execMeta.isLastRetry = invocation.finalBecauseOfFailfast || invocation.attemptIndex == attemptTotal-1
-		execMeta.remainingRetries = int64(attemptTotal - invocation.attemptIndex)
+		execMeta.isARetry = attemptIndex > 0
+		execMeta.isLastRetry = invocation.finalBecauseOfFailfast || attemptIndex == attemptTotal-1
+		execMeta.remainingRetries = int64(attemptTotal - attemptIndex)
 		execMeta.initialRetryCount = int64(invocation.cfg.AttemptToFixRetries)
 		execMeta.initialRetryCountSet = true
 		execMeta.retryContinuationDecided = true

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -399,6 +399,7 @@ type quarantinedRaceChildState struct {
 	beginAggregate  func()
 	aggregateFinish sync.Once
 	finishAggregate func()
+	pauseAggregate  func() func()
 	parallelBridge  func() error
 	parallelOnce    sync.Once
 	parallelStarted atomic.Bool
@@ -651,6 +652,12 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 	execMeta.processRetryParallelPause = func() func() {
 		activeDuration += time.Since(activeStart)
 		activeStart = time.Time{}
+		// A nested selected root releases its discovery ancestor in Parallel.
+		// Exclude that ancestor's work from this root's aggregate profile.
+		var resumeAggregate func()
+		if name == state.cfg.SelectedRoot && state.pauseAggregate != nil {
+			resumeAggregate = state.pauseAggregate()
+		}
 		if collector != nil {
 			collector.Pause()
 		}
@@ -658,6 +665,9 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 		coverageInterval = nil
 		return func() {
 			activeStart = time.Now()
+			if resumeAggregate != nil {
+				resumeAggregate()
+			}
 			if collectCoverage {
 				coverageInterval = state.coverage.begin(name)
 			}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -853,6 +853,8 @@ type quarantinedRaceInvocation struct {
 	cfg          *processRetrySubtreeConfig
 	attempt      processRetryAttemptResult
 	attemptIndex int
+
+	finalBecauseOfFailfast bool
 }
 
 // runQuarantinedRaceProcessIsolation replaces only the selected quarantined
@@ -928,6 +930,7 @@ func runQuarantinedRaceProcessIsolation(
 			cfg: cfg, attempt: attempt, attemptIndex: idx,
 		})
 		if quarantinedRaceFailfastStopsContinuation(attempt) {
+			invocations[len(invocations)-1].finalBecauseOfFailfast = true
 			failfastStopped = true
 			break
 		}
@@ -959,6 +962,7 @@ func runQuarantinedRaceProcessIsolation(
 					cfg: continuationCfg, attempt: attempt, attemptIndex: idx,
 				})
 				if quarantinedRaceFailfastStopsContinuation(attempt) {
+					invocations[len(invocations)-1].finalBecauseOfFailfast = true
 					break descendantRetries
 				}
 			}
@@ -1163,7 +1167,7 @@ func replayQuarantinedRaceEvent(
 	if ownsAttemptToFix {
 		attemptTotal := processRetryAttemptToFixExecutionCount(invocation.cfg.AttemptToFixRetries)
 		execMeta.isARetry = invocation.attemptIndex > 0
-		execMeta.isLastRetry = invocation.attemptIndex == attemptTotal-1
+		execMeta.isLastRetry = invocation.finalBecauseOfFailfast || invocation.attemptIndex == attemptTotal-1
 		execMeta.remainingRetries = int64(attemptTotal - invocation.attemptIndex)
 		execMeta.initialRetryCount = int64(invocation.cfg.AttemptToFixRetries)
 		execMeta.initialRetryCountSet = true

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -703,6 +703,11 @@ func runQuarantinedRaceChildSubtest(t *testing.T, original func(*testing.T), par
 }
 
 func processRetrySubtreeRaceDetected(fields *commonPrivateFields, initialBaseline, current int64) bool {
+	if fields != nil && fields.raceErrorLogged != nil && fields.raceErrorLogged.Load() {
+		// Parallel checks and records races before replacing lastRaceErrors with
+		// its post-resume baseline. Keep that already-attributed race.
+		return true
+	}
 	baseline := initialBaseline
 	if fields != nil && fields.isParallel != nil && *fields.isParallel && fields.lastRaceErrors != nil {
 		// testing.T.Parallel resets this baseline after the test resumes so races

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -34,7 +34,6 @@ const (
 	processRetrySubtreeReason         = "quarantined_race"
 	processRetrySubtreeMaxDirectives  = 4 * 1024
 	processRetrySubtreeMaxResults     = 4 * 1024
-	processRetrySubtreeResultMaxBytes = 16 * 1024 * 1024
 	processRetrySubtreeOutputMaxBytes = 8 * 1024
 	processRetrySubtreeWireMaxBytes   = 16 * 1024 * 1024
 )

--- a/internal/civisibility/integrations/gotesting/quarantine_process_norace_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_norace_test.go
@@ -1,0 +1,22 @@
+//go:build !race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import "testing"
+
+func quarantinedRaceIsolationFixtureSelected() bool { return false }
+
+func runQuarantinedRaceIsolationFixture(*testing.M) {
+	panic("quarantined race isolation fixture requires a race-enabled binary")
+}
+
+func TestQuarantinedRaceProcessRequiresRaceBuild(t *testing.T) {
+	if quarantinedRaceProcessSupported() {
+		t.Fatal("quarantined race process isolation must be disabled without -race")
+	}
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -115,6 +115,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastRootFixture":              properties(true),
 					"TestQuarantinedRaceFailfastDescendantFixture":        properties(false),
 					"TestQuarantinedRaceFailfastDescendantFixture/child":  properties(true),
+					"TestQuarantinedRaceFailfastMaskedChildFixture":       properties(true),
+					"TestQuarantinedRaceFailfastMaskedChildFixture/child": properties(false),
 					"TestQuarantinedRaceParallelFixture/isolated":         properties(false),
 					"TestQuarantinedRaceParallelRootsFixture/one":         properties(false),
 					"TestQuarantinedRaceParallelRootsFixture/two":         properties(false),
@@ -135,6 +137,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceOwnerGenerationFixture/root/clear/owner": properties(true),
 					"TestQuarantinedRaceParallelATFFixture/root":                 properties(false),
 					"TestQuarantinedRaceParallelATFFixture/root/owner":           properties(true),
+					"TestQuarantinedRaceSerialATFFixture/root":                   properties(false),
+					"TestQuarantinedRaceSerialATFFixture/root/owner":             properties(true),
+					"TestQuarantinedRaceForeignSuiteFixture/root":                properties(false),
 
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
@@ -345,6 +350,20 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(owner, constants.TestAttemptToFixPassed, "true", 1)
 		checkSpansByTagValue(owner, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		os.Exit(0)
+	case "serial-atf-sibling":
+		payload, err := os.ReadFile(filepath.Join(pidDir, "serial-atf-sibling-runs"))
+		if err != nil || len(payload) != 1 {
+			panic(fmt.Sprintf("serial sibling ran %d times, want 1: %v", len(payload), err))
+		}
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceSerialATFFixture/root/owner", 2)
+		checkSpansByTagValue(owner, constants.TestAttemptToFixPassed, "true", 1)
+		checkSpansByTagValue(owner, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		os.Exit(0)
+	case "foreign-suite":
+		foreignSuite := "quarantine_process_test.go"
+		foreign := checkSpansByResourceName(spans, foreignSuite+".TestQuarantinedRaceForeignSuiteFixture/root/foreign", 1)
+		checkSpansByTagValue(foreign, constants.TestStatus, constants.TestStatusPass, 1)
+		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
 		checkSpansByTagValue(parallelRoot, constants.TestStatus, constants.TestStatusFail, 1)
@@ -429,7 +448,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(failNowSpans, constants.TestStatus, constants.TestStatusFail, 1)
 		os.Exit(0)
 	case "failfast":
-		for _, name := range []string{"failfast-root-3", "failfast-descendant-2", "failfast-descendant-3"} {
+		for _, name := range []string{
+			"failfast-root-3",
+			"failfast-descendant-2", "failfast-descendant-3",
+			"failfast-masked-root-2", "failfast-masked-root-3",
+		} {
 			if _, err := os.Stat(filepath.Join(pidDir, name)); err == nil || !os.IsNotExist(err) {
 				panic(name + " ran after a valid failure under -failfast")
 			}
@@ -437,6 +460,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		readPID("failfast-root-1")
 		readPID("failfast-root-2")
 		readPID("failfast-descendant-1")
+		readPID("failfast-masked-root-1")
 		rootSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastRootFixture", 2)
 		checkSpansByTagValue(rootSpans, constants.TestIsRetry, "true", 1)
 		checkSpansByTagValue(rootSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
@@ -446,6 +470,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(descendantSpans, constants.TestIsRetry, "true", 0)
 		checkSpansByTagValue(descendantSpans, constants.TestAttemptToFixPassed, "false", 0)
 		checkSpansByTagValue(descendantSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		maskedChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastMaskedChildFixture/child", 1)
+		checkSpansByTagValue(maskedChild, constants.TestStatus, constants.TestStatusFail, 1)
 		os.Exit(0)
 	}
 	racePID := readPID("race")
@@ -583,7 +609,7 @@ func TestQuarantinedRaceCleanupEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "failfast", "^TestQuarantinedRaceFailfast(Root|Descendant)Fixture$", "-test.failfast")
+	runQuarantinedRaceEndToEnd(t, "failfast", "^TestQuarantinedRaceFailfast(Root|Descendant|MaskedChild)Fixture$", "-test.failfast")
 }
 
 func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
@@ -669,6 +695,14 @@ func TestQuarantinedRaceOwnerGenerationFinalityEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceParallelATFSiblingEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-atf-sibling", "^TestQuarantinedRaceParallelATFFixture$", "-test.timeout=15s")
+}
+
+func TestQuarantinedRaceSerialATFDoesNotRepeatSiblingEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "serial-atf-sibling", "^TestQuarantinedRaceSerialATFFixture$")
+}
+
+func TestQuarantinedRacePreservesDescendantSuiteEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "foreign-suite", "^TestQuarantinedRaceForeignSuiteFixture$")
 }
 
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
@@ -1282,5 +1316,43 @@ func TestQuarantinedRaceFailfastDescendantFixture(t *testing.T) {
 		require.NoError(t, err)
 		writeQuarantinedRaceIsolationPID(t, "failfast-descendant-"+strconv.Itoa(cfg.Attempt))
 		t.Fail()
+	}))
+}
+
+func TestQuarantinedRaceFailfastMaskedChildFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	writeQuarantinedRaceIsolationPID(t, "failfast-masked-root-"+strconv.Itoa(cfg.Attempt))
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		t.Fail()
+	}))
+}
+
+func TestQuarantinedRaceSerialATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("sibling", instrumentTestingTFunc(func(t *testing.T) {
+			path := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "serial-atf-sibling-runs")
+			file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+			require.NoError(t, err)
+			_, err = file.WriteString("x")
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+		}))
+		t.Run("owner", instrumentTestingTFunc(func(*testing.T) {}))
+	}))
+}
+
+func TestQuarantinedRaceForeignSuiteFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("foreign", instrumentTestingTFunc(quarantinedRaceForeignSuiteCallback))
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -1,0 +1,307 @@
+//go:build race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	quarantinedRaceIsolationFixtureEnv = "DD_TEST_QUARANTINED_RACE_ISOLATION"
+	quarantinedRaceIsolationPIDDirEnv  = "DD_TEST_QUARANTINED_RACE_ISOLATION_PID_DIR"
+)
+
+func quarantinedRaceIsolationFixtureSelected() bool {
+	return os.Getenv(quarantinedRaceIsolationFixtureEnv) == "true"
+}
+
+func runQuarantinedRaceIsolationFixture(m *testing.M) {
+	// A process child must enter the existing no-op CI Visibility bootstrap
+	// directly. It never creates a session, fetches settings, or starts retries.
+	if isProcessRetryChild() {
+		os.Exit(RunM(m))
+	}
+	requireEnv := func(key, value string) {
+		if err := os.Setenv(key, value); err != nil {
+			panic(err)
+		}
+	}
+	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
+	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, "1")
+
+	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
+	suite := "quarantine_process_race_test.go"
+	properties := func(attemptToFix bool) net.TestManagementTestsResponseDataTestProperties {
+		return net.TestManagementTestsResponseDataTestProperties{
+			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
+				Quarantined: true, AttemptToFix: attemptToFix,
+			},
+		}
+	}
+	server := setUpHTTPServer(false, false, false, nil, false, nil, true,
+		&net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
+			module: {Suites: map[string]net.TestManagementTestsResponseDataTests{
+				suite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+					"TestQuarantinedRaceFixture":                    properties(false),
+					"TestQuarantinedPanicFixture":                   properties(false),
+					"TestQuarantinedRaceSecondFixture":              properties(false),
+					"TestQuarantinedRaceAttemptToFixFixture":        properties(true),
+					"TestQuarantinedRaceNestedFixture/card":         properties(false),
+					"TestQuarantinedRaceNestedATFFixture/card":      properties(false),
+					"TestQuarantinedRaceNestedATFFixture/card/visa": properties(true),
+				}},
+			}},
+		}}, false, nil)
+	defer server.Close()
+
+	currentM = m
+	mTracer = integrations.InitializeCIVisibilityMock()
+	exitCode := RunM(m)
+	if exitCode != 0 {
+		panic(fmt.Sprintf("quarantined race isolation fixture exit code = %d", exitCode))
+	}
+
+	pidDir := os.Getenv(quarantinedRaceIsolationPIDDirEnv)
+	parentPID := strconv.Itoa(os.Getpid())
+	readPID := func(name string) string {
+		payload, err := os.ReadFile(filepath.Join(pidDir, name))
+		if err != nil {
+			panic(err)
+		}
+		return strings.TrimSpace(string(payload))
+	}
+	racePID := readPID("race")
+	secondPID := readPID("second")
+	panicPID := readPID("panic")
+	if racePID == parentPID || secondPID == parentPID || panicPID == parentPID ||
+		racePID == secondPID || racePID == panicPID || secondPID == panicPID {
+		panic("quarantined roots did not use distinct child processes")
+	}
+	cardPID := readPID("card")
+	if cardPID == parentPID || readPID("visa") != cardPID || readPID("mastercard") != cardPID || readPID("skipped") != cardPID {
+		panic("quarantined subtree did not stay in one child process")
+	}
+	if readPID("paypal") != parentPID {
+		panic("non-quarantined sibling did not stay in the parent process")
+	}
+	atf0, atf1 := readPID("atf-1"), readPID("atf-2")
+	if atf0 == parentPID || atf1 == parentPID || atf0 == atf1 {
+		panic("attempt-to-fix executions did not use fresh child processes")
+	}
+	nestedATF0, nestedATF1 := readPID("nested-atf-visa-1"), readPID("nested-atf-visa-2")
+	if nestedATF0 == parentPID || nestedATF1 == parentPID || nestedATF0 == nestedATF1 {
+		panic("descendant attempt-to-fix executions did not use fresh child processes")
+	}
+
+	spans := mTracer.FinishedSpans()
+	spanTypes := map[string]int{}
+	for _, span := range spans {
+		if spanType, ok := span.Tag(ext.SpanType).(string); ok {
+			spanTypes[spanType]++
+		}
+	}
+	if spanTypes[constants.SpanTypeTestSession] != 1 || spanTypes[constants.SpanTypeTestModule] != 1 ||
+		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 17 {
+		panic(fmt.Sprintf("unexpected parent-owned CI Visibility span counts: %#v", spanTypes))
+	}
+	raceSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFixture", 1)
+	checkSpansByTagValue(raceSpans, constants.TestStatus, constants.TestStatusFail, 1)
+	checkSpansByTagValue(raceSpans, constants.TestIsQuarantined, "true", 1)
+	checkSpansByTagValue(raceSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	panicSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedPanicFixture", 1)
+	checkSpansByTagValue(panicSpans, constants.TestStatus, constants.TestStatusFail, 1)
+	checkSpansByTagValue(panicSpans, constants.TestIsQuarantined, "true", 1)
+	checkSpansByTagValue(panicSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	atfSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAttemptToFixFixture", 2)
+	checkSpansByTagValue(atfSpans, constants.TestIsAttempToFix, "true", 2)
+	checkSpansByTagValue(atfSpans, constants.TestIsRetry, "true", 1)
+	checkSpansByTagValue(atfSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+	checkSpansByTagValue(atfSpans, constants.TestAttemptToFixPassed, "true", 1)
+	checkSpansByTagValue(atfSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	atfChildSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAttemptToFixFixture/child", 2)
+	checkSpansByTagValue(atfChildSpans, constants.TestIsAttempToFix, "true", 2)
+	checkSpansByTagValue(atfChildSpans, constants.TestIsRetry, "true", 1)
+	nestedATFSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedATFFixture/card/visa", 2)
+	checkSpansByTagValue(nestedATFSpans, constants.TestIsAttempToFix, "true", 2)
+	checkSpansByTagValue(nestedATFSpans, constants.TestIsRetry, "true", 1)
+	checkSpansByTagValue(nestedATFSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+	checkSpansByTagValue(nestedATFSpans, constants.TestAttemptToFixPassed, "true", 1)
+	checkSpansByTagValue(nestedATFSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+	checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedATFFixture/card", 1)
+	for _, name := range []string{
+		"TestQuarantinedRaceNestedFixture/card",
+		"TestQuarantinedRaceNestedFixture/card/visa",
+		"TestQuarantinedRaceNestedFixture/card/mastercard",
+		"TestQuarantinedRaceNestedFixture/card/skipped",
+	} {
+		childSpans := checkSpansByResourceName(spans, suite+"."+name, 1)
+		checkSpansByTagValue(childSpans, constants.TestIsQuarantined, "true", 1)
+	}
+	skippedSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/skipped", 1)
+	checkSpansByTagValue(skippedSpans, constants.TestStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagValue(skippedSpans, constants.TestSkipReason, "fixture skip", 1)
+	visaSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/visa", 1)
+	checkSpansByTagName(visaSpans, constants.TestSourceFile, 1)
+	checkSpansByTagName(visaSpans, constants.TestSourceStartLine, 1)
+	checkSpansByTagName(visaSpans, constants.TestSourceEndLine, 1)
+	checkSpansByTagName(visaSpans, constants.TestCodeOwners, 1)
+	os.Exit(0)
+}
+
+func TestQuarantinedRaceProcessEndToEnd(t *testing.T) {
+	pidDir := t.TempDir()
+	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(os.Args[1:], "^TestQuarantined(Race(Fixture|SecondFixture|AttemptToFixFixture|NestedFixture|NestedATFFixture)|PanicFixture)$")...)
+	cmd.Env = append(os.Environ(),
+		quarantinedRaceIsolationFixtureEnv+"=true",
+		quarantinedRaceIsolationPIDDirEnv+"="+pidDir,
+	)
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("quarantined race isolation fixture failed: %v\n%s", err, output.String())
+	}
+	if coverProfile := flag.Lookup("test.coverprofile"); coverProfile != nil && coverProfile.Value.String() != "" {
+		requireFunctionCovered(t, coverProfile.Value.String(), "bufferQuarantinedRaceChildOutput")
+	}
+}
+
+func requireFunctionCovered(t *testing.T, profilePath, functionName string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, "quarantine_process.go", nil, 0)
+	require.NoError(t, err)
+	start, finish := 0, 0
+	for _, declaration := range parsed.Decls {
+		if fn, ok := declaration.(*ast.FuncDecl); ok && fn.Name.Name == functionName {
+			start = fset.Position(fn.Pos()).Line
+			finish = fset.Position(fn.End()).Line
+			break
+		}
+	}
+	require.NotZero(t, start)
+	profile, err := os.ReadFile(profilePath)
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(profile), "\n") {
+		separator := strings.LastIndexByte(line, ':')
+		if separator < 0 || !strings.HasSuffix(filepath.ToSlash(line[:separator]), "/gotesting/quarantine_process.go") {
+			continue
+		}
+		var startLine, startColumn, endLine, endColumn, statements, count int
+		if _, err := fmt.Sscanf(line[separator+1:], "%d.%d,%d.%d %d %d", &startLine, &startColumn, &endLine, &endColumn, &statements, &count); err == nil &&
+			startLine <= finish && endLine >= start && count > 0 {
+			return
+		}
+	}
+	t.Fatalf("%s has no covered block in merged profile %s", functionName, profilePath)
+}
+
+func writeQuarantinedRaceIsolationPID(t *testing.T, name string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), name)
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600))
+}
+
+func TestQuarantinedRaceFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	writeQuarantinedRaceIsolationPID(t, "race")
+	var value int
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				value++
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestQuarantinedRaceSecondFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	writeQuarantinedRaceIsolationPID(t, "second")
+}
+
+func TestQuarantinedPanicFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	writeQuarantinedRaceIsolationPID(t, "panic")
+	panic("quarantined panic")
+}
+
+func TestQuarantinedRaceAttemptToFixFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	writeQuarantinedRaceIsolationPID(t, "atf-"+strconv.Itoa(cfg.Attempt))
+	t.Run("child", instrumentTestingTFunc(func(*testing.T) {}))
+}
+
+func TestQuarantinedRaceNestedFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("card", instrumentTestingTFunc(func(t *testing.T) {
+		writeQuarantinedRaceIsolationPID(t, "card")
+		t.Run("visa", instrumentTestingTFunc(func(t *testing.T) {
+			t.Parallel()
+			writeQuarantinedRaceIsolationPID(t, "visa")
+		}))
+		t.Run("mastercard", instrumentTestingTFunc(func(t *testing.T) {
+			t.Parallel()
+			writeQuarantinedRaceIsolationPID(t, "mastercard")
+		}))
+		t.Run("skipped", instrumentTestingTFunc(func(t *testing.T) {
+			writeQuarantinedRaceIsolationPID(t, "skipped")
+			instrumentCaptureFormattedSkip(t, "Skip", "fixture skip\n")
+			t.Skip("fixture skip")
+		}))
+	}))
+	t.Run("paypal", instrumentTestingTFunc(func(t *testing.T) {
+		writeQuarantinedRaceIsolationPID(t, "paypal")
+	}))
+}
+
+func TestQuarantinedRaceNestedATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("card", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("visa", instrumentTestingTFunc(func(t *testing.T) {
+			cfg, err := processRetryChildConfigFromEnv()
+			require.NoError(t, err)
+			writeQuarantinedRaceIsolationPID(t, "nested-atf-visa-"+strconv.Itoa(cfg.Attempt))
+		}))
+	}))
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -86,6 +86,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceIndependentATFFixture":             properties(true),
 					"TestQuarantinedRaceIndependentATFFixture/clear":       properties(false),
 					"TestQuarantinedRaceIndependentATFFixture/clear/owner": properties(true),
+					"TestQuarantinedRaceDeepFixture":                       properties(true),
+					"TestQuarantinedRaceDeepFixture/clear":                 properties(false),
+					"TestQuarantinedRaceDeepFixture/clear/owner":           properties(true),
+					"TestQuarantinedRaceDeepFixture/clear/owner/none":      properties(false),
+					"TestQuarantinedRaceDeepFixture/clear/owner/none/deep": properties(true),
 					"TestQuarantinedRaceLeafFixture/card/visa":             properties(false),
 					"TestQuarantinedRaceNestedFixture/card":                properties(false),
 					"TestQuarantinedRaceNestedFixture/card/disabled": {
@@ -105,6 +110,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
 					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
+					"TestQuarantinedRaceParallelDurationFixture/isolated":    properties(false),
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
@@ -163,6 +169,30 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(ownerSpans, constants.TestAttemptToFixPassed, "true", 2)
 		checkSpansByTagValue(ownerSpans, constants.TestFinalStatus, constants.TestStatusSkip, 2)
 		os.Exit(0)
+	case "deep-nested-attempt-family":
+		pids := map[string]struct{}{}
+		entries, err := os.ReadDir(pidDir)
+		if err != nil {
+			panic(err)
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "deep-nested-attempt-leaf-") {
+				pids[readPID(entry.Name())] = struct{}{}
+			}
+		}
+		delete(pids, parentPID)
+		if len(pids) != 8 {
+			panic(fmt.Sprintf("deep nested attempt family used %d fresh child processes, want 8", len(pids)))
+		}
+		ownerSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeepFixture/clear/owner", 4)
+		checkSpansByTagValue(ownerSpans, constants.TestIsRetry, "true", 2)
+		checkSpansByTagValue(ownerSpans, constants.TestAttemptToFixPassed, "true", 2)
+		leafSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeepFixture/clear/owner/none/deep", 8)
+		checkSpansByTagValue(leafSpans, constants.TestIsRetry, "true", 4)
+		checkSpansByTagValue(leafSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 4)
+		checkSpansByTagValue(leafSpans, constants.TestAttemptToFixPassed, "true", 4)
+		checkSpansByTagValue(leafSpans, constants.TestFinalStatus, constants.TestStatusSkip, 4)
+		os.Exit(0)
 	case "nested-aggregate-coverage", "nested-aggregate-coverage-control":
 		os.Exit(0)
 	case "parallel-admission":
@@ -176,14 +206,20 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		if readPID("parallel-coverage-child") == parentPID {
 			panic("covered parallel descendant did not run in the isolated child")
 		}
-		if readPID("parallel-coverage-maximum") != "1" {
-			panic("covered parallel descendants were not serialized")
+		if readPID("parallel-coverage-maximum") != "2" {
+			panic("covered parallel descendants did not run concurrently")
 		}
 		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelCoverageFixture/isolated", 1)
 		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
 		for _, name := range []string{"concurrent-a", "concurrent-b"} {
 			childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelCoverageFixture/isolated/"+name, 1)
 			checkSpansByTagValue(childSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		}
+		os.Exit(0)
+	case "parallel-duration":
+		childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelDurationFixture/isolated/suspended", 1)
+		if got := childSpans[0].Duration(); got >= 250*time.Millisecond {
+			panic(fmt.Sprintf("parallel suspension leaked into replayed duration: %s", got))
 		}
 		os.Exit(0)
 	case "terminal-descendants":
@@ -453,6 +489,14 @@ func TestQuarantinedRaceNestedAttemptFamilyEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "nested-attempt-family", "^TestQuarantinedRaceIndependentATFFixture$")
 }
 
+func TestQuarantinedRaceDeepNestedAttemptFamilyEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "deep-nested-attempt-family", "^TestQuarantinedRaceDeepFixture$")
+}
+
+func TestQuarantinedRaceParallelDurationEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-duration", "^TestQuarantinedRaceParallelDurationFixture$")
+}
+
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "terminal-descendants", "^TestQuarantinedRaceTerminalDescendantsFixture$")
 }
@@ -597,6 +641,21 @@ func TestQuarantinedRaceIndependentATFFixture(t *testing.T) {
 	}))
 }
 
+func TestQuarantinedRaceDeepFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("clear", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+			t.Run("none", instrumentTestingTFunc(func(t *testing.T) {
+				t.Run("deep", instrumentTestingTFunc(func(t *testing.T) {
+					writeQuarantinedRaceIsolationPID(t, "deep-nested-attempt-leaf-"+strconv.Itoa(os.Getpid()))
+				}))
+			}))
+		}))
+	}))
+}
+
 func TestQuarantinedRaceLeafFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
@@ -677,6 +736,13 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("t.Parallel did not release t.Run back to its parent")
 		}
+		ready := make(chan struct{}, 2)
+		allReady := make(chan struct{})
+		go func() {
+			<-ready
+			<-ready
+			close(allReady)
+		}()
 		var active atomic.Int32
 		var maximum atomic.Int32
 		t.Cleanup(func() {
@@ -690,11 +756,28 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 				defer active.Add(-1)
 				for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
 				}
-				time.Sleep(20 * time.Millisecond)
+				ready <- struct{}{}
+				select {
+				case <-allReady:
+				case <-time.After(2 * time.Second):
+					t.Fatal("covered parallel descendants could not rendezvous")
+				}
 			}))
 		}
 	}))
 	close(released)
+}
+
+func TestQuarantinedRaceParallelDurationFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("suspended", instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+		}))
+		time.Sleep(500 * time.Millisecond)
+	}))
 }
 
 func TestQuarantinedRaceAggregateCoverageFixture(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -64,12 +64,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if scenario == "feature-gate" {
 		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
 	}
-	if scenario == "parallel-root-slots" || scenario == "parallel-root-coordination" {
-		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
-		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
-	}
 	// These fixture limits detect protocol deadlocks, not instrumentation speed:
 	// race and coverage teardown can legitimately take several seconds in CI.
+	if scenario == "parallel-root-slots" || scenario == "parallel-root-coordination" {
+		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
+	}
 	if scenario == "parallel-atf-sibling" {
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
 	}

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -193,7 +193,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(leafSpans, constants.TestAttemptToFixPassed, "true", 4)
 		checkSpansByTagValue(leafSpans, constants.TestFinalStatus, constants.TestStatusSkip, 4)
 		os.Exit(0)
-	case "nested-aggregate-coverage", "nested-aggregate-coverage-control":
+	case "nested-aggregate-coverage", "nested-aggregate-parallel-coverage", "nested-aggregate-coverage-control":
 		os.Exit(0)
 	case "parallel-admission":
 		if readPID("parallel-child") == parentPID || readPID("parallel-sibling") != parentPID {
@@ -482,7 +482,13 @@ func TestQuarantinedRaceNestedAggregateCoverageEndToEnd(t *testing.T) {
 	profilePath := filepath.Join(t.TempDir(), "coverage.out")
 	runQuarantinedRaceEndToEnd(t, "nested-aggregate-coverage", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+profilePath)
 	controlCount := processCoverageCountForFunction(t, controlPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
-	require.Equal(t, controlCount+1, processCoverageCountForFunction(t, profilePath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount"))
+	serialCount := processCoverageCountForFunction(t, profilePath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
+	require.Equal(t, controlCount+1, serialCount)
+	// The nested subprocesses share Go's outer coverage directory, so compare
+	// successive profiles to assert that each scenario merges the marker once.
+	parallelPath := filepath.Join(t.TempDir(), "parallel.out")
+	runQuarantinedRaceEndToEnd(t, "nested-aggregate-parallel-coverage", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+parallelPath)
+	require.Equal(t, serialCount+1, processCoverageCountForFunction(t, parallelPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount"))
 }
 
 func TestQuarantinedRaceNestedAttemptFamilyEndToEnd(t *testing.T) {
@@ -784,8 +790,13 @@ func TestQuarantinedRaceAggregateCoverageFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
 	}
-	t.Run("isolated", instrumentTestingTFunc(func(*testing.T) {}))
-	if os.Getenv(quarantinedRaceIsolationFixtureEnv) == "nested-aggregate-coverage" {
+	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		if scenario == "nested-aggregate-parallel-coverage" {
+			(*T)(t).Parallel()
+		}
+	}))
+	if scenario == "nested-aggregate-coverage" || scenario == "nested-aggregate-parallel-coverage" {
 		quarantinedRaceAncestorCoverage.Store(int64(processRetryAttemptToFixExecutionCount(1)))
 	}
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -64,7 +64,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if scenario == "feature-gate" {
 		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
 	}
-	if scenario == "parallel-root-slots" {
+	if scenario == "parallel-root-slots" || scenario == "parallel-root-coordination" {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
 	}
@@ -275,6 +275,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
 		}
 		os.Exit(0)
+	case "parallel-root-coordination":
+		for _, name := range []string{"one", "two"} {
+			root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelRootsFixture/"+name, 1)
+			checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		}
+		os.Exit(0)
 	case "parallel-coverage":
 		if readPID("parallel-coverage-child") == parentPID {
 			panic("covered parallel descendant did not run in the isolated child")
@@ -418,9 +424,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	case "deferred-descendant-atf-failure":
 		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture", 2)
 		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 2)
-		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner", 1)
-		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusFail, 1)
-		checkSpansByTagValue(owner, constants.TestIsAttempToFix, "true", 1)
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner", 2)
+		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusFail, 2)
+		checkSpansByTagValue(owner, constants.TestIsAttempToFix, "true", 2)
+		checkSpansByTagValue(owner, constants.TestIsRetry, "true", 1)
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -682,6 +689,10 @@ func TestQuarantinedRaceParallelRootsReleaseProcessSlotsEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-root-slots", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=15s")
 }
 
+func TestQuarantinedRaceParallelRootsCoordinateAfterResumeEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-root-coordination", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=15s")
+}
+
 func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 	if testing.CoverMode() == "" {
 		t.Skip("requires coverage instrumentation")
@@ -747,7 +758,7 @@ func TestQuarantinedRaceManagedDescendantPreservesProcessOutputEndToEnd(t *testi
 	runQuarantinedRaceEndToEnd(t, "managed-descendant-output", "^TestQuarantinedRaceManagedDescendantFixture$")
 }
 
-func TestQuarantinedRaceDeferredDescendantATFFailureFailsPackageEndToEnd(t *testing.T) {
+func TestQuarantinedRaceDeferredDescendantATFFamilyCompletesAndFailsPackageEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "deferred-descendant-atf-failure", "^TestQuarantinedRaceDeferredDescendantATFFixture$")
 }
 
@@ -1009,6 +1020,22 @@ func TestQuarantinedRaceParallelRootsFixture(t *testing.T) {
 		t.Run(name, instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
 			writeQuarantinedRaceIsolationProcessPID(t, "parallel-root-"+name)
+			if os.Getenv(quarantinedRaceIsolationFixtureEnv) == "parallel-root-coordination" && isProcessRetryChild() {
+				peer := "two"
+				if name == "two" {
+					peer = "one"
+				}
+				deadline := time.Now().Add(3 * time.Second)
+				for {
+					if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "parallel-root-"+peer+"-child")); err == nil {
+						break
+					}
+					if time.Now().After(deadline) {
+						t.Fatalf("parallel root %s did not resume", peer)
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
 		}))
 	}
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -102,6 +102,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
 					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
+					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/parallel": properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
 				}},
@@ -167,6 +168,15 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(fmt.Sprintf("body panic was not reported on the isolated descendant: %q", message))
 		}
 		os.Exit(0)
+	case "race-before-parallel":
+		races := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceBeforeParallelFixture/isolated", 1)
+		checkSpansByTagValue(races, constants.TestStatus, constants.TestStatusFail, 1)
+		for _, entry := range logsEntries {
+			if entry.TestName == "TestQuarantinedRaceBeforeParallelFixture/isolated" && strings.Contains(entry.Message, "WARNING: DATA RACE") {
+				os.Exit(0)
+			}
+		}
+		panic("race before t.Parallel was not preserved in the selected root output")
 	case "testify-source":
 		if readPID("testify-source") == parentPID {
 			panic("Testify method did not run in the isolated child")
@@ -362,6 +372,10 @@ func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "terminal-descendants", "^TestQuarantinedRaceTerminalDescendantsFixture$")
+}
+
+func TestQuarantinedRaceBeforeParallelEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "race-before-parallel", "^TestQuarantinedRaceBeforeParallelFixture$")
 }
 
 func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
@@ -591,6 +605,16 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 		t.Run("child", instrumentTestingTFunc(func(*testing.T) {
 			panic("body panic sentinel")
 		}))
+	}))
+}
+
+func TestQuarantinedRaceBeforeParallelFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		triggerQuarantinedRaceFixture()
+		(*T)(t).Parallel()
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -79,12 +79,15 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		&net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
 			module: {Suites: map[string]net.TestManagementTestsResponseDataTests{
 				suite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
-					"TestQuarantinedRaceFixture":               properties(false),
-					"TestQuarantinedPanicFixture":              properties(false),
-					"TestQuarantinedRaceSecondFixture":         properties(false),
-					"TestQuarantinedRaceAttemptToFixFixture":   properties(true),
-					"TestQuarantinedRaceLeafFixture/card/visa": properties(false),
-					"TestQuarantinedRaceNestedFixture/card":    properties(false),
+					"TestQuarantinedRaceFixture":                           properties(false),
+					"TestQuarantinedPanicFixture":                          properties(false),
+					"TestQuarantinedRaceSecondFixture":                     properties(false),
+					"TestQuarantinedRaceAttemptToFixFixture":               properties(true),
+					"TestQuarantinedRaceIndependentATFFixture":             properties(true),
+					"TestQuarantinedRaceIndependentATFFixture/clear":       properties(false),
+					"TestQuarantinedRaceIndependentATFFixture/clear/owner": properties(true),
+					"TestQuarantinedRaceLeafFixture/card/visa":             properties(false),
+					"TestQuarantinedRaceNestedFixture/card":                properties(false),
 					"TestQuarantinedRaceNestedFixture/card/disabled": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
 					},
@@ -102,6 +105,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
 					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
+					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
 					"TestQuarantinedRaceAncestorFailureFixture/isolated":     properties(false),
@@ -135,6 +139,32 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	}
 	spans := mTracer.FinishedSpans()
 	switch scenario {
+	case "nested-attempt-family":
+		pids := map[string]struct{}{}
+		entries, err := os.ReadDir(pidDir)
+		if err != nil {
+			panic(err)
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "nested-attempt-owner-") {
+				pids[readPID(entry.Name())] = struct{}{}
+			}
+		}
+		if len(pids) != 4 {
+			panic(fmt.Sprintf("independent nested attempt family used %d child processes, want 4", len(pids)))
+		}
+		delete(pids, parentPID)
+		if len(pids) != 4 {
+			panic("independent nested attempt family ran in the parent process")
+		}
+		ownerSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceIndependentATFFixture/clear/owner", 4)
+		checkSpansByTagValue(ownerSpans, constants.TestIsRetry, "true", 2)
+		checkSpansByTagValue(ownerSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 2)
+		checkSpansByTagValue(ownerSpans, constants.TestAttemptToFixPassed, "true", 2)
+		checkSpansByTagValue(ownerSpans, constants.TestFinalStatus, constants.TestStatusSkip, 2)
+		os.Exit(0)
+	case "nested-aggregate-coverage", "nested-aggregate-coverage-control":
+		os.Exit(0)
 	case "parallel-admission":
 		if readPID("parallel-child") == parentPID || readPID("parallel-sibling") != parentPID {
 			panic("parallel quarantined root did not overlap its parent-process sibling")
@@ -407,6 +437,22 @@ func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$")
 }
 
+func TestQuarantinedRaceNestedAggregateCoverageEndToEnd(t *testing.T) {
+	if testing.CoverMode() == "" {
+		t.Skip("requires coverage instrumentation")
+	}
+	controlPath := filepath.Join(t.TempDir(), "control.out")
+	runQuarantinedRaceEndToEnd(t, "nested-aggregate-coverage-control", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+controlPath)
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+	runQuarantinedRaceEndToEnd(t, "nested-aggregate-coverage", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+profilePath)
+	controlCount := processCoverageCountForFunction(t, controlPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
+	require.Equal(t, controlCount+1, processCoverageCountForFunction(t, profilePath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount"))
+}
+
+func TestQuarantinedRaceNestedAttemptFamilyEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "nested-attempt-family", "^TestQuarantinedRaceIndependentATFFixture$")
+}
+
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "terminal-descendants", "^TestQuarantinedRaceTerminalDescendantsFixture$")
 }
@@ -441,8 +487,16 @@ func runQuarantinedRaceEndToEnd(t *testing.T, scenario, pattern string, extraArg
 
 func requireFunctionCovered(t *testing.T, profilePath, functionName string) {
 	t.Helper()
+	if processCoverageCountForFunction(t, profilePath, "quarantine_process.go", functionName) > 0 {
+		return
+	}
+	t.Fatalf("%s has no covered block in merged profile %s", functionName, profilePath)
+}
+
+func processCoverageCountForFunction(t *testing.T, profilePath, sourcePath, functionName string) int {
+	t.Helper()
 	fset := token.NewFileSet()
-	parsed, err := parser.ParseFile(fset, "quarantine_process.go", nil, 0)
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, 0)
 	require.NoError(t, err)
 	start, finish := 0, 0
 	for _, declaration := range parsed.Decls {
@@ -455,18 +509,19 @@ func requireFunctionCovered(t *testing.T, profilePath, functionName string) {
 	require.NotZero(t, start)
 	profile, err := os.ReadFile(profilePath)
 	require.NoError(t, err)
+	total := 0
 	for _, line := range strings.Split(string(profile), "\n") {
 		separator := strings.LastIndexByte(line, ':')
-		if separator < 0 || !strings.HasSuffix(filepath.ToSlash(line[:separator]), "/gotesting/quarantine_process.go") {
+		if separator < 0 || !strings.HasSuffix(filepath.ToSlash(line[:separator]), "/gotesting/"+filepath.Base(sourcePath)) {
 			continue
 		}
 		var startLine, startColumn, endLine, endColumn, statements, count int
 		if _, err := fmt.Sscanf(line[separator+1:], "%d.%d,%d.%d %d %d", &startLine, &startColumn, &endLine, &endColumn, &statements, &count); err == nil &&
 			startLine <= finish && endLine >= start && count > 0 {
-			return
+			total += count
 		}
 	}
-	t.Fatalf("%s has no covered block in merged profile %s", functionName, profilePath)
+	return total
 }
 
 func writeQuarantinedRaceIsolationPID(t *testing.T, name string) {
@@ -529,6 +584,17 @@ func TestQuarantinedRaceAttemptToFixFixture(t *testing.T) {
 	require.NoError(t, err)
 	writeQuarantinedRaceIsolationPID(t, "atf-"+strconv.Itoa(cfg.Attempt))
 	t.Run("child", instrumentTestingTFunc(func(*testing.T) {}))
+}
+
+func TestQuarantinedRaceIndependentATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("clear", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+			writeQuarantinedRaceIsolationPID(t, "nested-attempt-owner-"+strconv.Itoa(os.Getpid()))
+		}))
+	}))
 }
 
 func TestQuarantinedRaceLeafFixture(t *testing.T) {
@@ -630,6 +696,18 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 	}))
 	close(released)
 }
+
+func TestQuarantinedRaceAggregateCoverageFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(*testing.T) {}))
+	if os.Getenv(quarantinedRaceIsolationFixtureEnv) == "nested-aggregate-coverage" {
+		quarantinedRaceAncestorCoverage.Store(int64(processRetryAttemptToFixExecutionCount(1)))
+	}
+}
+
+var quarantinedRaceAncestorCoverage atomic.Int64
 
 func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -68,6 +68,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
 	}
+	if scenario == "parallel-atf-sibling" {
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "2s")
+	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
@@ -106,19 +109,28 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceSubtestFeatureGateFixture/disabled": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
 					},
-					"TestQuarantinedRaceCleanupPanicFixture":                 properties(false),
-					"TestQuarantinedRaceCleanupFailNowFixture":               properties(false),
-					"TestQuarantinedRaceCleanupGoexitFixture":                properties(false),
-					"TestQuarantinedRaceFailfastRootFixture":                 properties(true),
-					"TestQuarantinedRaceFailfastDescendantFixture":           properties(false),
-					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
-					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
-					"TestQuarantinedRaceParallelRootsFixture/one":            properties(false),
-					"TestQuarantinedRaceParallelRootsFixture/two":            properties(false),
-					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
-					"TestQuarantinedRaceParallelDurationFixture/isolated":    properties(false),
-					"TestQuarantinedRaceParallelWaitDurationFixture/root":    properties(false),
-					"TestQuarantinedRaceDynamicDescendantFixture/root":       properties(true),
+					"TestQuarantinedRaceCleanupPanicFixture":              properties(false),
+					"TestQuarantinedRaceCleanupFailNowFixture":            properties(false),
+					"TestQuarantinedRaceCleanupGoexitFixture":             properties(false),
+					"TestQuarantinedRaceFailfastRootFixture":              properties(true),
+					"TestQuarantinedRaceFailfastDescendantFixture":        properties(false),
+					"TestQuarantinedRaceFailfastDescendantFixture/child":  properties(true),
+					"TestQuarantinedRaceParallelFixture/isolated":         properties(false),
+					"TestQuarantinedRaceParallelRootsFixture/one":         properties(false),
+					"TestQuarantinedRaceParallelRootsFixture/two":         properties(false),
+					"TestQuarantinedRaceParallelCoverageFixture/isolated": properties(false),
+					"TestQuarantinedRaceParallelDurationFixture/isolated": properties(false),
+					"TestQuarantinedRaceParallelWaitDurationFixture/root": properties(false),
+					"TestQuarantinedRaceDynamicDescendantFixture/root":    properties(true),
+
+					"TestQuarantinedRaceManagedDescendantFixture/root":           properties(false),
+					"TestQuarantinedRaceManagedDescendantFixture/root/child":     properties(false),
+					"TestQuarantinedRaceOwnerGenerationFixture/root":             properties(true),
+					"TestQuarantinedRaceOwnerGenerationFixture/root/clear":       properties(false),
+					"TestQuarantinedRaceOwnerGenerationFixture/root/clear/owner": properties(true),
+					"TestQuarantinedRaceParallelATFFixture/root":                 properties(false),
+					"TestQuarantinedRaceParallelATFFixture/root/owner":           properties(true),
+
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
@@ -256,6 +268,33 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(dynamic, constants.TestIsAttempToFix, "true", 1)
 		checkSpansByTagValue(dynamic, constants.TestIsRetry, "true", 0)
 		checkSpansByTagValue(dynamic, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		os.Exit(0)
+	case "managed-descendant-masking":
+		if readPID("managed-descendant-run-result") != "true" {
+			panic("managed descendant failure changed the enclosing t.Run result")
+		}
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/child", 1)
+		checkSpansByTagValue(child, constants.TestStatus, constants.TestStatusFail, 1)
+		os.Exit(0)
+	case "managed-descendant-concurrent-failure":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusFail, 1)
+		for _, name := range []string{"child", "sibling"} {
+			span := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/"+name, 1)
+			checkSpansByTagValue(span, constants.TestStatus, constants.TestStatusFail, 1)
+		}
+		os.Exit(0)
+	case "owner-generation-finality":
+		inherited := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceOwnerGenerationFixture/root/clear/owner/inherited", 2)
+		checkSpansByTagValue(inherited, constants.TestFinalStatus, constants.TestStatusSkip, 2)
+		checkSpansByTagValue(inherited, constants.TestAttemptToFixPassed, "true", 2)
+		os.Exit(0)
+	case "parallel-atf-sibling":
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelATFFixture/root/owner", 2)
+		checkSpansByTagValue(owner, constants.TestAttemptToFixPassed, "true", 1)
+		checkSpansByTagValue(owner, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -548,6 +587,22 @@ func TestQuarantinedRaceParallelWaitDurationEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceDynamicDescendantFinalityEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "dynamic-descendant-finality", "^TestQuarantinedRaceDynamicDescendantFixture$")
+}
+
+func TestQuarantinedRaceManagedDescendantMaskingEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "managed-descendant-masking", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceManagedDescendantPreservesConcurrentFailureEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "managed-descendant-concurrent-failure", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceOwnerGenerationFinalityEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "owner-generation-finality", "^TestQuarantinedRaceOwnerGenerationFixture$")
+}
+
+func TestQuarantinedRaceParallelATFSiblingEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-atf-sibling", "^TestQuarantinedRaceParallelATFFixture$", "-test.timeout=15s")
 }
 
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
@@ -868,6 +923,65 @@ func TestQuarantinedRaceDynamicDescendantFixture(t *testing.T) {
 		}
 		require.NoError(t, os.WriteFile(marker, []byte("seen"), 0o600))
 		t.Run("dynamic", instrumentTestingTFunc(func(*testing.T) {}))
+	}))
+}
+
+func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		if os.Getenv(quarantinedRaceIsolationFixtureEnv) == "managed-descendant-concurrent-failure" {
+			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+				(*T)(t).Parallel()
+				time.Sleep(20 * time.Millisecond)
+				t.Error("managed descendant sentinel")
+			}))
+			t.Run("sibling", instrumentTestingTFunc(func(t *testing.T) {
+				(*T)(t).Parallel()
+				t.Error("unmanaged sibling sentinel")
+			}))
+			return
+		}
+		passed := t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+			t.Error("managed descendant sentinel")
+		}))
+		path := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "managed-descendant-run-result")
+		require.NoError(t, os.WriteFile(path, []byte(strconv.FormatBool(passed)), 0o600))
+	}))
+}
+
+func TestQuarantinedRaceOwnerGenerationFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("clear", instrumentTestingTFunc(func(t *testing.T) {
+			t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+				cfg, err := processRetryChildConfigFromEnv()
+				require.NoError(t, err)
+				if strings.HasSuffix(cfg.TestName, "/clear/owner") {
+					t.Run("inherited", instrumentTestingTFunc(func(*testing.T) {}))
+				}
+			}))
+		}))
+	}))
+}
+
+func TestQuarantinedRaceParallelATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		ready := make(chan struct{})
+		t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+			<-ready
+		}))
+		t.Run("sibling", instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+			close(ready)
+		}))
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -106,6 +106,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/parallel": properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
+					"TestQuarantinedRaceTerminalDescendantsFixture/goexit":   properties(false),
 				}},
 				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
@@ -167,6 +168,13 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(panicChild, constants.TestStatus, constants.TestStatusFail, 1)
 		if message, _ := panicChild[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, "body panic sentinel") {
 			panic(fmt.Sprintf("body panic was not reported on the isolated descendant: %q", message))
+		}
+		goexitRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/goexit", 1)
+		checkSpansByTagValue(goexitRoot, constants.TestStatus, constants.TestStatusFail, 1)
+		goexitChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/goexit/child", 1)
+		checkSpansByTagValue(goexitChild, constants.TestStatus, constants.TestStatusFail, 1)
+		if message, _ := goexitChild[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, "runtime.Goexit") {
+			panic(fmt.Sprintf("bare Goexit was not reported on the isolated descendant: %q", message))
 		}
 		os.Exit(0)
 	case "race-before-parallel":
@@ -618,6 +626,11 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 	t.Run("panic", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("child", instrumentTestingTFunc(func(*testing.T) {
 			panic("body panic sentinel")
+		}))
+	}))
+	t.Run("goexit", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("child", instrumentTestingTFunc(func(*testing.T) {
+			runtime.Goexit()
 		}))
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -94,13 +94,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceSubtestFeatureGateFixture/disabled": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
 					},
-					"TestQuarantinedRaceCleanupPanicFixture":             properties(false),
-					"TestQuarantinedRaceCleanupFailNowFixture":           properties(false),
-					"TestQuarantinedRaceCleanupGoexitFixture":            properties(false),
-					"TestQuarantinedRaceFailfastRootFixture":             properties(true),
-					"TestQuarantinedRaceFailfastDescendantFixture":       properties(false),
-					"TestQuarantinedRaceFailfastDescendantFixture/child": properties(true),
-					"TestQuarantinedRaceParallelFixture/isolated":        properties(false),
+					"TestQuarantinedRaceCleanupPanicFixture":              properties(false),
+					"TestQuarantinedRaceCleanupFailNowFixture":            properties(false),
+					"TestQuarantinedRaceCleanupGoexitFixture":             properties(false),
+					"TestQuarantinedRaceFailfastRootFixture":              properties(true),
+					"TestQuarantinedRaceFailfastDescendantFixture":        properties(false),
+					"TestQuarantinedRaceFailfastDescendantFixture/child":  properties(true),
+					"TestQuarantinedRaceParallelFixture/isolated":         properties(false),
+					"TestQuarantinedRaceParallelCoverageFixture/isolated": properties(false),
 				}},
 				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
@@ -133,6 +134,20 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelFixture/isolated", 1)
 		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		os.Exit(0)
+	case "parallel-coverage":
+		if readPID("parallel-coverage-child") == parentPID {
+			panic("covered parallel descendant did not run in the isolated child")
+		}
+		if readPID("parallel-coverage-maximum") != "1" {
+			panic("covered parallel descendants were not serialized")
+		}
+		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelCoverageFixture/isolated", 1)
+		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		for _, name := range []string{"concurrent-a", "concurrent-b"} {
+			childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelCoverageFixture/isolated/"+name, 1)
+			checkSpansByTagValue(childSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		}
 		os.Exit(0)
 	case "testify-source":
 		if readPID("testify-source") == parentPID {
@@ -196,9 +211,6 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if readPID("paypal") != parentPID {
 		panic("non-quarantined sibling did not stay in the parent process")
 	}
-	if testing.CoverMode() != "" && readPID("coverage-serialized") == parentPID {
-		panic("covered concurrent subtests were not serialized in the child process")
-	}
 	atf0, atf1 := readPID("atf-1"), readPID("atf-2")
 	if atf0 == parentPID || atf1 == parentPID || atf0 == atf1 {
 		panic("attempt-to-fix executions did not use fresh child processes")
@@ -228,7 +240,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 	}
 	if spanTypes[constants.SpanTypeTestSession] != 1 || spanTypes[constants.SpanTypeTestModule] != 1 ||
-		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 24 {
+		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 22 {
 		panic(fmt.Sprintf("unexpected parent-owned CI Visibility span counts: %#v", spanTypes))
 	}
 	raceSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFixture", 1)
@@ -287,10 +299,6 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagName(visaSpans, constants.TestCodeOwners, 1)
 	mastercardSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/mastercard", 1)
 	checkSpansByTagValue(mastercardSpans, constants.TestStatus, constants.TestStatusFail, 1)
-	for _, name := range []string{"concurrent-a", "concurrent-b"} {
-		childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/"+name, 1)
-		checkSpansByTagValue(childSpans, constants.TestStatus, constants.TestStatusPass, 1)
-	}
 	rootRaceReport := false
 	for _, entry := range logsEntries {
 		if entry.TestName == "TestQuarantinedRaceNestedFixture/card" && strings.Contains(entry.Message, "WARNING: DATA RACE") {
@@ -325,6 +333,13 @@ func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$")
+}
+
+func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
+	if testing.CoverMode() == "" {
+		t.Skip("requires coverage instrumentation")
+	}
+	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$")
 }
 
 func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
@@ -461,7 +476,7 @@ func TestQuarantinedRaceNestedFixture(t *testing.T) {
 	t.Run("card", instrumentTestingTFunc(func(t *testing.T) {
 		writeQuarantinedRaceIsolationPID(t, "card")
 		t.Run("visa", instrumentTestingTFunc(func(t *testing.T) {
-			t.Parallel()
+			(*T)(t).Parallel()
 			writeQuarantinedRaceIsolationPID(t, "visa")
 		}))
 		t.Run("mastercard", instrumentTestingTFunc(func(t *testing.T) {
@@ -476,29 +491,6 @@ func TestQuarantinedRaceNestedFixture(t *testing.T) {
 		t.Run("disabled", instrumentTestingTFunc(func(t *testing.T) {
 			writeQuarantinedRaceIsolationPID(t, "disabled-body")
 		}))
-		var active atomic.Int32
-		var maximum atomic.Int32
-		var concurrent sync.WaitGroup
-		for _, name := range []string{"concurrent-a", "concurrent-b"} {
-			concurrent.Add(1)
-			go func() {
-				defer concurrent.Done()
-				t.Run(name, instrumentTestingTFunc(func(t *testing.T) {
-					if testing.CoverMode() != "" {
-						t.Parallel()
-					}
-					current := active.Add(1)
-					defer active.Add(-1)
-					for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
-					}
-					time.Sleep(20 * time.Millisecond)
-				}))
-			}()
-		}
-		concurrent.Wait()
-		if testing.CoverMode() != "" && maximum.Load() == 1 {
-			writeQuarantinedRaceIsolationPID(t, "coverage-serialized")
-		}
 	}))
 	t.Run("paypal", instrumentTestingTFunc(func(t *testing.T) {
 		writeQuarantinedRaceIsolationPID(t, "paypal")
@@ -527,6 +519,39 @@ func TestQuarantinedRaceParallelFixture(t *testing.T) {
 		(*T)(t).Parallel()
 		writeQuarantinedRaceIsolationPID(t, "parallel-sibling")
 	}))
+}
+
+func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	released := make(chan struct{})
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		(*T)(t).Parallel()
+		select {
+		case <-released:
+			writeQuarantinedRaceIsolationPID(t, "parallel-coverage-child")
+		case <-time.After(2 * time.Second):
+			t.Fatal("t.Parallel did not release t.Run back to its parent")
+		}
+		var active atomic.Int32
+		var maximum atomic.Int32
+		t.Cleanup(func() {
+			path := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "parallel-coverage-maximum")
+			require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(int(maximum.Load()))), 0o600))
+		})
+		for _, name := range []string{"concurrent-a", "concurrent-b"} {
+			t.Run(name, instrumentTestingTFunc(func(t *testing.T) {
+				(*T)(t).Parallel()
+				current := active.Add(1)
+				defer active.Add(-1)
+				for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
+				}
+				time.Sleep(20 * time.Millisecond)
+			}))
+		}
+	}))
+	close(released)
 }
 
 type quarantinedRaceTestifySuite struct {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -72,6 +72,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedPanicFixture":                   properties(false),
 					"TestQuarantinedRaceSecondFixture":              properties(false),
 					"TestQuarantinedRaceAttemptToFixFixture":        properties(true),
+					"TestQuarantinedRaceLeafFixture/card/visa":      properties(false),
 					"TestQuarantinedRaceNestedFixture/card":         properties(false),
 					"TestQuarantinedRaceNestedATFFixture/card":      properties(false),
 					"TestQuarantinedRaceNestedATFFixture/card/visa": properties(true),
@@ -121,6 +122,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if nestedATF0 == parentPID || nestedATF1 == parentPID || nestedATF0 == nestedATF1 {
 		panic("descendant attempt-to-fix executions did not use fresh child processes")
 	}
+	leafPID := readPID("leaf-visa")
+	if leafPID == parentPID || readPID("leaf-card-child") != leafPID {
+		panic("exact quarantined leaf did not run through its ancestor in the child process")
+	}
+	if readPID("leaf-card-parent") != parentPID || readPID("leaf-mastercard-parent") != parentPID {
+		panic("exact quarantined leaf moved its non-quarantined family out of the parent process")
+	}
+	if _, err := os.Stat(filepath.Join(pidDir, "leaf-mastercard-child")); err == nil || !os.IsNotExist(err) {
+		panic("exact quarantined leaf also executed its sibling in the child process")
+	}
 
 	spans := mTracer.FinishedSpans()
 	spanTypes := map[string]int{}
@@ -130,7 +141,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 	}
 	if spanTypes[constants.SpanTypeTestSession] != 1 || spanTypes[constants.SpanTypeTestModule] != 1 ||
-		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 19 {
+		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 23 {
 		panic(fmt.Sprintf("unexpected parent-owned CI Visibility span counts: %#v", spanTypes))
 	}
 	raceSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFixture", 1)
@@ -159,6 +170,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagValue(nestedATFSpans, constants.TestAttemptToFixPassed, "true", 1)
 	checkSpansByTagValue(nestedATFSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 	checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedATFFixture/card", 1)
+	checkSpansByResourceName(spans, suite+".TestQuarantinedRaceLeafFixture", 1)
+	checkSpansByResourceName(spans, suite+".TestQuarantinedRaceLeafFixture/card", 1)
+	leafSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceLeafFixture/card/visa", 1)
+	checkSpansByTagValue(leafSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	checkSpansByTagValue(leafSpans, constants.TestIsQuarantined, "true", 1)
+	checkSpansByResourceName(spans, suite+".TestQuarantinedRaceLeafFixture/card/mastercard", 1)
 	for _, name := range []string{
 		"TestQuarantinedRaceNestedFixture/card",
 		"TestQuarantinedRaceNestedFixture/card/visa",
@@ -198,7 +215,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 
 func TestQuarantinedRaceProcessEndToEnd(t *testing.T) {
 	pidDir := t.TempDir()
-	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(os.Args[1:], "^TestQuarantined(Race(Fixture|SecondFixture|AttemptToFixFixture|NestedFixture|NestedATFFixture)|PanicFixture)$")...)
+	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(os.Args[1:], "^TestQuarantined(Race(Fixture|SecondFixture|AttemptToFixFixture|LeafFixture|NestedFixture|NestedATFFixture)|PanicFixture)$")...)
 	cmd.Env = append(os.Environ(),
 		quarantinedRaceIsolationFixtureEnv+"=true",
 		quarantinedRaceIsolationPIDDirEnv+"="+pidDir,
@@ -249,6 +266,14 @@ func writeQuarantinedRaceIsolationPID(t *testing.T, name string) {
 	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600))
 }
 
+func writeQuarantinedRaceIsolationProcessPID(t *testing.T, name string) {
+	process := "parent"
+	if isProcessRetryChild() {
+		process = "child"
+	}
+	writeQuarantinedRaceIsolationPID(t, name+"-"+process)
+}
+
 func TestQuarantinedRaceFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
@@ -295,6 +320,21 @@ func TestQuarantinedRaceAttemptToFixFixture(t *testing.T) {
 	require.NoError(t, err)
 	writeQuarantinedRaceIsolationPID(t, "atf-"+strconv.Itoa(cfg.Attempt))
 	t.Run("child", instrumentTestingTFunc(func(*testing.T) {}))
+}
+
+func TestQuarantinedRaceLeafFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("card", instrumentTestingTFunc(func(t *testing.T) {
+		writeQuarantinedRaceIsolationProcessPID(t, "leaf-card")
+		t.Run("visa", instrumentTestingTFunc(func(t *testing.T) {
+			writeQuarantinedRaceIsolationPID(t, "leaf-visa")
+		}))
+		t.Run("mastercard", instrumentTestingTFunc(func(t *testing.T) {
+			writeQuarantinedRaceIsolationProcessPID(t, "leaf-mastercard")
+		}))
+	}))
 }
 
 func TestQuarantinedRaceNestedFixture(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -64,6 +64,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if scenario == "feature-gate" {
 		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
 	}
+	if scenario == "parallel-root-slots" {
+		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
+	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
@@ -109,8 +113,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastDescendantFixture":           properties(false),
 					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
 					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
+					"TestQuarantinedRaceParallelRootsFixture/one":            properties(false),
+					"TestQuarantinedRaceParallelRootsFixture/two":            properties(false),
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
 					"TestQuarantinedRaceParallelDurationFixture/isolated":    properties(false),
+					"TestQuarantinedRaceParallelWaitDurationFixture/root":    properties(false),
+					"TestQuarantinedRaceDynamicDescendantFixture/root":       properties(true),
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
@@ -202,6 +210,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelFixture/isolated", 1)
 		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
 		os.Exit(0)
+	case "parallel-root-slots":
+		one, two := readPID("parallel-root-one-child"), readPID("parallel-root-two-child")
+		if one == parentPID || two == parentPID || one == two {
+			panic("parallel quarantined roots did not use distinct child processes")
+		}
+		for _, name := range []string{"one", "two"} {
+			root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelRootsFixture/"+name, 1)
+			checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		}
+		os.Exit(0)
 	case "parallel-coverage":
 		if readPID("parallel-coverage-child") == parentPID {
 			panic("covered parallel descendant did not run in the isolated child")
@@ -222,13 +240,30 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(fmt.Sprintf("parallel suspension leaked into replayed duration: %s", got))
 		}
 		os.Exit(0)
+	case "parallel-wait-duration":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root", 1)
+		if got := root[0].Duration(); got >= 250*time.Millisecond {
+			panic(fmt.Sprintf("parallel descendant wait leaked into root duration: %s", got))
+		}
+		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root/slow", 1)
+		if got := child[0].Duration(); got < 400*time.Millisecond {
+			panic(fmt.Sprintf("slow parallel descendant duration = %s, want at least 400ms", got))
+		}
+		os.Exit(0)
+	case "dynamic-descendant-finality":
+		checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDynamicDescendantFixture/root", 2)
+		dynamic := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDynamicDescendantFixture/root/dynamic", 1)
+		checkSpansByTagValue(dynamic, constants.TestIsAttempToFix, "true", 1)
+		checkSpansByTagValue(dynamic, constants.TestIsRetry, "true", 0)
+		checkSpansByTagValue(dynamic, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
 		checkSpansByTagValue(parallelRoot, constants.TestStatus, constants.TestStatusFail, 1)
 		parallelChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel/child", 1)
 		checkSpansByTagValue(parallelChild, constants.TestStatus, constants.TestStatusFail, 1)
-		if rootFinish, childFinish := parallelRoot[0].StartTime().Add(parallelRoot[0].Duration()), parallelChild[0].StartTime().Add(parallelChild[0].Duration()); rootFinish.Before(childFinish) {
-			panic("selected root finished before its parallel descendant")
+		if rootFinish, childFinish := parallelRoot[0].StartTime().Add(parallelRoot[0].Duration()), parallelChild[0].StartTime().Add(parallelChild[0].Duration()); !rootFinish.Before(childFinish) {
+			panic("parallel descendant wait leaked into selected root duration")
 		}
 		panicRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/panic", 1)
 		checkSpansByTagValue(panicRoot, constants.TestStatus, constants.TestStatusFail, 1)
@@ -466,6 +501,10 @@ func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$")
 }
 
+func TestQuarantinedRaceParallelRootsReleaseProcessSlotsEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-root-slots", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=15s")
+}
+
 func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 	if testing.CoverMode() == "" {
 		t.Skip("requires coverage instrumentation")
@@ -501,6 +540,14 @@ func TestQuarantinedRaceDeepNestedAttemptFamilyEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceParallelDurationEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-duration", "^TestQuarantinedRaceParallelDurationFixture$")
+}
+
+func TestQuarantinedRaceParallelWaitDurationEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-wait-duration", "^TestQuarantinedRaceParallelWaitDurationFixture$")
+}
+
+func TestQuarantinedRaceDynamicDescendantFinalityEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "dynamic-descendant-finality", "^TestQuarantinedRaceDynamicDescendantFixture$")
 }
 
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
@@ -729,6 +776,18 @@ func TestQuarantinedRaceParallelFixture(t *testing.T) {
 	}))
 }
 
+func TestQuarantinedRaceParallelRootsFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	for _, name := range []string{"one", "two"} {
+		t.Run(name, instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+			writeQuarantinedRaceIsolationProcessPID(t, "parallel-root-"+name)
+		}))
+	}
+}
+
 func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
@@ -783,6 +842,32 @@ func TestQuarantinedRaceParallelDurationFixture(t *testing.T) {
 			(*T)(t).Parallel()
 		}))
 		time.Sleep(500 * time.Millisecond)
+	}))
+}
+
+func TestQuarantinedRaceParallelWaitDurationFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("slow", instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+			time.Sleep(500 * time.Millisecond)
+		}))
+	}))
+}
+
+func TestQuarantinedRaceDynamicDescendantFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
+		marker := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "dynamic-descendant-seen")
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			return
+		}
+		require.NoError(t, os.WriteFile(marker, []byte("seen"), 0o600))
+		t.Run("dynamic", instrumentTestingTFunc(func(*testing.T) {}))
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -57,7 +57,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
 	attempts := "2"
-	if scenario == "failfast" {
+	if scenario == "failfast" || scenario == "deferred-descendant-atf-failfast" || scenario == "deferred-dynamic-descendant-finality" {
 		attempts = "3"
 	}
 	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, attempts)
@@ -161,6 +161,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
 					},
+					"TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner/inherited": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceDeferredDynamicDescendantFixture": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceDeferredDynamicDescendantFixture/quarantined": properties(false),
+					"TestQuarantinedRaceDeferredDynamicDescendantFixture/dynamic":     properties(true),
 
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
@@ -186,7 +194,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	currentM = m
 	mTracer = integrations.InitializeCIVisibilityMock()
 	exitCode := RunM(m)
-	expectFailure := scenario == "deferred-descendant-atf-failure"
+	expectFailure := scenario == "deferred-descendant-atf-failure" || scenario == "deferred-descendant-inherited-failure" || scenario == "deferred-descendant-atf-failfast"
 	if (exitCode != 0) != expectFailure {
 		panic(fmt.Sprintf("quarantined race isolation fixture exit code = %d", exitCode))
 	}
@@ -428,6 +436,25 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusFail, 2)
 		checkSpansByTagValue(owner, constants.TestIsAttempToFix, "true", 2)
 		checkSpansByTagValue(owner, constants.TestIsRetry, "true", 1)
+		os.Exit(0)
+	case "deferred-descendant-inherited-failure":
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner", 2)
+		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusPass, 2)
+		inherited := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner/inherited", 2)
+		checkSpansByTagValue(inherited, constants.TestStatus, constants.TestStatusFail, 2)
+		os.Exit(0)
+	case "deferred-descendant-atf-failfast":
+		if _, err := os.Stat(filepath.Join(pidDir, "deferred-owner-continuation-2")); err == nil || !os.IsNotExist(err) {
+			panic("deferred descendant retry ran after a failure under -failfast")
+		}
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner", 1)
+		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusFail, 1)
+		os.Exit(0)
+	case "deferred-dynamic-descendant-finality":
+		dynamic := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDynamicDescendantFixture/dynamic", 1)
+		checkSpansByTagValue(dynamic, constants.TestIsAttempToFix, "true", 1)
+		checkSpansByTagValue(dynamic, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		checkSpansByTagValue(dynamic, constants.TestAttemptToFixPassed, "true", 1)
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -760,6 +787,18 @@ func TestQuarantinedRaceManagedDescendantPreservesProcessOutputEndToEnd(t *testi
 
 func TestQuarantinedRaceDeferredDescendantATFFamilyCompletesAndFailsPackageEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "deferred-descendant-atf-failure", "^TestQuarantinedRaceDeferredDescendantATFFixture$")
+}
+
+func TestQuarantinedRaceDeferredInheritedATFFailureFailsPackageEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "deferred-descendant-inherited-failure", "^TestQuarantinedRaceDeferredDescendantATFFixture$")
+}
+
+func TestQuarantinedRaceDeferredDescendantATFFailfastEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "deferred-descendant-atf-failfast", "^TestQuarantinedRaceDeferredDescendantATFFixture$", "-test.failfast")
+}
+
+func TestQuarantinedRaceDeferredDynamicDescendantFinalityEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "deferred-dynamic-descendant-finality", "^TestQuarantinedRaceDeferredDynamicDescendantFixture$")
 }
 
 func TestQuarantinedRaceNestedRootTerminalsEndToEnd(t *testing.T) {
@@ -1495,8 +1534,33 @@ func TestQuarantinedRaceDeferredDescendantATFFixture(t *testing.T) {
 	t.Run("clear", instrumentTestingTFunc(func(t *testing.T) {
 		if isProcessRetryChild() {
 			t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+				scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
+				cfg, err := processRetryChildConfigFromEnv()
+				require.NoError(t, err)
+				if scenario == "deferred-descendant-atf-failfast" && strings.HasSuffix(cfg.TestName, "/clear/owner") {
+					writeQuarantinedRaceIsolationPID(t, "deferred-owner-continuation-"+strconv.Itoa(cfg.Attempt))
+				}
+				if scenario == "deferred-descendant-inherited-failure" {
+					t.Run("inherited", instrumentTestingTFunc(func(t *testing.T) { t.Error("inherited failure sentinel") }))
+					return
+				}
 				t.Error("deferred descendant attempt-to-fix sentinel")
 			}))
 		}
 	}))
+}
+
+func TestQuarantinedRaceDeferredDynamicDescendantFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("quarantined", instrumentTestingTFunc(func(*testing.T) {}))
+	if !isProcessRetryChild() {
+		return
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	if cfg.Attempt == 1 {
+		t.Run("dynamic", instrumentTestingTFunc(func(*testing.T) {}))
+	}
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -103,6 +103,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
+					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/parallel": properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
 				}},
@@ -177,6 +178,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			}
 		}
 		panic("race before t.Parallel was not preserved in the selected root output")
+	case "ancestor-terminal":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAncestorPanicFixture/isolated", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		checkSpansByTagValue(root, ext.ErrorType, "test_panic", 0)
+		os.Exit(0)
 	case "testify-source":
 		if readPID("testify-source") == parentPID {
 			panic("Testify method did not run in the isolated child")
@@ -287,9 +293,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagValue(atfSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 	atfChildSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAttemptToFixFixture/child", 2)
 	checkSpansByTagValue(atfChildSpans, constants.TestIsAttempToFix, "true", 2)
-	checkSpansByTagValue(atfChildSpans, constants.TestIsRetry, "true", 0)
-	checkSpansByTagValue(atfChildSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 0)
-	checkSpansByTagValue(atfChildSpans, constants.TestAttemptToFixPassed, "true", 0)
+	checkSpansByTagValue(atfChildSpans, constants.TestIsRetry, "true", 1)
+	checkSpansByTagValue(atfChildSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+	checkSpansByTagValue(atfChildSpans, constants.TestAttemptToFixPassed, "true", 1)
+	checkSpansByTagValue(atfChildSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 	nestedATFSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedATFFixture/card/visa", 2)
 	checkSpansByTagValue(nestedATFSpans, constants.TestIsAttempToFix, "true", 2)
 	checkSpansByTagValue(nestedATFSpans, constants.TestIsRetry, "true", 1)
@@ -327,6 +334,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagName(visaSpans, constants.TestCodeOwners, 1)
 	mastercardSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/mastercard", 1)
 	checkSpansByTagValue(mastercardSpans, constants.TestStatus, constants.TestStatusFail, 1)
+	checkSpansByTagValue(mastercardSpans, ext.ErrorType, "test_race", 1)
+	cardSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card", 1)
+	checkSpansByTagValue(cardSpans, ext.ErrorType, "test_race", 0)
 	rootRaceReport := false
 	for _, entry := range logsEntries {
 		if entry.TestName == "TestQuarantinedRaceNestedFixture/card" && strings.Contains(entry.Message, "WARNING: DATA RACE") {
@@ -376,6 +386,10 @@ func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceBeforeParallelEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "race-before-parallel", "^TestQuarantinedRaceBeforeParallelFixture$")
+}
+
+func TestQuarantinedRaceAncestorPanicEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "ancestor-terminal", "^TestQuarantinedRaceAncestorPanicFixture$")
 }
 
 func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
@@ -616,6 +630,16 @@ func TestQuarantinedRaceBeforeParallelFixture(t *testing.T) {
 		triggerQuarantinedRaceFixture()
 		(*T)(t).Parallel()
 	}))
+}
+
+func TestQuarantinedRaceAncestorPanicFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(*testing.T) {}))
+	if isProcessRetryChild() {
+		panic("ancestor panic sentinel")
+	}
 }
 
 type quarantinedRaceTestifySuite struct {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,7 +39,7 @@ const (
 )
 
 func quarantinedRaceIsolationFixtureSelected() bool {
-	return os.Getenv(quarantinedRaceIsolationFixtureEnv) == "true"
+	return os.Getenv(quarantinedRaceIsolationFixtureEnv) != ""
 }
 
 func runQuarantinedRaceIsolationFixture(m *testing.M) {
@@ -52,8 +53,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(err)
 		}
 	}
+	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
 	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, "2")
+	if scenario == "feature-gate" {
+		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
+	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
@@ -76,6 +81,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceNestedFixture/card":         properties(false),
 					"TestQuarantinedRaceNestedATFFixture/card":      properties(false),
 					"TestQuarantinedRaceNestedATFFixture/card/visa": properties(true),
+					"TestQuarantinedRaceSubtestFeatureGateFixture":  properties(false),
+					"TestQuarantinedRaceSubtestFeatureGateFixture/disabled": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
+					},
+					"TestQuarantinedRaceCleanupPanicFixture":             properties(false),
+					"TestQuarantinedRaceCleanupFailNowFixture":           properties(false),
+					"TestQuarantinedRaceCleanupGoexitFixture":            properties(false),
+					"TestQuarantinedRaceFailfastRootFixture":             properties(true),
+					"TestQuarantinedRaceFailfastDescendantFixture":       properties(false),
+					"TestQuarantinedRaceFailfastDescendantFixture/child": properties(true),
 				}},
 			}},
 		}}, false, nil)
@@ -96,6 +111,38 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(err)
 		}
 		return strings.TrimSpace(string(payload))
+	}
+	spans := mTracer.FinishedSpans()
+	switch scenario {
+	case "feature-gate":
+		if readPID("feature-gate-disabled") == parentPID {
+			panic("subtest feature gate fixture did not run in the isolated child")
+		}
+		featureSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceSubtestFeatureGateFixture/disabled", 1)
+		checkSpansByTagValue(featureSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		os.Exit(0)
+	case "cleanup":
+		panicSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceCleanupPanicFixture/child", 1)
+		checkSpansByTagValue(panicSpans, constants.TestStatus, constants.TestStatusFail, 1)
+		if message, _ := panicSpans[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, "cleanup panic sentinel") {
+			panic(fmt.Sprintf("cleanup panic was not reported on the isolated test: %q", message))
+		}
+		goexitSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceCleanupGoexitFixture/child", 1)
+		checkSpansByTagValue(goexitSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		failNowSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceCleanupFailNowFixture/child", 1)
+		checkSpansByTagValue(failNowSpans, constants.TestStatus, constants.TestStatusFail, 1)
+		os.Exit(0)
+	case "failfast":
+		for _, name := range []string{"failfast-root-2", "failfast-descendant-2"} {
+			if _, err := os.Stat(filepath.Join(pidDir, name)); err == nil || !os.IsNotExist(err) {
+				panic(name + " ran after a valid failure under -failfast")
+			}
+		}
+		readPID("failfast-root-1")
+		readPID("failfast-descendant-1")
+		checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastRootFixture", 1)
+		checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastDescendantFixture/child", 1)
+		os.Exit(0)
 	}
 	racePID := readPID("race")
 	secondPID := readPID("second")
@@ -133,7 +180,6 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		panic("exact quarantined leaf also executed its sibling in the child process")
 	}
 
-	spans := mTracer.FinishedSpans()
 	spanTypes := map[string]int{}
 	for _, span := range spans {
 		if spanType, ok := span.Tag(ext.SpanType).(string); ok {
@@ -214,19 +260,37 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 }
 
 func TestQuarantinedRaceProcessEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "true", "^TestQuarantined(Race(Fixture|SecondFixture|AttemptToFixFixture|LeafFixture|NestedFixture|NestedATFFixture)|PanicFixture)$")
+	if coverProfile := flag.Lookup("test.coverprofile"); coverProfile != nil && coverProfile.Value.String() != "" {
+		requireFunctionCovered(t, coverProfile.Value.String(), "bufferQuarantinedRaceChildOutput")
+	}
+}
+
+func TestQuarantinedRaceSubtestFeatureGateEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "feature-gate", "^TestQuarantinedRaceSubtestFeatureGateFixture$")
+}
+
+func TestQuarantinedRaceCleanupEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "cleanup", "^TestQuarantinedRaceCleanup(Panic|FailNow|Goexit)Fixture$")
+}
+
+func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "failfast", "^TestQuarantinedRaceFailfast(Root|Descendant)Fixture$", "-test.failfast")
+}
+
+func runQuarantinedRaceEndToEnd(t *testing.T, scenario, pattern string, extraArgs ...string) {
+	t.Helper()
 	pidDir := t.TempDir()
-	cmd := exec.Command(os.Args[0], buildTestControllerSubprocessArgs(os.Args[1:], "^TestQuarantined(Race(Fixture|SecondFixture|AttemptToFixFixture|LeafFixture|NestedFixture|NestedATFFixture)|PanicFixture)$")...)
+	args := append(buildTestControllerSubprocessArgs(os.Args[1:], pattern), extraArgs...)
+	cmd := exec.Command(os.Args[0], args...)
 	cmd.Env = append(os.Environ(),
-		quarantinedRaceIsolationFixtureEnv+"=true",
+		quarantinedRaceIsolationFixtureEnv+"="+scenario,
 		quarantinedRaceIsolationPIDDirEnv+"="+pidDir,
 	)
 	var output bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &output, &output
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("quarantined race isolation fixture failed: %v\n%s", err, output.String())
-	}
-	if coverProfile := flag.Lookup("test.coverprofile"); coverProfile != nil && coverProfile.Value.String() != "" {
-		requireFunctionCovered(t, coverProfile.Value.String(), "bufferQuarantinedRaceChildOutput")
 	}
 }
 
@@ -395,5 +459,63 @@ func TestQuarantinedRaceNestedATFFixture(t *testing.T) {
 			require.NoError(t, err)
 			writeQuarantinedRaceIsolationPID(t, "nested-atf-visa-"+strconv.Itoa(cfg.Attempt))
 		}))
+	}))
+}
+
+func TestQuarantinedRaceSubtestFeatureGateFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("disabled", instrumentTestingTFunc(func(t *testing.T) {
+		writeQuarantinedRaceIsolationPID(t, "feature-gate-disabled")
+	}))
+}
+
+func TestQuarantinedRaceCleanupPanicFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		t.Cleanup(func() { panic("cleanup panic sentinel") })
+	}))
+}
+
+func TestQuarantinedRaceCleanupGoexitFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		t.Cleanup(runtime.Goexit)
+	}))
+}
+
+func TestQuarantinedRaceCleanupFailNowFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		t.Cleanup(t.FailNow)
+	}))
+}
+
+func TestQuarantinedRaceFailfastRootFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	writeQuarantinedRaceIsolationPID(t, "failfast-root-"+strconv.Itoa(cfg.Attempt))
+	t.Fail()
+}
+
+func TestQuarantinedRaceFailfastDescendantFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		cfg, err := processRetryChildConfigFromEnv()
+		require.NoError(t, err)
+		writeQuarantinedRaceIsolationPID(t, "failfast-descendant-"+strconv.Itoa(cfg.Attempt))
+		t.Fail()
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -429,7 +429,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(failNowSpans, constants.TestStatus, constants.TestStatusFail, 1)
 		os.Exit(0)
 	case "failfast":
-		for _, name := range []string{"failfast-root-3", "failfast-descendant-3"} {
+		for _, name := range []string{"failfast-root-3", "failfast-descendant-2", "failfast-descendant-3"} {
 			if _, err := os.Stat(filepath.Join(pidDir, name)); err == nil || !os.IsNotExist(err) {
 				panic(name + " ran after a valid failure under -failfast")
 			}
@@ -437,14 +437,15 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		readPID("failfast-root-1")
 		readPID("failfast-root-2")
 		readPID("failfast-descendant-1")
-		readPID("failfast-descendant-2")
-		for _, name := range []string{"TestQuarantinedRaceFailfastRootFixture", "TestQuarantinedRaceFailfastDescendantFixture/child"} {
-			failfastSpans := checkSpansByResourceName(spans, suite+"."+name, 2)
-			checkSpansByTagValue(failfastSpans, constants.TestIsRetry, "true", 1)
-			checkSpansByTagValue(failfastSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
-			checkSpansByTagValue(failfastSpans, constants.TestAttemptToFixPassed, "false", 1)
-			checkSpansByTagValue(failfastSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
-		}
+		rootSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastRootFixture", 2)
+		checkSpansByTagValue(rootSpans, constants.TestIsRetry, "true", 1)
+		checkSpansByTagValue(rootSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+		checkSpansByTagValue(rootSpans, constants.TestAttemptToFixPassed, "false", 1)
+		checkSpansByTagValue(rootSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		descendantSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastDescendantFixture/child", 1)
+		checkSpansByTagValue(descendantSpans, constants.TestIsRetry, "true", 0)
+		checkSpansByTagValue(descendantSpans, constants.TestAttemptToFixPassed, "false", 0)
+		checkSpansByTagValue(descendantSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		os.Exit(0)
 	}
 	racePID := readPID("race")
@@ -1280,8 +1281,6 @@ func TestQuarantinedRaceFailfastDescendantFixture(t *testing.T) {
 		cfg, err := processRetryChildConfigFromEnv()
 		require.NoError(t, err)
 		writeQuarantinedRaceIsolationPID(t, "failfast-descendant-"+strconv.Itoa(cfg.Attempt))
-		if cfg.Attempt > 1 {
-			t.Fail()
-		}
+		t.Fail()
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -140,6 +140,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceSerialATFFixture/root":                   properties(false),
 					"TestQuarantinedRaceSerialATFFixture/root/owner":             properties(true),
 					"TestQuarantinedRaceForeignSuiteFixture/root":                properties(false),
+					"TestQuarantinedRaceAncestorATFFixture": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceAncestorATFFixture/child": properties(true),
 
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
@@ -149,6 +153,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/goexit":   properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/output":   properties(false),
+				}},
+				"quarantine_process_test.go": {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+					"TestQuarantinedRaceForeignSuiteFixture/root/foreign": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
+					},
 				}},
 				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
@@ -362,7 +371,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	case "foreign-suite":
 		foreignSuite := "quarantine_process_test.go"
 		foreign := checkSpansByResourceName(spans, foreignSuite+".TestQuarantinedRaceForeignSuiteFixture/root/foreign", 1)
-		checkSpansByTagValue(foreign, constants.TestStatus, constants.TestStatusPass, 1)
+		checkSpansByTagValue(foreign, constants.TestStatus, constants.TestStatusSkip, 1)
+		checkSpansByTagValue(foreign, constants.TestIsDisabled, "true", 1)
+		os.Exit(0)
+	case "ancestor-atf":
+		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAncestorATFFixture/child", 2)
+		checkSpansByTagValue(child, constants.TestIsAttempToFix, "true", 2)
+		checkSpansByTagValue(child, constants.TestIsRetry, "true", 1)
+		checkSpansByTagValue(child, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+		checkSpansByTagValue(child, constants.TestAttemptToFixPassed, "false", 1)
+		checkSpansByTagValue(child, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -703,6 +721,10 @@ func TestQuarantinedRaceSerialATFDoesNotRepeatSiblingEndToEnd(t *testing.T) {
 
 func TestQuarantinedRacePreservesDescendantSuiteEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "foreign-suite", "^TestQuarantinedRaceForeignSuiteFixture$")
+}
+
+func TestQuarantinedRacePreservesAncestorATFMetadataEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "ancestor-atf", "^TestQuarantinedRaceAncestorATFFixture$")
 }
 
 func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
@@ -1354,5 +1376,18 @@ func TestQuarantinedRaceForeignSuiteFixture(t *testing.T) {
 	}
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("foreign", instrumentTestingTFunc(quarantinedRaceForeignSuiteCallback))
+	}))
+}
+
+func TestQuarantinedRaceAncestorATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+		cfg, err := processRetryChildConfigFromEnv()
+		require.NoError(t, err)
+		if cfg.RetryReason == processRetrySubtreeReason {
+			t.Fail()
+		}
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -125,6 +125,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 
 					"TestQuarantinedRaceManagedDescendantFixture/root":           properties(false),
 					"TestQuarantinedRaceManagedDescendantFixture/root/child":     properties(false),
+					"TestQuarantinedRaceNestedRootTerminalFixture/panic":         properties(false),
+					"TestQuarantinedRaceNestedRootTerminalFixture/goexit":        properties(false),
+					"TestQuarantinedRaceNestedRootTerminalFixture/cleanup-panic": properties(false),
 					"TestQuarantinedRaceOwnerGenerationFixture/root":             properties(true),
 					"TestQuarantinedRaceOwnerGenerationFixture/root/clear":       properties(false),
 					"TestQuarantinedRaceOwnerGenerationFixture/root/clear/owner": properties(true),
@@ -284,6 +287,42 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		for _, name := range []string{"child", "sibling"} {
 			span := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/"+name, 1)
 			checkSpansByTagValue(span, constants.TestStatus, constants.TestStatusFail, 1)
+		}
+		os.Exit(0)
+	case "managed-descendant-root-failure":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusFail, 1)
+		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/child", 1)
+		checkSpansByTagValue(child, constants.TestStatus, constants.TestStatusFail, 1)
+		os.Exit(0)
+	case "managed-descendant-output":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		childName := "TestQuarantinedRaceManagedDescendantFixture/root/child"
+		child := checkSpansByResourceName(spans, suite+"."+childName, 1)
+		checkSpansByTagValue(child, constants.TestStatus, constants.TestStatusFail, 1)
+		stdout, stderr := false, false
+		for _, entry := range logsEntries {
+			if entry.TestName == childName {
+				stdout = stdout || strings.Contains(entry.Message, "managed descendant stdout sentinel")
+				stderr = stderr || strings.Contains(entry.Message, "managed descendant stderr sentinel")
+			}
+		}
+		if stdout && stderr {
+			os.Exit(0)
+		}
+		panic("managed descendant process output was not preserved")
+	case "nested-root-terminal":
+		for terminal, sentinel := range map[string]string{
+			"panic":         "nested root panic sentinel",
+			"goexit":        "runtime.Goexit",
+			"cleanup-panic": "nested root cleanup panic sentinel",
+		} {
+			span := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedRootTerminalFixture/"+terminal, 1)
+			checkSpansByTagValue(span, constants.TestStatus, constants.TestStatusFail, 1)
+			if message, _ := span[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, sentinel) {
+				panic(fmt.Sprintf("nested %s terminal was not reported: %q", terminal, message))
+			}
 		}
 		os.Exit(0)
 	case "owner-generation-finality":
@@ -595,6 +634,18 @@ func TestQuarantinedRaceManagedDescendantMaskingEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceManagedDescendantPreservesConcurrentFailureEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "managed-descendant-concurrent-failure", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceManagedDescendantPreservesRootFailureEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "managed-descendant-root-failure", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceManagedDescendantPreservesProcessOutputEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "managed-descendant-output", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceNestedRootTerminalsEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "nested-root-terminal", "^TestQuarantinedRaceNestedRootTerminalFixture$")
 }
 
 func TestQuarantinedRaceOwnerGenerationFinalityEndToEnd(t *testing.T) {
@@ -931,7 +982,8 @@ func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
 		t.Skip("fixture subprocess only")
 	}
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
-		if os.Getenv(quarantinedRaceIsolationFixtureEnv) == "managed-descendant-concurrent-failure" {
+		scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
+		if scenario == "managed-descendant-concurrent-failure" {
 			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 				(*T)(t).Parallel()
 				time.Sleep(20 * time.Millisecond)
@@ -943,11 +995,42 @@ func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
 			}))
 			return
 		}
+		if scenario == "managed-descendant-root-failure" {
+			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+				(*T)(t).Parallel()
+				time.Sleep(20 * time.Millisecond)
+				t.Error("managed descendant sentinel")
+			}))
+			t.Error("selected root failure sentinel")
+			return
+		}
 		passed := t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+			if scenario == "managed-descendant-output" {
+				_, _ = fmt.Fprintln(os.Stdout, "managed descendant stdout sentinel")
+				_, _ = fmt.Fprintln(os.Stderr, "managed descendant stderr sentinel")
+			}
 			t.Error("managed descendant sentinel")
 		}))
+		if scenario == "managed-descendant-output" {
+			return
+		}
 		path := filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "managed-descendant-run-result")
 		require.NoError(t, os.WriteFile(path, []byte(strconv.FormatBool(passed)), 0o600))
+	}))
+}
+
+func TestQuarantinedRaceNestedRootTerminalFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("panic", instrumentTestingTFunc(func(*testing.T) {
+		panic("nested root panic sentinel")
+	}))
+	t.Run("goexit", instrumentTestingTFunc(func(*testing.T) {
+		runtime.Goexit()
+	}))
+	t.Run("cleanup-panic", instrumentTestingTFunc(func(t *testing.T) {
+		t.Cleanup(func() { panic("nested root cleanup panic sentinel") })
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -44,6 +44,10 @@ func quarantinedRaceIsolationFixtureSelected() bool {
 }
 
 func runQuarantinedRaceIsolationFixture(m *testing.M) {
+	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
+	if scenario == "parallel-duration" || scenario == "parallel-wait-duration" || scenario == "terminal-descendants" {
+		installQuarantinedRaceLogicalClock()
+	}
 	// A process child must enter the existing no-op CI Visibility bootstrap
 	// directly. It never creates a session, fetches settings, or starts retries.
 	if isProcessRetryChild() {
@@ -54,7 +58,6 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(err)
 		}
 	}
-	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
 	attempts := "2"
 	if scenario == "failfast" || scenario == "deferred-descendant-atf-failfast" || scenario == "deferred-dynamic-descendant-finality" {
@@ -318,18 +321,18 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		os.Exit(0)
 	case "parallel-duration":
 		childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelDurationFixture/isolated/suspended", 1)
-		if got := childSpans[0].Duration(); got >= 250*time.Millisecond {
-			panic(fmt.Sprintf("parallel suspension leaked into replayed duration: %s", got))
+		if got := childSpans[0].Duration(); got != time.Second {
+			panic(fmt.Sprintf("parallel child duration = %s, want 1s of logical active time", got))
 		}
 		os.Exit(0)
 	case "parallel-wait-duration":
 		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root", 1)
-		if got := root[0].Duration(); got >= 250*time.Millisecond {
-			panic(fmt.Sprintf("parallel descendant wait leaked into root duration: %s", got))
+		if got := root[0].Duration(); got != 0 {
+			panic(fmt.Sprintf("parallel root duration = %s, want no logical active time", got))
 		}
 		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root/slow", 1)
-		if got := child[0].Duration(); got < 400*time.Millisecond {
-			panic(fmt.Sprintf("slow parallel descendant duration = %s, want at least 400ms", got))
+		if got := child[0].Duration(); got != 100*time.Second {
+			panic(fmt.Sprintf("parallel child duration = %s, want 100s of logical active time", got))
 		}
 		os.Exit(0)
 	case "dynamic-descendant-finality":
@@ -724,7 +727,7 @@ func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$")
+	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$", "-test.timeout=15s")
 }
 
 func TestQuarantinedRaceParallelDeniedEndToEnd(t *testing.T) {
@@ -743,7 +746,7 @@ func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 	if testing.CoverMode() == "" {
 		t.Skip("requires coverage instrumentation")
 	}
-	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$")
+	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$", "-test.timeout=15s")
 }
 
 func TestQuarantinedRaceNestedAggregateCoverageEndToEnd(t *testing.T) {
@@ -976,6 +979,19 @@ func writeQuarantinedRaceIsolationProcessPID(t *testing.T, name string) {
 	writeQuarantinedRaceIsolationPID(t, name+"-"+process)
 }
 
+var quarantinedRaceLogicalClockElapsed atomic.Int64
+
+func installQuarantinedRaceLogicalClock() {
+	origin := time.Unix(1, 0)
+	quarantinedRaceNow = func() time.Time {
+		return origin.Add(time.Duration(quarantinedRaceLogicalClockElapsed.Load()))
+	}
+}
+
+func advanceQuarantinedRaceLogicalClock(delta time.Duration) {
+	quarantinedRaceLogicalClockElapsed.Add(delta.Nanoseconds())
+}
+
 func TestQuarantinedRaceFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
@@ -1152,12 +1168,8 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 	released := make(chan struct{})
 	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
 		(*T)(t).Parallel()
-		select {
-		case <-released:
-			writeQuarantinedRaceIsolationPID(t, "parallel-coverage-child")
-		case <-time.After(2 * time.Second):
-			t.Fatal("t.Parallel did not release t.Run back to its parent")
-		}
+		<-released
+		writeQuarantinedRaceIsolationPID(t, "parallel-coverage-child")
 		ready := make(chan struct{}, 2)
 		allReady := make(chan struct{})
 		go func() {
@@ -1179,11 +1191,7 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 				for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
 				}
 				ready <- struct{}{}
-				select {
-				case <-allReady:
-				case <-time.After(2 * time.Second):
-					t.Fatal("covered parallel descendants could not rendezvous")
-				}
+				<-allReady
 			}))
 		}
 	}))
@@ -1197,8 +1205,9 @@ func TestQuarantinedRaceParallelDurationFixture(t *testing.T) {
 	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("suspended", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
+			advanceQuarantinedRaceLogicalClock(time.Second)
 		}))
-		time.Sleep(500 * time.Millisecond)
+		advanceQuarantinedRaceLogicalClock(100 * time.Second)
 	}))
 }
 
@@ -1209,7 +1218,7 @@ func TestQuarantinedRaceParallelWaitDurationFixture(t *testing.T) {
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("slow", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			time.Sleep(500 * time.Millisecond)
+			advanceQuarantinedRaceLogicalClock(100 * time.Second)
 		}))
 	}))
 }
@@ -1267,24 +1276,28 @@ func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
 			return
 		}
 		if scenario == "managed-descendant-concurrent-failure" {
+			siblingFailed := make(chan struct{})
 			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 				(*T)(t).Parallel()
-				time.Sleep(20 * time.Millisecond)
+				<-siblingFailed
 				t.Error("managed descendant sentinel")
 			}))
 			t.Run("sibling", instrumentTestingTFunc(func(t *testing.T) {
 				(*T)(t).Parallel()
 				t.Error("unmanaged sibling sentinel")
+				close(siblingFailed)
 			}))
 			return
 		}
 		if scenario == "managed-descendant-root-failure" {
+			rootFailed := make(chan struct{})
 			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 				(*T)(t).Parallel()
-				time.Sleep(20 * time.Millisecond)
+				<-rootFailed
 				t.Error("managed descendant sentinel")
 			}))
 			t.Error("selected root failure sentinel")
+			close(rootFailed)
 			return
 		}
 		passed := t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
@@ -1380,10 +1393,7 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 	t.Run("parallel", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			// Keep the body longer than race/coverage instrumentation overhead so
-			// the root-versus-child finish ordering checks the excluded scheduler
-			// wait instead of depending on machine speed.
-			time.Sleep(500 * time.Millisecond)
+			advanceQuarantinedRaceLogicalClock(100 * time.Second)
 			t.Error("parallel descendant sentinel")
 		}))
 	}))

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -20,7 +20,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
@@ -50,7 +52,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 	}
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
-	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, "1")
+	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, "2")
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
@@ -107,6 +109,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if readPID("paypal") != parentPID {
 		panic("non-quarantined sibling did not stay in the parent process")
 	}
+	if testing.CoverMode() != "" && readPID("coverage-serialized") == parentPID {
+		panic("covered concurrent subtests were not serialized in the child process")
+	}
 	atf0, atf1 := readPID("atf-1"), readPID("atf-2")
 	if atf0 == parentPID || atf1 == parentPID || atf0 == atf1 {
 		panic("attempt-to-fix executions did not use fresh child processes")
@@ -124,7 +129,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 	}
 	if spanTypes[constants.SpanTypeTestSession] != 1 || spanTypes[constants.SpanTypeTestModule] != 1 ||
-		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 17 {
+		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 19 {
 		panic(fmt.Sprintf("unexpected parent-owned CI Visibility span counts: %#v", spanTypes))
 	}
 	raceSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFixture", 1)
@@ -143,7 +148,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagValue(atfSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 	atfChildSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAttemptToFixFixture/child", 2)
 	checkSpansByTagValue(atfChildSpans, constants.TestIsAttempToFix, "true", 2)
-	checkSpansByTagValue(atfChildSpans, constants.TestIsRetry, "true", 1)
+	checkSpansByTagValue(atfChildSpans, constants.TestIsRetry, "true", 0)
+	checkSpansByTagValue(atfChildSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 0)
+	checkSpansByTagValue(atfChildSpans, constants.TestAttemptToFixPassed, "true", 0)
 	nestedATFSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedATFFixture/card/visa", 2)
 	checkSpansByTagValue(nestedATFSpans, constants.TestIsAttempToFix, "true", 2)
 	checkSpansByTagValue(nestedATFSpans, constants.TestIsRetry, "true", 1)
@@ -164,10 +171,27 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	checkSpansByTagValue(skippedSpans, constants.TestStatus, constants.TestStatusSkip, 1)
 	checkSpansByTagValue(skippedSpans, constants.TestSkipReason, "fixture skip", 1)
 	visaSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/visa", 1)
+	checkSpansByTagValue(visaSpans, constants.TestStatus, constants.TestStatusPass, 1)
 	checkSpansByTagName(visaSpans, constants.TestSourceFile, 1)
 	checkSpansByTagName(visaSpans, constants.TestSourceStartLine, 1)
 	checkSpansByTagName(visaSpans, constants.TestSourceEndLine, 1)
 	checkSpansByTagName(visaSpans, constants.TestCodeOwners, 1)
+	mastercardSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/mastercard", 1)
+	checkSpansByTagValue(mastercardSpans, constants.TestStatus, constants.TestStatusFail, 1)
+	for _, name := range []string{"concurrent-a", "concurrent-b"} {
+		childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/"+name, 1)
+		checkSpansByTagValue(childSpans, constants.TestStatus, constants.TestStatusPass, 1)
+	}
+	rootRaceReport := false
+	for _, entry := range logsEntries {
+		if entry.TestName == "TestQuarantinedRaceNestedFixture/card" && strings.Contains(entry.Message, "WARNING: DATA RACE") {
+			rootRaceReport = true
+			break
+		}
+	}
+	if !rootRaceReport {
+		panic("selected quarantined root did not preserve the child race-detector report")
+	}
 	os.Exit(0)
 }
 
@@ -229,6 +253,10 @@ func TestQuarantinedRaceFixture(t *testing.T) {
 		t.Skip("fixture subprocess only")
 	}
 	writeQuarantinedRaceIsolationPID(t, "race")
+	triggerQuarantinedRaceFixture()
+}
+
+func triggerQuarantinedRaceFixture() {
 	var value int
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -279,14 +307,37 @@ func TestQuarantinedRaceNestedFixture(t *testing.T) {
 			writeQuarantinedRaceIsolationPID(t, "visa")
 		}))
 		t.Run("mastercard", instrumentTestingTFunc(func(t *testing.T) {
-			t.Parallel()
 			writeQuarantinedRaceIsolationPID(t, "mastercard")
+			triggerQuarantinedRaceFixture()
 		}))
 		t.Run("skipped", instrumentTestingTFunc(func(t *testing.T) {
 			writeQuarantinedRaceIsolationPID(t, "skipped")
 			instrumentCaptureFormattedSkip(t, "Skip", "fixture skip\n")
 			t.Skip("fixture skip")
 		}))
+		var active atomic.Int32
+		var maximum atomic.Int32
+		var concurrent sync.WaitGroup
+		for _, name := range []string{"concurrent-a", "concurrent-b"} {
+			concurrent.Add(1)
+			go func() {
+				defer concurrent.Done()
+				t.Run(name, instrumentTestingTFunc(func(t *testing.T) {
+					if testing.CoverMode() != "" {
+						t.Parallel()
+					}
+					current := active.Add(1)
+					defer active.Add(-1)
+					for observed := maximum.Load(); current > observed && !maximum.CompareAndSwap(observed, current); observed = maximum.Load() {
+					}
+					time.Sleep(20 * time.Millisecond)
+				}))
+			}()
+		}
+		concurrent.Wait()
+		if testing.CoverMode() != "" && maximum.Load() == 1 {
+			writeQuarantinedRaceIsolationPID(t, "coverage-serialized")
+		}
 	}))
 	t.Run("paypal", instrumentTestingTFunc(func(t *testing.T) {
 		writeQuarantinedRaceIsolationPID(t, "paypal")

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -125,6 +125,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 
 					"TestQuarantinedRaceManagedDescendantFixture/root":           properties(false),
 					"TestQuarantinedRaceManagedDescendantFixture/root/child":     properties(false),
+					"TestQuarantinedRaceManagedDescendantFixture/root/first":     properties(false),
+					"TestQuarantinedRaceManagedDescendantFixture/root/second":    properties(false),
 					"TestQuarantinedRaceNestedRootTerminalFixture/panic":         properties(false),
 					"TestQuarantinedRaceNestedRootTerminalFixture/goexit":        properties(false),
 					"TestQuarantinedRaceNestedRootTerminalFixture/cleanup-panic": properties(false),
@@ -288,6 +290,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			span := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/"+name, 1)
 			checkSpansByTagValue(span, constants.TestStatus, constants.TestStatusFail, 1)
 		}
+		os.Exit(0)
+	case "managed-descendant-concurrent-managed":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+		first := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/first", 1)
+		checkSpansByTagValue(first, constants.TestStatus, constants.TestStatusFail, 1)
+		second := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/second", 1)
+		checkSpansByTagValue(second, constants.TestStatus, constants.TestStatusPass, 1)
 		os.Exit(0)
 	case "managed-descendant-root-failure":
 		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
@@ -634,6 +644,10 @@ func TestQuarantinedRaceManagedDescendantMaskingEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceManagedDescendantPreservesConcurrentFailureEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "managed-descendant-concurrent-failure", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceManagedDescendantsDoNotLeakConcurrentFailureEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "managed-descendant-concurrent-managed", "^TestQuarantinedRaceManagedDescendantFixture$")
 }
 
 func TestQuarantinedRaceManagedDescendantPreservesRootFailureEndToEnd(t *testing.T) {
@@ -983,6 +997,38 @@ func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
 	}
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
 		scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
+		if scenario == "managed-descendant-concurrent-managed" {
+			failed := make(chan struct{})
+			firstRelease := make(chan struct{})
+			firstDone := make(chan struct{})
+			secondStarted := make(chan struct{})
+			secondRelease := make(chan struct{})
+			var runs sync.WaitGroup
+			runs.Add(2)
+			go func() {
+				defer runs.Done()
+				t.Run("first", instrumentTestingTFunc(func(t *testing.T) {
+					t.Error("first managed descendant sentinel")
+					close(failed)
+					<-firstRelease
+				}))
+				close(firstDone)
+			}()
+			<-failed
+			go func() {
+				defer runs.Done()
+				t.Run("second", instrumentTestingTFunc(func(*testing.T) {
+					close(secondStarted)
+					<-secondRelease
+				}))
+			}()
+			<-secondStarted
+			close(firstRelease)
+			<-firstDone
+			close(secondRelease)
+			runs.Wait()
+			return
+		}
 		if scenario == "managed-descendant-concurrent-failure" {
 			t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 				(*T)(t).Parallel()

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -104,9 +104,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
 					"TestQuarantinedRaceAncestorPanicFixture/isolated":       properties(false),
+					"TestQuarantinedRaceAncestorFailureFixture/isolated":     properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/parallel": properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
 					"TestQuarantinedRaceTerminalDescendantsFixture/goexit":   properties(false),
+					"TestQuarantinedRaceTerminalDescendantsFixture/output":   properties(false),
 				}},
 				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
@@ -176,7 +178,22 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		if message, _ := goexitChild[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, "runtime.Goexit") {
 			panic(fmt.Sprintf("bare Goexit was not reported on the isolated descendant: %q", message))
 		}
-		os.Exit(0)
+		outputRootName := "TestQuarantinedRaceTerminalDescendantsFixture/output"
+		outputRoot := checkSpansByResourceName(spans, suite+"."+outputRootName, 1)
+		checkSpansByTagValue(outputRoot, constants.TestStatus, constants.TestStatusFail, 1)
+		outputChild := checkSpansByResourceName(spans, suite+"."+outputRootName+"/child", 1)
+		checkSpansByTagValue(outputChild, constants.TestStatus, constants.TestStatusFail, 1)
+		stdout, stderr := false, false
+		for _, entry := range logsEntries {
+			if entry.TestName == outputRootName {
+				stdout = stdout || strings.Contains(entry.Message, "direct stdout sentinel")
+				stderr = stderr || strings.Contains(entry.Message, "direct stderr sentinel")
+			}
+		}
+		if stdout && stderr {
+			os.Exit(0)
+		}
+		panic("non-race child process output was not preserved on the selected root")
 	case "race-before-parallel":
 		races := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceBeforeParallelFixture/isolated", 1)
 		checkSpansByTagValue(races, constants.TestStatus, constants.TestStatusFail, 1)
@@ -187,9 +204,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 		panic("race before t.Parallel was not preserved in the selected root output")
 	case "ancestor-terminal":
-		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAncestorPanicFixture/isolated", 1)
-		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
-		checkSpansByTagValue(root, ext.ErrorType, "test_panic", 0)
+		for _, fixture := range []string{"Panic", "Failure"} {
+			root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAncestor"+fixture+"Fixture/isolated", 1)
+			checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
+			checkSpansByTagValue(root, ext.ErrorType, "test_panic", 0)
+		}
 		os.Exit(0)
 	case "testify-source":
 		if readPID("testify-source") == parentPID {
@@ -397,7 +416,7 @@ func TestQuarantinedRaceBeforeParallelEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceAncestorPanicEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "ancestor-terminal", "^TestQuarantinedRaceAncestorPanicFixture$")
+	runQuarantinedRaceEndToEnd(t, "ancestor-terminal", "^TestQuarantinedRaceAncestor(Panic|Failure)Fixture$")
 }
 
 func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
@@ -633,6 +652,13 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 			runtime.Goexit()
 		}))
 	}))
+	t.Run("output", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+			_, _ = fmt.Fprintln(os.Stdout, "direct stdout sentinel")
+			_, _ = fmt.Fprintln(os.Stderr, "direct stderr sentinel")
+			t.Error("non-race failure sentinel")
+		}))
+	}))
 }
 
 func TestQuarantinedRaceBeforeParallelFixture(t *testing.T) {
@@ -652,6 +678,16 @@ func TestQuarantinedRaceAncestorPanicFixture(t *testing.T) {
 	t.Run("isolated", instrumentTestingTFunc(func(*testing.T) {}))
 	if isProcessRetryChild() {
 		panic("ancestor panic sentinel")
+	}
+}
+
+func TestQuarantinedRaceAncestorFailureFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(*testing.T) {}))
+	if isProcessRetryChild() {
+		t.Error("ancestor failure sentinel")
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -68,8 +68,13 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
 	}
-	if scenario == "parallel-atf-sibling" || scenario == "parallel-denied" {
-		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "2s")
+	// These fixture limits detect protocol deadlocks, not instrumentation speed:
+	// race and coverage teardown can legitimately take several seconds in CI.
+	if scenario == "parallel-atf-sibling" {
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
+	}
+	if scenario == "parallel-denied" {
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
 	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
@@ -749,14 +754,14 @@ func TestQuarantinedRaceNestedAggregateCoverageEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "nested-aggregate-coverage-control", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+controlPath)
 	profilePath := filepath.Join(t.TempDir(), "coverage.out")
 	runQuarantinedRaceEndToEnd(t, "nested-aggregate-coverage", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+profilePath)
-	controlCount := processCoverageCountForFunction(t, controlPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
-	serialCount := processCoverageCountForFunction(t, profilePath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
+	controlCount := processCoverageCountForFunctionBody(t, controlPath, "quarantine_process.go", "processRetryCommonInfoFromSubtreeResult")
+	serialCount := processCoverageCountForFunctionBody(t, profilePath, "quarantine_process.go", "processRetryCommonInfoFromSubtreeResult")
 	require.Equal(t, controlCount+1, serialCount)
 	// The nested subprocesses share Go's outer coverage directory, so compare
 	// successive profiles to assert that each scenario merges the marker once.
 	parallelPath := filepath.Join(t.TempDir(), "parallel.out")
 	runQuarantinedRaceEndToEnd(t, "nested-aggregate-parallel-coverage", "^TestQuarantinedRaceAggregateCoverageFixture$", "-test.coverprofile="+parallelPath)
-	require.Equal(t, serialCount+1, processCoverageCountForFunction(t, parallelPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount"))
+	require.Equal(t, serialCount+1, processCoverageCountForFunctionBody(t, parallelPath, "quarantine_process.go", "processRetryCommonInfoFromSubtreeResult"))
 }
 
 func TestQuarantinedRaceNestedAttemptFamilyEndToEnd(t *testing.T) {
@@ -1361,7 +1366,8 @@ func TestQuarantinedRaceAggregateCoverageFixture(t *testing.T) {
 		}
 	}))
 	if scenario == "nested-aggregate-coverage" || scenario == "nested-aggregate-parallel-coverage" {
-		quarantinedRaceAncestorCoverage.Store(int64(processRetryAttemptToFixExecutionCount(1)))
+		marker := processRetryCommonInfoFromSubtreeResult(processRetrySubtreeResult{TestName: "aggregate-coverage-marker"})
+		quarantinedRaceAncestorCoverage.Store(int64(len(marker.testName)))
 	}
 }
 
@@ -1374,7 +1380,10 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 	t.Run("parallel", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			time.Sleep(20 * time.Millisecond)
+			// Keep the body longer than race/coverage instrumentation overhead so
+			// the root-versus-child finish ordering checks the excluded scheduler
+			// wait instead of depending on machine speed.
+			time.Sleep(500 * time.Millisecond)
 			t.Error("parallel descendant sentinel")
 		}))
 	}))

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -62,6 +63,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
+	testifySuite := suite + "/quarantinedRaceTestifySuite"
 	properties := func(attemptToFix bool) net.TestManagementTestsResponseDataTestProperties {
 		return net.TestManagementTestsResponseDataTestProperties{
 			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
@@ -91,6 +93,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceFailfastRootFixture":             properties(true),
 					"TestQuarantinedRaceFailfastDescendantFixture":       properties(false),
 					"TestQuarantinedRaceFailfastDescendantFixture/child": properties(true),
+					"TestQuarantinedRaceParallelFixture/isolated":        properties(false),
+				}},
+				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
+					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
 				}},
 			}},
 		}}, false, nil)
@@ -114,6 +120,24 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	}
 	spans := mTracer.FinishedSpans()
 	switch scenario {
+	case "parallel-admission":
+		if readPID("parallel-child") == parentPID || readPID("parallel-sibling") != parentPID {
+			panic("parallel quarantined root did not overlap its parent-process sibling")
+		}
+		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelFixture/isolated", 1)
+		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		os.Exit(0)
+	case "testify-source":
+		if readPID("testify-source") == parentPID {
+			panic("Testify method did not run in the isolated child")
+		}
+		testifySpans := checkSpansByResourceName(spans, testifySuite+".TestQuarantinedRaceTestifyFixture/TestSource", 1)
+		method := runtime.FuncForPC(reflect.ValueOf((*quarantinedRaceTestifySuite).TestSource).Pointer())
+		_, sourceLine := method.FileLine(method.Entry())
+		if got := fmt.Sprint(testifySpans[0].Tag(constants.TestSourceStartLine)); got != strconv.Itoa(sourceLine) {
+			panic(fmt.Sprintf("Testify source line = %s, want method line %d", got, sourceLine))
+		}
+		os.Exit(0)
 	case "feature-gate":
 		if readPID("feature-gate-disabled") == parentPID {
 			panic("subtest feature gate fixture did not run in the isolated child")
@@ -276,6 +300,14 @@ func TestQuarantinedRaceCleanupEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "failfast", "^TestQuarantinedRaceFailfast(Root|Descendant)Fixture$", "-test.failfast")
+}
+
+func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$")
+}
+
+func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "testify-source", "^TestQuarantinedRaceTestifyFixture$")
 }
 
 func runQuarantinedRaceEndToEnd(t *testing.T, scenario, pattern string, extraArgs ...string) {
@@ -446,6 +478,50 @@ func TestQuarantinedRaceNestedFixture(t *testing.T) {
 	}))
 	t.Run("paypal", instrumentTestingTFunc(func(t *testing.T) {
 		writeQuarantinedRaceIsolationPID(t, "paypal")
+	}))
+}
+
+func TestQuarantinedRaceParallelFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		(*T)(t).Parallel()
+		writeQuarantinedRaceIsolationPID(t, "parallel-child")
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "parallel-sibling")); err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("parallel sibling was not admitted while the isolated body was running")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}))
+	t.Run("sibling", instrumentTestingTFunc(func(t *testing.T) {
+		(*T)(t).Parallel()
+		writeQuarantinedRaceIsolationPID(t, "parallel-sibling")
+	}))
+}
+
+type quarantinedRaceTestifySuite struct {
+	t *testing.T
+}
+
+func (s *quarantinedRaceTestifySuite) TestSource() {
+	writeQuarantinedRaceIsolationPID(s.t, "testify-source")
+}
+
+func TestQuarantinedRaceTestifyFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	suite := &quarantinedRaceTestifySuite{}
+	instrumentTestifySuiteRun(t, suite)
+	t.Run("TestSource", instrumentTestingTFunc(func(t *testing.T) {
+		suite.t = t
+		suite.TestSource()
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -94,14 +94,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceSubtestFeatureGateFixture/disabled": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
 					},
-					"TestQuarantinedRaceCleanupPanicFixture":              properties(false),
-					"TestQuarantinedRaceCleanupFailNowFixture":            properties(false),
-					"TestQuarantinedRaceCleanupGoexitFixture":             properties(false),
-					"TestQuarantinedRaceFailfastRootFixture":              properties(true),
-					"TestQuarantinedRaceFailfastDescendantFixture":        properties(false),
-					"TestQuarantinedRaceFailfastDescendantFixture/child":  properties(true),
-					"TestQuarantinedRaceParallelFixture/isolated":         properties(false),
-					"TestQuarantinedRaceParallelCoverageFixture/isolated": properties(false),
+					"TestQuarantinedRaceCleanupPanicFixture":                 properties(false),
+					"TestQuarantinedRaceCleanupFailNowFixture":               properties(false),
+					"TestQuarantinedRaceCleanupGoexitFixture":                properties(false),
+					"TestQuarantinedRaceFailfastRootFixture":                 properties(true),
+					"TestQuarantinedRaceFailfastDescendantFixture":           properties(false),
+					"TestQuarantinedRaceFailfastDescendantFixture/child":     properties(true),
+					"TestQuarantinedRaceParallelFixture/isolated":            properties(false),
+					"TestQuarantinedRaceParallelCoverageFixture/isolated":    properties(false),
+					"TestQuarantinedRaceTerminalDescendantsFixture/parallel": properties(false),
+					"TestQuarantinedRaceTerminalDescendantsFixture/panic":    properties(false),
 				}},
 				testifySuite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
 					"TestQuarantinedRaceTestifyFixture/TestSource": properties(false),
@@ -147,6 +149,22 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		for _, name := range []string{"concurrent-a", "concurrent-b"} {
 			childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelCoverageFixture/isolated/"+name, 1)
 			checkSpansByTagValue(childSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		}
+		os.Exit(0)
+	case "terminal-descendants":
+		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
+		checkSpansByTagValue(parallelRoot, constants.TestStatus, constants.TestStatusFail, 1)
+		parallelChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel/child", 1)
+		checkSpansByTagValue(parallelChild, constants.TestStatus, constants.TestStatusFail, 1)
+		if rootFinish, childFinish := parallelRoot[0].StartTime().Add(parallelRoot[0].Duration()), parallelChild[0].StartTime().Add(parallelChild[0].Duration()); rootFinish.Before(childFinish) {
+			panic("selected root finished before its parallel descendant")
+		}
+		panicRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/panic", 1)
+		checkSpansByTagValue(panicRoot, constants.TestStatus, constants.TestStatusFail, 1)
+		panicChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/panic/child", 1)
+		checkSpansByTagValue(panicChild, constants.TestStatus, constants.TestStatusFail, 1)
+		if message, _ := panicChild[0].Tag(ext.ErrorMsg).(string); !strings.Contains(message, "body panic sentinel") {
+			panic(fmt.Sprintf("body panic was not reported on the isolated descendant: %q", message))
 		}
 		os.Exit(0)
 	case "testify-source":
@@ -340,6 +358,10 @@ func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 		t.Skip("requires coverage instrumentation")
 	}
 	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$")
+}
+
+func TestQuarantinedRaceTerminalDescendantsEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "terminal-descendants", "^TestQuarantinedRaceTerminalDescendantsFixture$")
 }
 
 func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
@@ -552,6 +574,24 @@ func TestQuarantinedRaceParallelCoverageFixture(t *testing.T) {
 		}
 	}))
 	close(released)
+}
+
+func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("parallel", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
+			(*T)(t).Parallel()
+			time.Sleep(20 * time.Millisecond)
+			t.Error("parallel descendant sentinel")
+		}))
+	}))
+	t.Run("panic", instrumentTestingTFunc(func(t *testing.T) {
+		t.Run("child", instrumentTestingTFunc(func(*testing.T) {
+			panic("body panic sentinel")
+		}))
+	}))
 }
 
 type quarantinedRaceTestifySuite struct {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -169,6 +169,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					},
 					"TestQuarantinedRaceDeferredDynamicDescendantFixture/quarantined": properties(false),
 					"TestQuarantinedRaceDeferredDynamicDescendantFixture/dynamic":     properties(true),
+					"TestQuarantinedRaceInitialInheritedFixture": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceInitialInheritedFixture/initial": properties(false),
+					"TestQuarantinedRaceDeferredAggregateCoverageFixture": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceDeferredAggregateCoverageFixture/quarantined": properties(false),
 
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
@@ -455,6 +463,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(dynamic, constants.TestIsAttempToFix, "true", 1)
 		checkSpansByTagValue(dynamic, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		checkSpansByTagValue(dynamic, constants.TestAttemptToFixPassed, "true", 1)
+		os.Exit(0)
+	case "initial-inherited-finality":
+		initial := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceInitialInheritedFixture/initial", 1)
+		checkSpansByTagValue(initial, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		os.Exit(0)
+	case "deferred-aggregate-coverage", "deferred-aggregate-coverage-control":
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -801,6 +815,23 @@ func TestQuarantinedRaceDeferredDynamicDescendantFinalityEndToEnd(t *testing.T) 
 	runQuarantinedRaceEndToEnd(t, "deferred-dynamic-descendant-finality", "^TestQuarantinedRaceDeferredDynamicDescendantFixture$")
 }
 
+func TestQuarantinedRaceInitialInheritedFinalityEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "initial-inherited-finality", "^TestQuarantinedRaceInitialInheritedFixture$")
+}
+
+func TestQuarantinedRaceDeferredAggregateCoverageEndToEnd(t *testing.T) {
+	if testing.CoverMode() == "" {
+		t.Skip("requires coverage instrumentation")
+	}
+	controlPath := filepath.Join(t.TempDir(), "control.out")
+	runQuarantinedRaceEndToEnd(t, "deferred-aggregate-coverage-control", "^TestQuarantinedRaceDeferredAggregateCoverageFixture$", "-test.coverprofile="+controlPath, "-test.gocoverdir="+t.TempDir())
+	profilePath := filepath.Join(t.TempDir(), "coverage.out")
+	runQuarantinedRaceEndToEnd(t, "deferred-aggregate-coverage", "^TestQuarantinedRaceDeferredAggregateCoverageFixture$", "-test.coverprofile="+profilePath, "-test.gocoverdir="+t.TempDir())
+	controlCount := processCoverageCountForFunctionBody(t, controlPath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
+	coveredCount := processCoverageCountForFunctionBody(t, profilePath, "quarantine_process.go", "processRetryAttemptToFixExecutionCount")
+	require.Equal(t, controlCount+1, coveredCount)
+}
+
 func TestQuarantinedRaceNestedRootTerminalsEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "nested-root-terminal", "^TestQuarantinedRaceNestedRootTerminalFixture$")
 }
@@ -844,7 +875,7 @@ func TestQuarantinedRaceTestifySourceEndToEnd(t *testing.T) {
 func runQuarantinedRaceEndToEnd(t *testing.T, scenario, pattern string, extraArgs ...string) {
 	t.Helper()
 	pidDir := t.TempDir()
-	args := append(buildTestControllerSubprocessArgs(os.Args[1:], pattern), extraArgs...)
+	args := buildTestControllerSubprocessArgs(os.Args[1:], pattern, extraArgs...)
 	cmd := exec.Command(os.Args[0], args...)
 	cmd.Env = append(os.Environ(),
 		quarantinedRaceIsolationFixtureEnv+"="+scenario,
@@ -894,6 +925,36 @@ func processCoverageCountForFunction(t *testing.T, profilePath, sourcePath, func
 		}
 	}
 	return total
+}
+
+func processCoverageCountForFunctionBody(t *testing.T, profilePath, sourcePath, functionName string) int {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, sourcePath, nil, 0)
+	require.NoError(t, err)
+	var start, finish token.Position
+	for _, declaration := range parsed.Decls {
+		if fn, ok := declaration.(*ast.FuncDecl); ok && fn.Name.Name == functionName {
+			start, finish = fset.Position(fn.Body.Pos()), fset.Position(fn.Body.End())
+			break
+		}
+	}
+	require.NotZero(t, start.Line)
+	profile, err := os.ReadFile(profilePath)
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(profile), "\n") {
+		separator := strings.LastIndexByte(line, ':')
+		if separator < 0 || !strings.HasSuffix(filepath.ToSlash(line[:separator]), "/gotesting/"+filepath.Base(sourcePath)) {
+			continue
+		}
+		var startLine, startColumn, endLine, endColumn, statements, count int
+		if _, err := fmt.Sscanf(line[separator+1:], "%d.%d,%d.%d %d %d", &startLine, &startColumn, &endLine, &endColumn, &statements, &count); err == nil &&
+			startLine == start.Line && startColumn == start.Column && endLine == finish.Line && endColumn == finish.Column {
+			return count
+		}
+	}
+	t.Fatalf("coverage block for %s not found", functionName)
+	return 0
 }
 
 func writeQuarantinedRaceIsolationPID(t *testing.T, name string) {
@@ -1562,5 +1623,35 @@ func TestQuarantinedRaceDeferredDynamicDescendantFixture(t *testing.T) {
 	require.NoError(t, err)
 	if cfg.Attempt == 1 {
 		t.Run("dynamic", instrumentTestingTFunc(func(*testing.T) {}))
+	}
+}
+
+func TestQuarantinedRaceInitialInheritedFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	if !isProcessRetryChild() {
+		t.Run("initial", instrumentTestingTFunc(func(*testing.T) {}))
+		return
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	if strings.HasSuffix(cfg.TestName, "/initial") {
+		t.Run("initial", instrumentTestingTFunc(func(*testing.T) {}))
+	}
+}
+
+func TestQuarantinedRaceDeferredAggregateCoverageFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("quarantined", instrumentTestingTFunc(func(*testing.T) {}))
+	if !isProcessRetryChild() {
+		return
+	}
+	cfg, err := processRetryChildConfigFromEnv()
+	require.NoError(t, err)
+	if cfg.TestName == "TestQuarantinedRaceDeferredAggregateCoverageFixture" && os.Getenv(quarantinedRaceIsolationFixtureEnv) == "deferred-aggregate-coverage" {
+		require.Equal(t, 1, processRetryAttemptToFixExecutionCount(1))
 	}
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -68,13 +68,20 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
 	}
-	if scenario == "parallel-atf-sibling" {
+	if scenario == "parallel-atf-sibling" || scenario == "parallel-denied" {
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "2s")
 	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	suite := "quarantine_process_race_test.go"
 	testifySuite := suite + "/quarantinedRaceTestifySuite"
+	itrEnabled := scenario == "foreign-suite"
+	var itrData []net.SkippableResponseDataAttributes
+	if itrEnabled {
+		itrData = []net.SkippableResponseDataAttributes{{
+			Suite: "quarantine_process_test.go", Name: "TestQuarantinedRaceForeignSuiteFixture/root/itr",
+		}}
+	}
 	properties := func(attemptToFix bool) net.TestManagementTestsResponseDataTestProperties {
 		return net.TestManagementTestsResponseDataTestProperties{
 			Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{
@@ -82,7 +89,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			},
 		}
 	}
-	server := setUpHTTPServer(false, false, false, nil, false, nil, true,
+	server := setUpHTTPServer(false, false, false, nil, itrEnabled, itrData, true,
 		&net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
 			module: {Suites: map[string]net.TestManagementTestsResponseDataTests{
 				suite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
@@ -140,6 +147,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 					"TestQuarantinedRaceSerialATFFixture/root":                   properties(false),
 					"TestQuarantinedRaceSerialATFFixture/root/owner":             properties(true),
 					"TestQuarantinedRaceForeignSuiteFixture/root":                properties(false),
+					"TestQuarantinedRaceForeignSuiteFixture/root/parent":         properties(true),
+					"TestQuarantinedRaceParallelDeniedFixture/isolated":          properties(false),
 					"TestQuarantinedRaceAncestorATFFixture": {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
 					},
@@ -240,6 +249,12 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 		parallelSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelFixture/isolated", 1)
 		checkSpansByTagValue(parallelSpans, constants.TestStatus, constants.TestStatusPass, 1)
+		os.Exit(0)
+	case "parallel-denied":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelDeniedFixture/isolated", 1)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusFail, 1)
+		checkSpansByTagValue(root, ext.ErrorType, "panic", 1)
+		checkSpansByTagValue(root, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 		os.Exit(0)
 	case "parallel-root-slots":
 		one, two := readPID("parallel-root-one-child"), readPID("parallel-root-two-child")
@@ -373,6 +388,13 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		foreign := checkSpansByResourceName(spans, foreignSuite+".TestQuarantinedRaceForeignSuiteFixture/root/foreign", 1)
 		checkSpansByTagValue(foreign, constants.TestStatus, constants.TestStatusSkip, 1)
 		checkSpansByTagValue(foreign, constants.TestIsDisabled, "true", 1)
+		itr := checkSpansByResourceName(spans, foreignSuite+".TestQuarantinedRaceForeignSuiteFixture/root/itr", 1)
+		checkSpansByTagValue(itr, constants.TestSkippedByITR, "true", 1)
+		parent := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceForeignSuiteFixture/root/parent", 2)
+		checkSpansByTagValue(parent, constants.TestIsAttempToFix, "true", 2)
+		child := checkSpansByResourceName(spans, foreignSuite+".TestQuarantinedRaceForeignSuiteFixture/root/parent/child", 2)
+		checkSpansByTagValue(child, constants.TestIsAttempToFix, "true", 2)
+		checkSpansByTagValue(child, constants.TestIsRetry, "true", 1)
 		os.Exit(0)
 	case "ancestor-atf":
 		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceAncestorATFFixture/child", 2)
@@ -632,6 +654,10 @@ func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
 
 func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$")
+}
+
+func TestQuarantinedRaceParallelDeniedEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "parallel-denied", "^TestQuarantinedRaceParallelDeniedFixture$", "-test.timeout=10s")
 }
 
 func TestQuarantinedRaceParallelRootsReleaseProcessSlotsEndToEnd(t *testing.T) {
@@ -1376,6 +1402,22 @@ func TestQuarantinedRaceForeignSuiteFixture(t *testing.T) {
 	}
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("foreign", instrumentTestingTFunc(quarantinedRaceForeignSuiteCallback))
+		t.Run("itr", instrumentTestingTFunc(quarantinedRaceForeignSuiteITRCallback))
+		t.Run("parent", instrumentTestingTFunc(quarantinedRaceForeignSuiteParentCallback))
+	}))
+}
+
+func quarantinedRaceForeignSuiteParentCallback(t *testing.T) {
+	t.Run("child", instrumentTestingTFunc(quarantinedRaceHomeSuiteCallback))
+}
+
+func TestQuarantinedRaceParallelDeniedFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
+		t.Setenv("DD_TEST_PARALLEL_ADMISSION", "denied")
+		t.Parallel()
 	}))
 }
 

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -153,6 +153,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
 					},
 					"TestQuarantinedRaceAncestorATFFixture/child": properties(true),
+					"TestQuarantinedRaceDeferredDescendantATFFixture": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
+					"TestQuarantinedRaceDeferredDescendantATFFixture/quarantined": properties(false),
+					"TestQuarantinedRaceDeferredDescendantATFFixture/clear":       {},
+					"TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{AttemptToFix: true},
+					},
 
 					"TestQuarantinedRaceAggregateCoverageFixture/isolated":   properties(false),
 					"TestQuarantinedRaceBeforeParallelFixture/isolated":      properties(false),
@@ -178,7 +186,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	currentM = m
 	mTracer = integrations.InitializeCIVisibilityMock()
 	exitCode := RunM(m)
-	if exitCode != 0 {
+	expectFailure := scenario == "deferred-descendant-atf-failure"
+	if (exitCode != 0) != expectFailure {
 		panic(fmt.Sprintf("quarantined race isolation fixture exit code = %d", exitCode))
 	}
 
@@ -337,12 +346,14 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	case "managed-descendant-output":
 		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root", 1)
 		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 1)
-		childName := "TestQuarantinedRaceManagedDescendantFixture/root/child"
-		child := checkSpansByResourceName(spans, suite+"."+childName, 1)
-		checkSpansByTagValue(child, constants.TestStatus, constants.TestStatusFail, 1)
+		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceManagedDescendantFixture/root/child", 1)
+		checkSpansByTagValue(child, constants.TestStatus, constants.TestStatusPass, 1)
+		grandchildName := "TestQuarantinedRaceManagedDescendantFixture/root/child/grandchild"
+		grandchild := checkSpansByResourceName(spans, suite+"."+grandchildName, 1)
+		checkSpansByTagValue(grandchild, constants.TestStatus, constants.TestStatusFail, 1)
 		stdout, stderr := false, false
 		for _, entry := range logsEntries {
-			if entry.TestName == childName {
+			if entry.TestName == grandchildName {
 				stdout = stdout || strings.Contains(entry.Message, "managed descendant stdout sentinel")
 				stderr = stderr || strings.Contains(entry.Message, "managed descendant stderr sentinel")
 			}
@@ -403,6 +414,13 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(child, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
 		checkSpansByTagValue(child, constants.TestAttemptToFixPassed, "false", 1)
 		checkSpansByTagValue(child, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		os.Exit(0)
+	case "deferred-descendant-atf-failure":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture", 2)
+		checkSpansByTagValue(root, constants.TestStatus, constants.TestStatusPass, 2)
+		owner := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceDeferredDescendantATFFixture/clear/owner", 1)
+		checkSpansByTagValue(owner, constants.TestStatus, constants.TestStatusFail, 1)
+		checkSpansByTagValue(owner, constants.TestIsAttempToFix, "true", 1)
 		os.Exit(0)
 	case "terminal-descendants":
 		parallelRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel", 1)
@@ -727,6 +745,10 @@ func TestQuarantinedRaceManagedDescendantPreservesRootFailureEndToEnd(t *testing
 
 func TestQuarantinedRaceManagedDescendantPreservesProcessOutputEndToEnd(t *testing.T) {
 	runQuarantinedRaceEndToEnd(t, "managed-descendant-output", "^TestQuarantinedRaceManagedDescendantFixture$")
+}
+
+func TestQuarantinedRaceDeferredDescendantATFFailureFailsPackageEndToEnd(t *testing.T) {
+	runQuarantinedRaceEndToEnd(t, "deferred-descendant-atf-failure", "^TestQuarantinedRaceDeferredDescendantATFFixture$")
 }
 
 func TestQuarantinedRaceNestedRootTerminalsEndToEnd(t *testing.T) {
@@ -1135,8 +1157,12 @@ func TestQuarantinedRaceManagedDescendantFixture(t *testing.T) {
 		}
 		passed := t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 			if scenario == "managed-descendant-output" {
-				_, _ = fmt.Fprintln(os.Stdout, "managed descendant stdout sentinel")
-				_, _ = fmt.Fprintln(os.Stderr, "managed descendant stderr sentinel")
+				t.Run("grandchild", instrumentTestingTFunc(func(t *testing.T) {
+					_, _ = fmt.Fprintln(os.Stdout, "managed descendant stdout sentinel")
+					_, _ = fmt.Fprintln(os.Stderr, "managed descendant stderr sentinel")
+					t.Error("managed descendant sentinel")
+				}))
+				return
 			}
 			t.Error("managed descendant sentinel")
 		}))
@@ -1430,6 +1456,20 @@ func TestQuarantinedRaceAncestorATFFixture(t *testing.T) {
 		require.NoError(t, err)
 		if cfg.RetryReason == processRetrySubtreeReason {
 			t.Fail()
+		}
+	}))
+}
+
+func TestQuarantinedRaceDeferredDescendantATFFixture(t *testing.T) {
+	if !quarantinedRaceIsolationFixtureSelected() {
+		t.Skip("fixture subprocess only")
+	}
+	t.Run("quarantined", instrumentTestingTFunc(func(*testing.T) {}))
+	t.Run("clear", instrumentTestingTFunc(func(t *testing.T) {
+		if isProcessRetryChild() {
+			t.Run("owner", instrumentTestingTFunc(func(t *testing.T) {
+				t.Error("deferred descendant attempt-to-fix sentinel")
+			}))
 		}
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -56,7 +56,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	}
 	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
-	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, "2")
+	attempts := "2"
+	if scenario == "failfast" {
+		attempts = "3"
+	}
+	requireEnv(constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable, attempts)
 	if scenario == "feature-gate" {
 		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
 	}
@@ -75,12 +79,15 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		&net.TestManagementTestsResponseDataModules{Modules: map[string]net.TestManagementTestsResponseDataSuites{
 			module: {Suites: map[string]net.TestManagementTestsResponseDataTests{
 				suite: {Tests: map[string]net.TestManagementTestsResponseDataTestProperties{
-					"TestQuarantinedRaceFixture":                    properties(false),
-					"TestQuarantinedPanicFixture":                   properties(false),
-					"TestQuarantinedRaceSecondFixture":              properties(false),
-					"TestQuarantinedRaceAttemptToFixFixture":        properties(true),
-					"TestQuarantinedRaceLeafFixture/card/visa":      properties(false),
-					"TestQuarantinedRaceNestedFixture/card":         properties(false),
+					"TestQuarantinedRaceFixture":               properties(false),
+					"TestQuarantinedPanicFixture":              properties(false),
+					"TestQuarantinedRaceSecondFixture":         properties(false),
+					"TestQuarantinedRaceAttemptToFixFixture":   properties(true),
+					"TestQuarantinedRaceLeafFixture/card/visa": properties(false),
+					"TestQuarantinedRaceNestedFixture/card":    properties(false),
+					"TestQuarantinedRaceNestedFixture/card/disabled": {
+						Properties: net.TestManagementTestsResponseDataTestPropertiesAttributes{Disabled: true},
+					},
 					"TestQuarantinedRaceNestedATFFixture/card":      properties(false),
 					"TestQuarantinedRaceNestedATFFixture/card/visa": properties(true),
 					"TestQuarantinedRaceSubtestFeatureGateFixture":  properties(false),
@@ -157,15 +164,22 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(failNowSpans, constants.TestStatus, constants.TestStatusFail, 1)
 		os.Exit(0)
 	case "failfast":
-		for _, name := range []string{"failfast-root-2", "failfast-descendant-2"} {
+		for _, name := range []string{"failfast-root-3", "failfast-descendant-3"} {
 			if _, err := os.Stat(filepath.Join(pidDir, name)); err == nil || !os.IsNotExist(err) {
 				panic(name + " ran after a valid failure under -failfast")
 			}
 		}
 		readPID("failfast-root-1")
+		readPID("failfast-root-2")
 		readPID("failfast-descendant-1")
-		checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastRootFixture", 1)
-		checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFailfastDescendantFixture/child", 1)
+		readPID("failfast-descendant-2")
+		for _, name := range []string{"TestQuarantinedRaceFailfastRootFixture", "TestQuarantinedRaceFailfastDescendantFixture/child"} {
+			failfastSpans := checkSpansByResourceName(spans, suite+"."+name, 2)
+			checkSpansByTagValue(failfastSpans, constants.TestIsRetry, "true", 1)
+			checkSpansByTagValue(failfastSpans, constants.TestRetryReason, constants.AttemptToFixRetryReason, 1)
+			checkSpansByTagValue(failfastSpans, constants.TestAttemptToFixPassed, "false", 1)
+			checkSpansByTagValue(failfastSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
+		}
 		os.Exit(0)
 	}
 	racePID := readPID("race")
@@ -203,6 +217,9 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if _, err := os.Stat(filepath.Join(pidDir, "leaf-mastercard-child")); err == nil || !os.IsNotExist(err) {
 		panic("exact quarantined leaf also executed its sibling in the child process")
 	}
+	if _, err := os.Stat(filepath.Join(pidDir, "disabled-body")); err == nil || !os.IsNotExist(err) {
+		panic("disabled subtree descendant executed its body")
+	}
 
 	spanTypes := map[string]int{}
 	for _, span := range spans {
@@ -211,7 +228,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 	}
 	if spanTypes[constants.SpanTypeTestSession] != 1 || spanTypes[constants.SpanTypeTestModule] != 1 ||
-		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 23 {
+		spanTypes[constants.SpanTypeTestSuite] != 1 || spanTypes[constants.SpanTypeTest] != 24 {
 		panic(fmt.Sprintf("unexpected parent-owned CI Visibility span counts: %#v", spanTypes))
 	}
 	raceSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceFixture", 1)
@@ -258,6 +275,10 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	skippedSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/skipped", 1)
 	checkSpansByTagValue(skippedSpans, constants.TestStatus, constants.TestStatusSkip, 1)
 	checkSpansByTagValue(skippedSpans, constants.TestSkipReason, "fixture skip", 1)
+	disabledSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/disabled", 1)
+	checkSpansByTagValue(disabledSpans, constants.TestStatus, constants.TestStatusSkip, 1)
+	checkSpansByTagValue(disabledSpans, constants.TestIsDisabled, "true", 1)
+	checkSpansByTagValue(disabledSpans, constants.TestFinalStatus, constants.TestStatusSkip, 1)
 	visaSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceNestedFixture/card/visa", 1)
 	checkSpansByTagValue(visaSpans, constants.TestStatus, constants.TestStatusPass, 1)
 	checkSpansByTagName(visaSpans, constants.TestSourceFile, 1)
@@ -452,6 +473,9 @@ func TestQuarantinedRaceNestedFixture(t *testing.T) {
 			instrumentCaptureFormattedSkip(t, "Skip", "fixture skip\n")
 			t.Skip("fixture skip")
 		}))
+		t.Run("disabled", instrumentTestingTFunc(func(t *testing.T) {
+			writeQuarantinedRaceIsolationPID(t, "disabled-body")
+		}))
 		var active atomic.Int32
 		var maximum atomic.Int32
 		var concurrent sync.WaitGroup
@@ -581,7 +605,9 @@ func TestQuarantinedRaceFailfastRootFixture(t *testing.T) {
 	cfg, err := processRetryChildConfigFromEnv()
 	require.NoError(t, err)
 	writeQuarantinedRaceIsolationPID(t, "failfast-root-"+strconv.Itoa(cfg.Attempt))
-	t.Fail()
+	if cfg.Attempt > 1 {
+		t.Fail()
+	}
 }
 
 func TestQuarantinedRaceFailfastDescendantFixture(t *testing.T) {
@@ -592,6 +618,8 @@ func TestQuarantinedRaceFailfastDescendantFixture(t *testing.T) {
 		cfg, err := processRetryChildConfigFromEnv()
 		require.NoError(t, err)
 		writeQuarantinedRaceIsolationPID(t, "failfast-descendant-"+strconv.Itoa(cfg.Attempt))
-		t.Fail()
+		if cfg.Attempt > 1 {
+			t.Fail()
+		}
 	}))
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -44,10 +44,6 @@ func quarantinedRaceIsolationFixtureSelected() bool {
 }
 
 func runQuarantinedRaceIsolationFixture(m *testing.M) {
-	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
-	if scenario == "parallel-duration" || scenario == "parallel-wait-duration" || scenario == "terminal-descendants" {
-		installQuarantinedRaceLogicalClock()
-	}
 	// A process child must enter the existing no-op CI Visibility bootstrap
 	// directly. It never creates a session, fetches settings, or starts retries.
 	if isProcessRetryChild() {
@@ -58,6 +54,7 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 			panic(err)
 		}
 	}
+	scenario := os.Getenv(quarantinedRaceIsolationFixtureEnv)
 	requireEnv(constants.CIVisibilityRetryExecutionModeEnvironmentVariable, "process")
 	attempts := "2"
 	if scenario == "failfast" || scenario == "deferred-descendant-atf-failfast" || scenario == "deferred-dynamic-descendant-finality" {
@@ -319,19 +316,17 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		}
 		os.Exit(0)
 	case "parallel-duration":
+		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelDurationFixture/isolated", 1)
 		childSpans := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelDurationFixture/isolated/suspended", 1)
-		if got := childSpans[0].Duration(); got != time.Second {
-			panic(fmt.Sprintf("parallel child duration = %s, want 1s of logical active time", got))
+		if childSpans[0].Duration() >= root[0].Duration() {
+			panic(fmt.Sprintf("parallel suspension leaked into replayed child duration: child=%s root=%s", childSpans[0].Duration(), root[0].Duration()))
 		}
 		os.Exit(0)
 	case "parallel-wait-duration":
 		root := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root", 1)
-		if got := root[0].Duration(); got != 0 {
-			panic(fmt.Sprintf("parallel root duration = %s, want no logical active time", got))
-		}
 		child := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceParallelWaitDurationFixture/root/slow", 1)
-		if got := child[0].Duration(); got != 100*time.Second {
-			panic(fmt.Sprintf("parallel child duration = %s, want 100s of logical active time", got))
+		if root[0].Duration() >= child[0].Duration() {
+			panic(fmt.Sprintf("parallel descendant wait leaked into root duration: root=%s child=%s", root[0].Duration(), child[0].Duration()))
 		}
 		os.Exit(0)
 	case "dynamic-descendant-finality":
@@ -482,8 +477,8 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 		checkSpansByTagValue(parallelRoot, constants.TestStatus, constants.TestStatusFail, 1)
 		parallelChild := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/parallel/child", 1)
 		checkSpansByTagValue(parallelChild, constants.TestStatus, constants.TestStatusFail, 1)
-		if rootFinish, childFinish := parallelRoot[0].StartTime().Add(parallelRoot[0].Duration()), parallelChild[0].StartTime().Add(parallelChild[0].Duration()); !rootFinish.Before(childFinish) {
-			panic("parallel descendant wait leaked into selected root duration")
+		if parallelRoot[0].Duration() >= parallelChild[0].Duration() {
+			panic(fmt.Sprintf("parallel descendant wait leaked into selected root duration: root=%s child=%s", parallelRoot[0].Duration(), parallelChild[0].Duration()))
 		}
 		panicRoot := checkSpansByResourceName(spans, suite+".TestQuarantinedRaceTerminalDescendantsFixture/panic", 1)
 		checkSpansByTagValue(panicRoot, constants.TestStatus, constants.TestStatusFail, 1)
@@ -978,19 +973,6 @@ func writeQuarantinedRaceIsolationProcessPID(t *testing.T, name string) {
 	writeQuarantinedRaceIsolationPID(t, name+"-"+process)
 }
 
-var quarantinedRaceLogicalClockElapsed atomic.Int64
-
-func installQuarantinedRaceLogicalClock() {
-	origin := time.Unix(1, 0)
-	quarantinedRaceNow = func() time.Time {
-		return origin.Add(time.Duration(quarantinedRaceLogicalClockElapsed.Load()))
-	}
-}
-
-func advanceQuarantinedRaceLogicalClock(delta time.Duration) {
-	quarantinedRaceLogicalClockElapsed.Add(delta.Nanoseconds())
-}
-
 func TestQuarantinedRaceFixture(t *testing.T) {
 	if !quarantinedRaceIsolationFixtureSelected() {
 		t.Skip("fixture subprocess only")
@@ -1200,9 +1182,8 @@ func TestQuarantinedRaceParallelDurationFixture(t *testing.T) {
 	t.Run("isolated", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("suspended", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			advanceQuarantinedRaceLogicalClock(time.Second)
 		}))
-		advanceQuarantinedRaceLogicalClock(100 * time.Second)
+		runQuarantinedRaceActiveWork()
 	}))
 }
 
@@ -1213,9 +1194,25 @@ func TestQuarantinedRaceParallelWaitDurationFixture(t *testing.T) {
 	t.Run("root", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("slow", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			advanceQuarantinedRaceLogicalClock(100 * time.Second)
+			runQuarantinedRaceActiveWork()
 		}))
 	}))
+}
+
+func runQuarantinedRaceActiveWork() {
+	const rounds = 1_000_000
+	request := make(chan struct{})
+	acknowledged := make(chan struct{})
+	go func() {
+		for range rounds {
+			<-request
+			acknowledged <- struct{}{}
+		}
+	}()
+	for range rounds {
+		request <- struct{}{}
+		<-acknowledged
+	}
 }
 
 func TestQuarantinedRaceDynamicDescendantFixture(t *testing.T) {
@@ -1388,7 +1385,7 @@ func TestQuarantinedRaceTerminalDescendantsFixture(t *testing.T) {
 	t.Run("parallel", instrumentTestingTFunc(func(t *testing.T) {
 		t.Run("child", instrumentTestingTFunc(func(t *testing.T) {
 			(*T)(t).Parallel()
-			advanceQuarantinedRaceLogicalClock(100 * time.Second)
+			runQuarantinedRaceActiveWork()
 			t.Error("parallel descendant sentinel")
 		}))
 	}))

--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -67,12 +67,11 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if scenario == "feature-gate" {
 		requireEnv(constants.CIVisibilitySubtestFeaturesEnabled, "false")
 	}
-	// These fixture limits detect protocol deadlocks, not instrumentation speed:
-	// race and coverage teardown can legitimately take several seconds in CI.
 	if scenario == "parallel-root-slots" || scenario == "parallel-root-coordination" {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
-		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
 	}
+	// These fixture limits detect protocol deadlocks, not instrumentation speed:
+	// race and coverage teardown can legitimately take several seconds in CI.
 	if scenario == "parallel-atf-sibling" {
 		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
 	}
@@ -735,11 +734,11 @@ func TestQuarantinedRaceParallelDeniedEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceParallelRootsReleaseProcessSlotsEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-root-slots", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=15s")
+	runQuarantinedRaceEndToEnd(t, "parallel-root-slots", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceParallelRootsCoordinateAfterResumeEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-root-coordination", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=15s")
+	runQuarantinedRaceEndToEnd(t, "parallel-root-coordination", "^TestQuarantinedRaceParallelRootsFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
@@ -1146,13 +1145,9 @@ func TestQuarantinedRaceParallelRootsFixture(t *testing.T) {
 				if name == "two" {
 					peer = "one"
 				}
-				deadline := time.Now().Add(3 * time.Second)
 				for {
 					if _, err := os.Stat(filepath.Join(os.Getenv(quarantinedRaceIsolationPIDDirEnv), "parallel-root-"+peer+"-child")); err == nil {
 						break
-					}
-					if time.Now().After(deadline) {
-						t.Fatalf("parallel root %s did not resume", peer)
 					}
 					time.Sleep(10 * time.Millisecond)
 				}

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -7,6 +7,7 @@ package gotesting
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -100,6 +101,16 @@ func TestQuarantinedRaceUsesPostParallelRaceBaseline(t *testing.T) {
 
 	parallel = false
 	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "a serial subtree root must retain descendant race attribution")
+}
+
+func TestOrchestrionParallelAdviceMatchesHookContract(t *testing.T) {
+	source, err := os.ReadFile("orchestrion.yml")
+	require.NoError(t, err)
+
+	config := string(source)
+	assert.Contains(t, config, "func __dd_civisibility_instrumentTestingParallel(t *T) (bool, func())")
+	assert.Contains(t, config, "__dd_civisibility_handled, __dd_civisibility_resume := __dd_civisibility_instrumentTestingParallel")
+	assert.Contains(t, config, "defer __dd_civisibility_resume()")
 }
 
 func TestQuarantinedRaceNestedRootEnvelopePreservesMetadata(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -51,6 +51,12 @@ func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T)
 	assert.Empty(t, owner)
 }
 
+func TestQuarantinedRaceAttemptToFixSettingIsTotalExecutionCount(t *testing.T) {
+	assert.Equal(t, 1, processRetryAttemptToFixExecutionCount(0))
+	assert.Equal(t, 1, processRetryAttemptToFixExecutionCount(1))
+	assert.Equal(t, 3, processRetryAttemptToFixExecutionCount(3))
+}
+
 func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
@@ -68,6 +74,97 @@ func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
 			assert.Equal(t, tt.forced, forced)
 		})
 	}
+}
+
+func TestQuarantinedRaceITRDecisionExecutesModifiedTest(t *testing.T) {
+	const name = "quarantinedRaceSkippableFixture"
+	cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{TestName: name}}}
+	fn := runtime.FuncForPC(reflect.ValueOf(quarantinedRaceSkippableFixture).Pointer())
+
+	skip, forced := cfg.itrDecision(name, processRetrySubtreeDirective{Modified: true}, fn)
+	assert.False(t, skip)
+	assert.False(t, forced)
+}
+
+func TestQuarantinedRaceUsesPostParallelRaceBaseline(t *testing.T) {
+	parallel := true
+	baseline := &atomic.Int64{}
+	baseline.Store(3)
+	fields := &commonPrivateFields{isParallel: &parallel, lastRaceErrors: baseline}
+
+	assert.False(t, processRetrySubtreeRaceDetected(fields, 1, 3), "race while paused must not be attributed after Parallel resumes")
+	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 4), "race after resume must still be attributed")
+
+	parallel = false
+	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "a serial subtree root must retain descendant race attribution")
+}
+
+func TestQuarantinedRaceNestedRootEnvelopePreservesMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		skipped  bool
+		forced   bool
+		modified bool
+	}{
+		{name: "skipped by ITR", skipped: true},
+		{name: "forced by ITR", forced: true},
+		{name: "modified", modified: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &processRetrySubtreeConfig{
+				Version:      processRetrySubtreeVersion,
+				SelectedRoot: "TestCheckout/card",
+				Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card", Quarantined: true},
+			}
+			status := processRetryStatusPass
+			skipReason := ""
+			if tt.skipped {
+				status = processRetryStatusSkip
+				skipReason = "itr"
+			}
+			state := newQuarantinedRaceChildState(cfg)
+			state.append(processRetrySubtreeResult{
+				TestName: "TestCheckout/card", Status: status,
+				Skipped: tt.skipped, SkipReason: skipReason,
+				SkippedByITR: tt.skipped, ITRForcedRun: tt.forced, Modified: tt.modified,
+			})
+			observation := &processRetryChildObservation{
+				cfg:     processRetryChildConfig{TestName: cfg.SelectedRoot, Subtree: cfg},
+				subtree: state,
+			}
+
+			got := observation.buildSubtreeResult(processRetryResult{TestName: cfg.SelectedRoot}, "")
+			assert.Equal(t, tt.skipped, got.SkippedByITR)
+			assert.Equal(t, tt.forced, got.ITRForcedRun)
+			assert.Equal(t, tt.modified, got.Modified)
+		})
+	}
+}
+
+func TestQuarantinedRaceRootReplayKeepsRaceDetectorOutput(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		SelectedRoot: "TestCheckout/card",
+		Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card", Quarantined: true},
+	}
+	invocation := quarantinedRaceInvocation{
+		cfg: cfg,
+		attempt: processRetryAttemptResult{
+			OutputTail:      "WARNING: DATA RACE\nfull detector stack",
+			OutputTruncated: true,
+			Result: processRetryResult{
+				TestName: cfg.SelectedRoot, Status: processRetryStatusFail,
+				Failed: true, OutputTail: "race detected during execution of test",
+				Subtests: []processRetrySubtreeResult{{
+					TestName: cfg.SelectedRoot + "/child", Status: processRetryStatusFail,
+					Failed: true, RaceDetected: true,
+				}},
+			},
+		},
+	}
+
+	got := processRetrySubtreeRootFromInvocation(invocation)
+	assert.Equal(t, invocation.attempt.OutputTail, got.OutputTail)
+	assert.True(t, got.OutputTruncated)
 }
 
 func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -79,12 +79,12 @@ func TestDirectQuarantinedRaceAttemptOwnersReturnsOnlyNearestFamilies(t *testing
 	assert.Equal(t, "TestCheckout/card/sibling", owners[1].TestName)
 }
 
-func TestQuarantinedRaceParallelContinuationDisablesAggregateCoverage(t *testing.T) {
+func TestQuarantinedRaceParallelContinuationDisablesCoverage(t *testing.T) {
 	const root, owner = "TestCheckout/root", "TestCheckout/root/owner"
 	for _, parallel := range []bool{false, true} {
 		t.Run(fmt.Sprintf("parallel=%t", parallel), func(t *testing.T) {
 			cfg := &processRetrySubtreeConfig{
-				Version: processRetrySubtreeVersion, SelectedRoot: root, AttemptToFixRetries: 2, CollectAggregate: true,
+				Version: processRetrySubtreeVersion, SelectedRoot: root, AttemptToFixRetries: 2, CollectPerTest: true, CollectAggregate: true,
 				Root: processRetrySubtreeDirective{TestName: root, ModuleName: "module", SuiteName: "suite", Quarantined: true},
 			}
 			attempt := processRetryAttemptResult{Result: processRetryResult{Subtests: []processRetrySubtreeResult{{
@@ -98,9 +98,19 @@ func TestQuarantinedRaceParallelContinuationDisablesAggregateCoverage(t *testing
 			})
 			require.Nil(t, failure)
 			require.NotNil(t, runCfg)
+			assert.Equal(t, !parallel, runCfg.CollectPerTest)
 			assert.Equal(t, !parallel, runCfg.CollectAggregate)
 		})
 	}
+}
+
+func TestFinalizeQuarantinedRaceInvocationConsumesCleanup(t *testing.T) {
+	cleanups := 0
+	attempt := finalizeQuarantinedRaceInvocation(&processRetrySubtreeConfig{}, processRetryAttemptResult{
+		Cleanup: func() { cleanups++ },
+	})
+	require.Nil(t, attempt.Cleanup)
+	require.Equal(t, 1, cleanups)
 }
 
 func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -90,21 +90,16 @@ func TestQuarantinedRaceITRDecisionExecutesModifiedTest(t *testing.T) {
 	assert.False(t, forced)
 }
 
-func TestQuarantinedRaceUsesPostParallelRaceBaseline(t *testing.T) {
-	parallel := true
+func TestQuarantinedRaceUsesTestingRaceOwnership(t *testing.T) {
 	baseline := &atomic.Int64{}
 	logged := &atomic.Bool{}
 	baseline.Store(3)
-	fields := &commonPrivateFields{isParallel: &parallel, lastRaceErrors: baseline, raceErrorLogged: logged}
+	fields := &commonPrivateFields{lastRaceErrors: baseline, raceErrorLogged: logged}
 
-	assert.False(t, processRetrySubtreeRaceDetected(fields, 1, 3), "race while paused must not be attributed after Parallel resumes")
+	assert.False(t, processRetrySubtreeRaceDetected(fields, 1, 3), "an advanced testing baseline must not be re-attributed")
 	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 4), "race after resume must still be attributed")
 	logged.Store(true)
-	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "race logged before Parallel must remain attributed")
-
-	logged.Store(false)
-	parallel = false
-	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "a serial subtree root must retain descendant race attribution")
+	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "a race owned by the test must remain attributed")
 }
 
 func TestOrchestrionParallelAdviceMatchesHookContract(t *testing.T) {
@@ -117,16 +112,18 @@ func TestOrchestrionParallelAdviceMatchesHookContract(t *testing.T) {
 	assert.Contains(t, config, "defer __dd_civisibility_resume()")
 }
 
-func TestQuarantinedRaceNestedRootEnvelopePreservesMetadata(t *testing.T) {
+func TestQuarantinedRaceNestedRootEnvelopePreservesRecordedResult(t *testing.T) {
 	for _, tt := range []struct {
-		name     string
-		skipped  bool
-		forced   bool
-		modified bool
+		name       string
+		skipped    bool
+		forced     bool
+		modified   bool
+		controlled processRetryStatus
 	}{
 		{name: "skipped by ITR", skipped: true},
 		{name: "forced by ITR", forced: true},
 		{name: "modified", modified: true},
+		{name: "ancestor controlled terminal", controlled: processRetryStatusControlledPanicReady},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &processRetrySubtreeConfig{
@@ -151,7 +148,10 @@ func TestQuarantinedRaceNestedRootEnvelopePreservesMetadata(t *testing.T) {
 				subtree: state,
 			}
 
-			got := observation.buildSubtreeResult(processRetryResult{TestName: cfg.SelectedRoot}, "")
+			got := observation.buildSubtreeResult(processRetryResult{TestName: cfg.SelectedRoot}, tt.controlled)
+			assert.Equal(t, status, got.Status)
+			assert.False(t, got.Failed)
+			assert.False(t, got.Panic)
 			assert.Equal(t, tt.skipped, got.SkippedByITR)
 			assert.Equal(t, tt.forced, got.ITRForcedRun)
 			assert.Equal(t, tt.modified, got.Modified)

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -7,6 +7,8 @@ package gotesting
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -19,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 )
 
 func quarantinedRaceSkippableFixture(*testing.T) {}
@@ -236,6 +240,137 @@ func TestQuarantinedRaceSubtreeOutputUsesEncodedLimit(t *testing.T) {
 			assert.True(t, strings.HasSuffix(normalized, got))
 		})
 	}
+}
+
+func TestQuarantinedRaceAggregatePayloadFitsWireLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		count    int
+		populate func(*processRetrySubtreeResult)
+		check    func(*testing.T, processRetrySubtreeResult)
+	}{
+		{
+			name:  "output",
+			count: 2 * 1024,
+			populate: func(result *processRetrySubtreeResult) {
+				result.OutputTail = strings.Repeat("x", processRetrySubtreeOutputMaxBytes)
+			},
+			check: func(t *testing.T, result processRetrySubtreeResult) {
+				assert.True(t, result.OutputTruncated)
+				assert.Less(t, len(result.OutputTail), processRetrySubtreeOutputMaxBytes)
+			},
+		},
+		{
+			name:  "error stack",
+			count: 512,
+			populate: func(result *processRetrySubtreeResult) {
+				result.ErrorStack = strings.Repeat("x", processRetryErrorStackMaxBytes)
+			},
+			check: func(t *testing.T, result processRetrySubtreeResult) {
+				assert.Contains(t, result.ErrorStack, processRetryMetadataTruncationMarker)
+				assert.Less(t, len(result.ErrorStack), processRetryErrorStackMaxBytes)
+			},
+		},
+		{
+			name:  "coverage",
+			count: 1,
+			populate: func(result *processRetrySubtreeResult) {
+				result.Coverage = []coverage.ProcessTestCoverageFile{{
+					Name: "file.go", Bitmap: bytes.Repeat([]byte{'x'}, processRetrySubtreeWireMaxBytes),
+				}}
+			},
+			check: func(t *testing.T, result processRetrySubtreeResult) {
+				assert.Empty(t, result.Coverage)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := "TestAggregate/root"
+			cfg := processRetryChildConfig{
+				ResultPath: filepath.Join(t.TempDir(), "result.json"),
+				TestName:   root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+				Subtree: &processRetrySubtreeConfig{
+					Version: processRetrySubtreeVersion, SelectedRoot: root,
+					Root: processRetrySubtreeDirective{TestName: root, Quarantined: true},
+				},
+			}
+			result := processRetryResult{
+				Version: 1, TestName: root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+				Status: processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, Failed: true,
+				Subtests: make([]processRetrySubtreeResult, tt.count),
+			}
+			for idx := range result.Subtests {
+				result.Subtests[idx] = processRetrySubtreeResult{
+					TestName: fmt.Sprintf("%s/child-%04d", root, idx),
+					Status:   processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+					Failed: true, Quarantined: true, ErrorType: "error",
+				}
+				tt.populate(&result.Subtests[idx])
+			}
+
+			require.NoError(t, writeProcessRetryResultAtomically(cfg.ResultPath, result))
+			payload, err := os.ReadFile(cfg.ResultPath)
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(payload), processRetrySubtreeWireMaxBytes)
+			got, _, err := readProcessRetryResult(cfg.ResultPath, cfg)
+			require.NoError(t, err)
+			require.Len(t, got.Subtests, tt.count)
+			assert.Equal(t, root+"/child-0000", got.Subtests[0].TestName)
+			assert.Equal(t, processRetryStatusFail, got.Subtests[0].Status)
+			assert.True(t, got.Subtests[0].Failed)
+			tt.check(t, got.Subtests[0])
+			tt.check(t, got.Subtests[len(got.Subtests)-1])
+		})
+	}
+}
+
+func TestQuarantinedRaceSmallPayloadSerializationIsUnchanged(t *testing.T) {
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+	result := processRetryResult{
+		Version: 1, TestName: "TestSmall/root", Attempt: 1, RetryReason: processRetrySubtreeReason,
+		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		Subtests: []processRetrySubtreeResult{{
+			TestName: "TestSmall/root/child", Status: processRetryStatusPass,
+			StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		}},
+	}
+	want, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	require.NoError(t, writeProcessRetryResultAtomically(resultPath, result))
+	got, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestQuarantinedRaceUnrepresentableCoreWritesExplicitResult(t *testing.T) {
+	root := "TestOversized/root"
+	cfg := processRetryChildConfig{
+		ResultPath: filepath.Join(t.TempDir(), "result.json"),
+		TestName:   root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+		Subtree: &processRetrySubtreeConfig{
+			Version: processRetrySubtreeVersion, SelectedRoot: root,
+			Root: processRetrySubtreeDirective{TestName: root, Quarantined: true},
+		},
+	}
+	result := processRetryResult{
+		Version: 1, TestName: root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		Subtests: []processRetrySubtreeResult{{
+			TestName: root + "/" + strings.Repeat("x", processRetrySubtreeWireMaxBytes),
+			Status:   processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		}},
+	}
+
+	require.NoError(t, writeProcessRetryResultAtomically(cfg.ResultPath, result))
+	got, timingOK, err := readProcessRetryResult(cfg.ResultPath, cfg)
+	require.NoError(t, err)
+	assert.False(t, timingOK)
+	assert.Equal(t, processRetryStatusNotRun, got.Status)
+	assert.Equal(t, processRetryResultErrorSubtreeTooLarge, got.ResultError)
+	ordinary := cfg
+	ordinary.Subtree = nil
+	require.ErrorIs(t, validateProcessRetryResult(got, ordinary), errProcessRetryResultInvalid)
 }
 
 func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 )
 
@@ -64,49 +65,53 @@ func TestDirectQuarantinedRaceAttemptOwnersReturnsOnlyNearestFamilies(t *testing
 }
 
 func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing.T) {
+	const module, suite = "module", "suite"
 	cfg := &processRetrySubtreeConfig{
 		Version:      processRetrySubtreeVersion,
 		SelectedRoot: "TestCheckout",
 		Root: processRetrySubtreeDirective{
-			TestName: "TestCheckout", Quarantined: true, AttemptToFix: true,
+			TestName: "TestCheckout", ModuleName: module, SuiteName: suite, Quarantined: true, AttemptToFix: true,
 		},
 		OwnsAttemptToFix: true,
 		Directives: []processRetrySubtreeDirective{
-			{TestName: "TestCheckout/clear", Quarantined: true},
-			{TestName: "TestCheckout/clear/owner", Quarantined: true, AttemptToFix: true},
-			{TestName: "TestCheckout/clear/owner/clear", Quarantined: true},
-			{TestName: "TestCheckout/clear/owner/clear/deep", Quarantined: true, AttemptToFix: true},
+			{TestName: "TestCheckout/clear", ModuleName: module, SuiteName: suite, Quarantined: true},
+			{TestName: "TestCheckout/clear/owner", ModuleName: module, SuiteName: suite, Quarantined: true, AttemptToFix: true},
+			{TestName: "TestCheckout/clear/owner/clear", ModuleName: module, SuiteName: suite, Quarantined: true},
+			{TestName: "TestCheckout/clear/owner/clear/deep", ModuleName: module, SuiteName: suite, Quarantined: true, AttemptToFix: true},
 		},
 	}
-	continuation, err := cfg.forSelectedRoot("TestCheckout/clear/owner")
+	continuation, err := cfg.forSelectedRoot(module, suite, "TestCheckout/clear/owner")
 	require.NoError(t, err)
-	_, owner := continuation.resolveDirective("TestCheckout/clear/owner/clear/deep")
+	_, owner := continuation.resolveDirective(module, suite, "TestCheckout/clear/owner/clear/deep")
 	assert.Equal(t, "TestCheckout/clear/owner/clear/deep", owner)
 }
 
 func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T) {
+	const module, suite = "module", "suite"
 	cfg := &processRetrySubtreeConfig{
 		Version:      processRetrySubtreeVersion,
 		SelectedRoot: "TestCheckout/card",
 		Root: processRetrySubtreeDirective{
 			TestName:    "TestCheckout/card",
+			ModuleName:  module,
+			SuiteName:   suite,
 			Quarantined: true,
 		},
 		Directives: []processRetrySubtreeDirective{
-			{TestName: "TestCheckout/card/visa", Quarantined: true, AttemptToFix: true},
-			{TestName: "TestCheckout/card/visa/credit", Quarantined: true},
+			{TestName: "TestCheckout/card/visa", ModuleName: module, SuiteName: suite, Quarantined: true, AttemptToFix: true},
+			{TestName: "TestCheckout/card/visa/credit", ModuleName: module, SuiteName: suite, Quarantined: true},
 		},
 	}
 
-	directive, owner := cfg.resolveDirective("TestCheckout/card/visa")
+	directive, owner := cfg.resolveDirective(module, suite, "TestCheckout/card/visa")
 	require.True(t, directive.AttemptToFix)
 	assert.Equal(t, "TestCheckout/card/visa", owner)
 
-	directive, owner = cfg.resolveDirective("TestCheckout/card/visa/debit")
+	directive, owner = cfg.resolveDirective(module, suite, "TestCheckout/card/visa/debit")
 	require.True(t, directive.AttemptToFix)
 	assert.Equal(t, "TestCheckout/card/visa", owner)
 
-	directive, owner = cfg.resolveDirective("TestCheckout/card/visa/credit")
+	directive, owner = cfg.resolveDirective(module, suite, "TestCheckout/card/visa/credit")
 	assert.False(t, directive.AttemptToFix)
 	assert.Empty(t, owner)
 }
@@ -433,19 +438,20 @@ func TestQuarantinedRaceUnrepresentableCoreWritesExplicitResult(t *testing.T) {
 }
 
 func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {
+	const module, suite = "module", "suite"
 	valid := &processRetrySubtreeConfig{
 		Version:      processRetrySubtreeVersion,
 		SelectedRoot: "TestCheckout/card",
 		Root: processRetrySubtreeDirective{
-			TestName:    "TestCheckout/card",
+			TestName: "TestCheckout/card", ModuleName: module, SuiteName: suite,
 			Quarantined: true,
 		},
-		Directives: []processRetrySubtreeDirective{{TestName: "TestCheckout/card/visa", Quarantined: true}},
+		Directives: []processRetrySubtreeDirective{{TestName: "TestCheckout/card/visa", ModuleName: module, SuiteName: suite, Quarantined: true}},
 	}
 	require.NoError(t, validateProcessRetrySubtreeConfig(valid, valid.SelectedRoot))
 
 	outside := *valid
-	outside.Directives = []processRetrySubtreeDirective{{TestName: "TestCheckout/paypal", Quarantined: true}}
+	outside.Directives = []processRetrySubtreeDirective{{TestName: "TestCheckout/paypal", ModuleName: module, SuiteName: suite, Quarantined: true}}
 	require.Error(t, validateProcessRetrySubtreeConfig(&outside, outside.SelectedRoot))
 
 	duplicate := *valid
@@ -526,7 +532,9 @@ func TestQuarantinedRaceControlConfigCarriesValidatedSnapshot(t *testing.T) {
 	subtree := &processRetrySubtreeConfig{
 		Version:      processRetrySubtreeVersion,
 		SelectedRoot: "TestCheckout/card",
-		Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card", Quarantined: true},
+		Root: processRetrySubtreeDirective{
+			TestName: "TestCheckout/card", ModuleName: "module", SuiteName: "suite", Quarantined: true,
+		},
 	}
 	cfg := processRetryControlConfig{
 		Version: processRetryControlVersion, Transport: processRetryControlTransportUnixPipes,
@@ -542,6 +550,21 @@ func TestQuarantinedRaceControlConfigCarriesValidatedSnapshot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, subtree, got.Subtree)
+
+	attemptToFix := cfg
+	attemptToFix.RetryReason = constants.AttemptToFixRetryReason
+	attemptToFix.Subtree.AncestorAttemptToFix = true
+	attemptToFix.Subtree.OwnsAttemptToFix = false
+	require.NoError(t, writeProcessRetryControlConfig(path, attemptToFix))
+	_, err = readProcessRetryControlConfig(path, processRetryChildConfig{
+		TestName: attemptToFix.TestName, Attempt: attemptToFix.Attempt, RetryReason: attemptToFix.RetryReason,
+		MRunEpoch: attemptToFix.MRunEpoch, InvocationOrdinal: attemptToFix.InvocationOrdinal, Subtree: attemptToFix.Subtree,
+	})
+	require.NoError(t, err)
+
+	invalid := attemptToFix
+	invalid.RetryReason = constants.AutoTestRetriesRetryReason
+	require.Error(t, writeProcessRetryControlConfig(path, invalid))
 }
 
 func TestQuarantinedRaceAcceptsOnlyExplainedTestFailures(t *testing.T) {
@@ -561,7 +584,9 @@ func TestQuarantinedRaceAcceptsOnlyExplainedTestFailures(t *testing.T) {
 	assert.True(t, processRetryInfrastructureFailure(inconsistent))
 }
 
-func quarantinedRaceForeignSuiteCallback(*testing.T) {}
+func quarantinedRaceForeignSuiteCallback(*testing.T) {
+	panic("disabled foreign-suite callback ran")
+}
 
 func TestQuarantinedRaceReplayMarksTruncatedOutput(t *testing.T) {
 	attempt := processRetryAttemptFromSubtreeResult(processRetrySubtreeResult{

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -93,12 +93,16 @@ func TestQuarantinedRaceITRDecisionExecutesModifiedTest(t *testing.T) {
 func TestQuarantinedRaceUsesPostParallelRaceBaseline(t *testing.T) {
 	parallel := true
 	baseline := &atomic.Int64{}
+	logged := &atomic.Bool{}
 	baseline.Store(3)
-	fields := &commonPrivateFields{isParallel: &parallel, lastRaceErrors: baseline}
+	fields := &commonPrivateFields{isParallel: &parallel, lastRaceErrors: baseline, raceErrorLogged: logged}
 
 	assert.False(t, processRetrySubtreeRaceDetected(fields, 1, 3), "race while paused must not be attributed after Parallel resumes")
 	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 4), "race after resume must still be attributed")
+	logged.Store(true)
+	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "race logged before Parallel must remain attributed")
 
+	logged.Store(false)
 	parallel = false
 	assert.True(t, processRetrySubtreeRaceDetected(fields, 1, 3), "a serial subtree root must retain descendant race attribution")
 }

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -6,12 +6,15 @@
 package gotesting
 
 import (
+	"bytes"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,6 +168,27 @@ func TestQuarantinedRaceRootReplayKeepsRaceDetectorOutput(t *testing.T) {
 	got := processRetrySubtreeRootFromInvocation(invocation)
 	assert.Equal(t, invocation.attempt.OutputTail, got.OutputTail)
 	assert.True(t, got.OutputTruncated)
+}
+
+func TestQuarantinedRaceSubtreeOutputUsesEncodedLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		output []byte
+	}{
+		{name: "escaped", output: []byte(strings.Repeat("\n", processRetrySubtreeOutputMaxBytes))},
+		{name: "invalid UTF-8", output: bytes.Repeat([]byte{0xff, 'x'}, processRetrySubtreeOutputMaxBytes/2)},
+		{name: "raw tail", output: []byte(strings.Repeat("x", processRetrySubtreeOutputMaxBytes+1))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, truncated := truncateProcessRetrySubtreeOutput(tt.output)
+			normalized := strings.ToValidUTF8(string(tt.output), "\uFFFD")
+
+			assert.True(t, truncated)
+			assert.True(t, utf8.ValidString(got))
+			assert.True(t, processRetryJSONStringFits(got, processRetrySubtreeOutputMaxBytes))
+			assert.True(t, strings.HasSuffix(normalized, got))
+		})
+	}
 }
 
 func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -338,6 +338,34 @@ func TestQuarantinedRaceRootReplayKeepsNonRaceProcessOutput(t *testing.T) {
 	assert.Equal(t, invocation.attempt.OutputTail, processRetrySubtreeRootFromInvocation(invocation).OutputTail)
 }
 
+func TestQuarantinedRaceManagedDescendantReplayKeepsNonRaceProcessOutput(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		SelectedRoot: "TestCheckout/card",
+		Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card"},
+		Directives: []processRetrySubtreeDirective{{
+			TestName: "TestCheckout/card/child", Quarantined: true,
+		}},
+	}
+	invocation := quarantinedRaceInvocation{
+		cfg: cfg,
+		attempt: processRetryAttemptResult{
+			OutputTail: "direct stdout\ndirect stderr",
+			Result: processRetryResult{
+				TestName: cfg.SelectedRoot,
+				Subtests: []processRetrySubtreeResult{
+					{TestName: cfg.SelectedRoot + "/child", Status: processRetryStatusPass},
+					{TestName: cfg.SelectedRoot + "/child/grandchild", Status: processRetryStatusFail, Failed: true},
+				},
+			},
+		},
+	}
+
+	resolved, err := cfg.resolveSubtreeResults(invocation.attempt.Result.Subtests)
+	require.NoError(t, err)
+	got := processRetrySubtreeResultWithInvocationOutput(invocation, invocation.attempt.Result.Subtests[1], resolved[1])
+	assert.Equal(t, invocation.attempt.OutputTail, got.OutputTail)
+}
+
 func TestQuarantinedRaceSubtreeOutputUsesEncodedLimit(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -80,10 +80,14 @@ func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing
 			{TestName: "TestCheckout/clear/owner/clear/deep", ModuleName: module, SuiteName: suite, Quarantined: true, AttemptToFix: true},
 		},
 	}
-	continuation, err := cfg.forSelectedRoot(module, suite, "TestCheckout/clear/owner")
+	continuation, err := cfg.forSelectedRoot(processRetrySubtreeResult{
+		TestName: "TestCheckout/clear/owner", ModuleName: module, SuiteName: suite,
+		Quarantined: true, AttemptToFix: true, AttemptToFixOwn: true,
+	})
 	require.NoError(t, err)
-	_, owner := continuation.resolveDirective(module, suite, "TestCheckout/clear/owner/clear/deep")
-	assert.Equal(t, "TestCheckout/clear/owner/clear/deep", owner)
+	parent := continuation.resolveChildDirective(continuation.resolvedRootDirective(), module, suite, "TestCheckout/clear/owner/clear")
+	resolved := continuation.resolveChildDirective(parent, module, suite, "TestCheckout/clear/owner/clear/deep")
+	assert.Equal(t, "TestCheckout/clear/owner/clear/deep", resolved.attemptOwner)
 }
 
 func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T) {
@@ -103,17 +107,36 @@ func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T)
 		},
 	}
 
-	directive, owner := cfg.resolveDirective(module, suite, "TestCheckout/card/visa")
-	require.True(t, directive.AttemptToFix)
-	assert.Equal(t, "TestCheckout/card/visa", owner)
+	visa := cfg.resolveChildDirective(cfg.resolvedRootDirective(), module, suite, "TestCheckout/card/visa")
+	require.True(t, visa.directive.AttemptToFix)
+	assert.Equal(t, "TestCheckout/card/visa", visa.attemptOwner)
 
-	directive, owner = cfg.resolveDirective(module, suite, "TestCheckout/card/visa/debit")
-	require.True(t, directive.AttemptToFix)
-	assert.Equal(t, "TestCheckout/card/visa", owner)
+	debit := cfg.resolveChildDirective(visa, module, suite, "TestCheckout/card/visa/debit")
+	require.True(t, debit.directive.AttemptToFix)
+	assert.Equal(t, "TestCheckout/card/visa", debit.attemptOwner)
 
-	directive, owner = cfg.resolveDirective(module, suite, "TestCheckout/card/visa/credit")
-	assert.False(t, directive.AttemptToFix)
-	assert.Empty(t, owner)
+	credit := cfg.resolveChildDirective(visa, module, suite, "TestCheckout/card/visa/credit")
+	assert.False(t, credit.directive.AttemptToFix)
+	assert.Empty(t, credit.attemptOwner)
+}
+
+func TestQuarantinedRaceDirectiveResolutionPreservesCrossSuiteParent(t *testing.T) {
+	const module = "module"
+	cfg := &processRetrySubtreeConfig{
+		SelectedRoot: "TestCheckout/card",
+		Root: processRetrySubtreeDirective{
+			TestName: "TestCheckout/card", ModuleName: module, SuiteName: "root.go", Quarantined: true,
+		},
+		Directives: []processRetrySubtreeDirective{{
+			TestName: "TestCheckout/card/parent", ModuleName: module, SuiteName: "parent.go", AttemptToFix: true,
+		}},
+	}
+	parent := cfg.resolveChildDirective(cfg.resolvedRootDirective(), module, "parent.go", "TestCheckout/card/parent")
+	child := cfg.resolveChildDirective(parent, module, "child.go", "TestCheckout/card/parent/child")
+
+	assert.True(t, child.directive.Quarantined)
+	assert.True(t, child.directive.AttemptToFix)
+	assert.Equal(t, "TestCheckout/card/parent", child.attemptOwner)
 }
 
 func TestQuarantinedRaceAttemptToFixSettingIsTotalExecutionCount(t *testing.T) {
@@ -153,9 +176,9 @@ func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
 		{name: "quarantinedRaceSkippableFixture", fn: quarantinedRaceSkippableFixture},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{TestName: tt.name}}}
+			cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{SuiteName: "suite", TestName: tt.name}}}
 			fn := runtime.FuncForPC(reflect.ValueOf(tt.fn).Pointer())
-			skip, forced := cfg.itrDecision(tt.name, processRetrySubtreeDirective{}, fn)
+			skip, forced := cfg.itrDecision("suite", tt.name, processRetrySubtreeDirective{}, fn)
 			assert.Equal(t, !tt.forced, skip)
 			assert.Equal(t, tt.forced, forced)
 		})
@@ -164,12 +187,32 @@ func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
 
 func TestQuarantinedRaceITRDecisionExecutesModifiedTest(t *testing.T) {
 	const name = "quarantinedRaceSkippableFixture"
-	cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{TestName: name}}}
+	cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{SuiteName: "suite", TestName: name}}}
 	fn := runtime.FuncForPC(reflect.ValueOf(quarantinedRaceSkippableFixture).Pointer())
 
-	skip, forced := cfg.itrDecision(name, processRetrySubtreeDirective{Modified: true}, fn)
+	skip, forced := cfg.itrDecision("suite", name, processRetrySubtreeDirective{Modified: true}, fn)
 	assert.False(t, skip)
 	assert.False(t, forced)
+}
+
+func TestQuarantinedRaceITRDecisionUsesSuiteIdentity(t *testing.T) {
+	const name = "quarantinedRaceSkippableFixture"
+	cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{SuiteName: "foreign.go", TestName: name}}}
+	fn := runtime.FuncForPC(reflect.ValueOf(quarantinedRaceSkippableFixture).Pointer())
+
+	skip, _ := cfg.itrDecision("root.go", name, processRetrySubtreeDirective{}, fn)
+	assert.False(t, skip)
+	skip, _ = cfg.itrDecision("foreign.go", name, processRetrySubtreeDirective{}, fn)
+	assert.True(t, skip)
+}
+
+func TestQuarantinedRaceContinuationFailureUsesDescendantIdentity(t *testing.T) {
+	result := processRetrySubtreeResult{TestName: "TestCheckout/card/child", ModuleName: "module", SuiteName: "child.go"}
+	info := processRetryCommonInfoFromSubtreeResult(result)
+
+	assert.Equal(t, result.ModuleName, info.moduleName)
+	assert.Equal(t, result.SuiteName, info.suiteName)
+	assert.Equal(t, result.TestName, info.identity.FullName)
 }
 
 func TestQuarantinedRaceUsesTestingRaceOwnership(t *testing.T) {
@@ -192,6 +235,16 @@ func TestOrchestrionParallelAdviceMatchesHookContract(t *testing.T) {
 	assert.Contains(t, config, "func __dd_civisibility_instrumentTestingParallel(t *T) (bool, func())")
 	assert.Contains(t, config, "__dd_civisibility_handled, __dd_civisibility_resume := __dd_civisibility_instrumentTestingParallel")
 	assert.Contains(t, config, "defer __dd_civisibility_resume()")
+}
+
+func TestQuarantinedRaceParallelBridgeRequiresNativeAdmission(t *testing.T) {
+	t.Run("eligible", func(t *testing.T) {
+		assert.True(t, testingParallelWillSuspend(t))
+	})
+	t.Run("denied by Setenv", func(t *testing.T) {
+		t.Setenv("DD_TEST_PARALLEL_ADMISSION", "denied")
+		assert.False(t, testingParallelWillSuspend(t))
+	})
 }
 
 func TestQuarantinedRaceNestedRootEnvelopePreservesRecordedResult(t *testing.T) {
@@ -587,6 +640,12 @@ func TestQuarantinedRaceAcceptsOnlyExplainedTestFailures(t *testing.T) {
 func quarantinedRaceForeignSuiteCallback(*testing.T) {
 	panic("disabled foreign-suite callback ran")
 }
+
+func quarantinedRaceForeignSuiteITRCallback(*testing.T) {
+	panic("ITR-skipped foreign-suite callback ran")
+}
+
+func quarantinedRaceHomeSuiteCallback(*testing.T) {}
 
 func TestQuarantinedRaceReplayMarksTruncatedOutput(t *testing.T) {
 	attempt := processRetryAttemptFromSubtreeResult(processRetrySubtreeResult{

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -61,6 +61,20 @@ func TestQuarantinedRaceAttemptToFixSettingIsTotalExecutionCount(t *testing.T) {
 	assert.Equal(t, 3, processRetryAttemptToFixExecutionCount(3))
 }
 
+func TestQuarantinedRaceAggregateCoverageStartsAtSelectedRoot(t *testing.T) {
+	calls := 0
+	state := newQuarantinedRaceChildState(&processRetrySubtreeConfig{SelectedRoot: "TestCheckout/card"})
+	state.beginAggregate = func() { calls++ }
+
+	state.beginAggregateCoverage("TestCheckout")
+	state.beginAggregateCoverage("TestCheckout/card/visa")
+	assert.Zero(t, calls)
+
+	state.beginAggregateCoverage("TestCheckout/card")
+	state.beginAggregateCoverage("TestCheckout/card")
+	assert.Equal(t, 1, calls)
+}
+
 func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
@@ -183,6 +197,24 @@ func TestQuarantinedRaceRootReplayKeepsRaceDetectorOutput(t *testing.T) {
 	got := processRetrySubtreeRootFromInvocation(invocation)
 	assert.Equal(t, invocation.attempt.OutputTail, got.OutputTail)
 	assert.True(t, got.OutputTruncated)
+}
+
+func TestQuarantinedRaceRootReplayKeepsNonRaceProcessOutput(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		SelectedRoot: "TestCheckout/card",
+		Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card", Quarantined: true},
+	}
+	invocation := quarantinedRaceInvocation{
+		cfg: cfg,
+		attempt: processRetryAttemptResult{
+			OutputTail: "direct stdout\ndirect stderr",
+			Result: processRetryResult{
+				TestName: cfg.SelectedRoot, Status: processRetryStatusFail, Failed: true,
+			},
+		},
+	}
+
+	assert.Equal(t, invocation.attempt.OutputTail, processRetrySubtreeRootFromInvocation(invocation).OutputTail)
 }
 
 func TestQuarantinedRaceSubtreeOutputUsesEncodedLimit(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -32,6 +32,58 @@ func TestQuarantinedRaceExactRunPatternAnchorsEveryComponent(t *testing.T) {
 	assert.Equal(t, "TestCheckout/.*", processRetryChildRunPattern("TestCheckout/.*", "TestCheckout/card"))
 }
 
+func TestQuarantinedRaceCoverageCoordinatorDiscardsOnlySiblingOverlap(t *testing.T) {
+	var coordinator quarantinedRaceCoverageCoordinator
+	parent := coordinator.begin("TestCheckout/card")
+	child := coordinator.begin("TestCheckout/card/visa")
+	assert.True(t, coordinator.finish(child))
+	assert.True(t, coordinator.finish(parent))
+
+	first := coordinator.begin("TestCheckout/card/visa")
+	second := coordinator.begin("TestCheckout/card/mastercard")
+	assert.False(t, coordinator.finish(first))
+	assert.False(t, coordinator.finish(second))
+
+	isolated := coordinator.begin("TestCheckout/card/amex")
+	assert.True(t, coordinator.finish(isolated))
+}
+
+func TestDirectQuarantinedRaceAttemptOwnersReturnsOnlyNearestFamilies(t *testing.T) {
+	result := func(name string) processRetrySubtreeResult {
+		return processRetrySubtreeResult{TestName: name, AttemptToFixOwn: true}
+	}
+	owners := directQuarantinedRaceAttemptOwners([]processRetrySubtreeResult{
+		result("TestCheckout/card"),
+		result("TestCheckout/card/owner"),
+		result("TestCheckout/card/owner/clear/deep"),
+		result("TestCheckout/card/sibling"),
+	}, "TestCheckout/card")
+	require.Len(t, owners, 2)
+	assert.Equal(t, "TestCheckout/card/owner", owners[0].TestName)
+	assert.Equal(t, "TestCheckout/card/sibling", owners[1].TestName)
+}
+
+func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout",
+		Root: processRetrySubtreeDirective{
+			TestName: "TestCheckout", Quarantined: true, AttemptToFix: true,
+		},
+		OwnsAttemptToFix: true,
+		Directives: []processRetrySubtreeDirective{
+			{TestName: "TestCheckout/clear", Quarantined: true},
+			{TestName: "TestCheckout/clear/owner", Quarantined: true, AttemptToFix: true},
+			{TestName: "TestCheckout/clear/owner/clear", Quarantined: true},
+			{TestName: "TestCheckout/clear/owner/clear/deep", Quarantined: true, AttemptToFix: true},
+		},
+	}
+	continuation, err := cfg.forSelectedRoot("TestCheckout/clear/owner")
+	require.NoError(t, err)
+	_, owner := continuation.resolveDirective("TestCheckout/clear/owner/clear/deep")
+	assert.Equal(t, "TestCheckout/clear/owner/clear/deep", owner)
+}
+
 func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T) {
 	cfg := &processRetrySubtreeConfig{
 		Version:      processRetrySubtreeVersion,

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -302,9 +302,9 @@ func TestOrchestrionParallelAdviceMatchesHookContract(t *testing.T) {
 	require.NoError(t, err)
 
 	config := string(source)
-	assert.Contains(t, config, "func __dd_civisibility_instrumentTestingParallel(t *T) (bool, func())")
-	assert.Contains(t, config, "__dd_civisibility_handled, __dd_civisibility_resume := __dd_civisibility_instrumentTestingParallel")
-	assert.Contains(t, config, "defer __dd_civisibility_resume()")
+	assert.Contains(t, config, "func __dd_civisibility_instrumentTestingParallel(t *T) bool")
+	assert.Contains(t, config, "if __dd_civisibility_instrumentTestingParallel({{ .Function.Receiver }})")
+	assert.NotContains(t, config, "__dd_civisibility_resume")
 }
 
 func TestQuarantinedRaceParallelBridgeRequiresNativeAdmission(t *testing.T) {
@@ -317,29 +317,14 @@ func TestQuarantinedRaceParallelBridgeRequiresNativeAdmission(t *testing.T) {
 	})
 }
 
-func TestQuarantinedRaceParallelPauseIsIdempotentAcrossWrapperAndHook(t *testing.T) {
+func TestQuarantinedRaceParallelHookDisabledOutsideRaceSubtree(t *testing.T) {
 	meta := createTestMetadata(t, nil)
 	defer deleteTestMetadata(t)
-	meta.processRetryOwner = meta
-	var pauses, resumes atomic.Int32
 	meta.processRetryParallelPause = func() func() {
-		pauses.Add(1)
-		return func() { resumes.Add(1) }
+		t.Fatal("disabled hook must not inspect subtree metadata")
+		return nil
 	}
-
-	_, outerResume := instrumentTestingParallel(t)
-	_, nestedResume := instrumentTestingParallel(t)
-	require.NotNil(t, outerResume)
-	require.Nil(t, nestedResume)
-	outerResume()
-	require.EqualValues(t, 1, pauses.Load())
-	require.EqualValues(t, 1, resumes.Load())
-
-	_, nextResume := instrumentTestingParallel(t)
-	require.NotNil(t, nextResume)
-	nextResume()
-	require.EqualValues(t, 2, pauses.Load())
-	require.EqualValues(t, 2, resumes.Load())
+	assert.False(t, instrumentTestingParallel(t))
 }
 
 func TestQuarantinedRaceNestedRootEnvelopePreservesRecordedResult(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -90,6 +90,27 @@ func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing
 	assert.Equal(t, "TestCheckout/clear/owner/clear/deep", resolved.attemptOwner)
 }
 
+func TestQuarantinedRaceContinuationConfigAcceptsClearAttemptOwner(t *testing.T) {
+	const module, suite = "module", "suite"
+	cfg := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout",
+		Root: processRetrySubtreeDirective{
+			TestName: "TestCheckout", ModuleName: module, SuiteName: suite, Quarantined: true,
+		},
+		AttemptToFixRetries: 2,
+	}
+
+	continuation, err := cfg.forSelectedRoot(processRetrySubtreeResult{
+		TestName: "TestCheckout/clear/owner", ModuleName: module, SuiteName: suite,
+		AttemptToFix: true, AttemptToFixOwn: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, continuation.DescendantContinuation)
+	assert.False(t, continuation.Root.Quarantined)
+	assert.Empty(t, continuation.Directives)
+}
+
 func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T) {
 	const module, suite = "module", "suite"
 	cfg := &processRetrySubtreeConfig{
@@ -245,6 +266,31 @@ func TestQuarantinedRaceParallelBridgeRequiresNativeAdmission(t *testing.T) {
 		t.Setenv("DD_TEST_PARALLEL_ADMISSION", "denied")
 		assert.False(t, testingParallelWillSuspend(t))
 	})
+}
+
+func TestQuarantinedRaceParallelPauseIsIdempotentAcrossWrapperAndHook(t *testing.T) {
+	meta := createTestMetadata(t, nil)
+	defer deleteTestMetadata(t)
+	meta.processRetryOwner = meta
+	var pauses, resumes atomic.Int32
+	meta.processRetryParallelPause = func() func() {
+		pauses.Add(1)
+		return func() { resumes.Add(1) }
+	}
+
+	_, outerResume := instrumentTestingParallel(t)
+	_, nestedResume := instrumentTestingParallel(t)
+	require.NotNil(t, outerResume)
+	require.Nil(t, nestedResume)
+	outerResume()
+	require.EqualValues(t, 1, pauses.Load())
+	require.EqualValues(t, 1, resumes.Load())
+
+	_, nextResume := instrumentTestingParallel(t)
+	require.NotNil(t, nextResume)
+	nextResume()
+	require.EqualValues(t, 2, pauses.Load())
+	require.EqualValues(t, 2, resumes.Load())
 }
 
 func TestQuarantinedRaceNestedRootEnvelopePreservesRecordedResult(t *testing.T) {
@@ -542,6 +588,10 @@ func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {
 	mismatched := *valid
 	mismatched.SelectedRoot = "TestCheckout/other"
 	require.Error(t, validateProcessRetrySubtreeConfig(&mismatched, valid.SelectedRoot))
+
+	invalidContinuation := *valid
+	invalidContinuation.DescendantContinuation = true
+	require.Error(t, validateProcessRetrySubtreeConfig(&invalidContinuation, invalidContinuation.SelectedRoot))
 }
 
 func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -354,14 +354,14 @@ func TestQuarantinedRaceAggregatePayloadFitsWireLimit(t *testing.T) {
 				},
 			}
 			result := processRetryResult{
-				Version: 1, TestName: root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+				Version: 1, TestName: root, ModuleName: "module", SuiteName: "suite", Attempt: 1, RetryReason: processRetrySubtreeReason,
 				Status: processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, Failed: true,
 				Subtests: make([]processRetrySubtreeResult, tt.count),
 			}
 			for idx := range result.Subtests {
 				result.Subtests[idx] = processRetrySubtreeResult{
-					TestName: fmt.Sprintf("%s/child-%04d", root, idx),
-					Status:   processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+					TestName: fmt.Sprintf("%s/child-%04d", root, idx), ModuleName: "module", SuiteName: "suite",
+					Status: processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
 					Failed: true, Quarantined: true, ErrorType: "error",
 				}
 				tt.populate(&result.Subtests[idx])
@@ -470,6 +470,8 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 	valid := processRetryResult{
 		Version:           1,
 		TestName:          cfg.SelectedRoot,
+		ModuleName:        "module",
+		SuiteName:         "suite",
 		Attempt:           1,
 		RetryReason:       processRetrySubtreeReason,
 		MRunEpoch:         1,
@@ -480,6 +482,8 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 		DurationNanos:     10,
 		Subtests: []processRetrySubtreeResult{{
 			TestName:       "TestCheckout/card/visa",
+			ModuleName:     "module",
+			SuiteName:      "suite",
 			Status:         processRetryStatusPass,
 			StartUnixNano:  now + 1,
 			FinishUnixNano: now + 9,
@@ -492,6 +496,15 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 		MRunEpoch: 1, InvocationOrdinal: 1, Subtree: cfg,
 	}
 	require.NoError(t, validateProcessRetryResult(valid, expected))
+
+	missingIdentity := valid
+	missingIdentity.ModuleName = ""
+	require.Error(t, validateProcessRetryResult(missingIdentity, expected))
+
+	missingSubtestIdentity := valid
+	missingSubtestIdentity.Subtests = append([]processRetrySubtreeResult(nil), valid.Subtests...)
+	missingSubtestIdentity.Subtests[0].SuiteName = ""
+	require.Error(t, validateProcessRetryResult(missingSubtestIdentity, expected))
 
 	duplicate := valid
 	duplicate.Subtests = append(append([]processRetrySubtreeResult(nil), valid.Subtests...), valid.Subtests[0])
@@ -547,6 +560,8 @@ func TestQuarantinedRaceAcceptsOnlyExplainedTestFailures(t *testing.T) {
 	}
 	assert.True(t, processRetryInfrastructureFailure(inconsistent))
 }
+
+func quarantinedRaceForeignSuiteCallback(*testing.T) {}
 
 func TestQuarantinedRaceReplayMarksTruncatedOutput(t *testing.T) {
 	attempt := processRetryAttemptFromSubtreeResult(processRetrySubtreeResult{

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -66,17 +66,24 @@ func TestQuarantinedRaceAttemptToFixSettingIsTotalExecutionCount(t *testing.T) {
 }
 
 func TestQuarantinedRaceAggregateCoverageStartsAtSelectedRoot(t *testing.T) {
-	calls := 0
+	starts, finishes := 0, 0
 	state := newQuarantinedRaceChildState(&processRetrySubtreeConfig{SelectedRoot: "TestCheckout/card"})
-	state.beginAggregate = func() { calls++ }
+	state.beginAggregate = func() { starts++ }
+	state.finishAggregate = func() { finishes++ }
 
 	state.beginAggregateCoverage("TestCheckout")
 	state.beginAggregateCoverage("TestCheckout/card/visa")
-	assert.Zero(t, calls)
+	state.finishAggregateCoverage("TestCheckout")
+	state.finishAggregateCoverage("TestCheckout/card/visa")
+	assert.Zero(t, starts)
+	assert.Zero(t, finishes)
 
 	state.beginAggregateCoverage("TestCheckout/card")
 	state.beginAggregateCoverage("TestCheckout/card")
-	assert.Equal(t, 1, calls)
+	state.finishAggregateCoverage("TestCheckout/card")
+	state.finishAggregateCoverage("TestCheckout/card")
+	assert.Equal(t, 1, starts)
+	assert.Equal(t, 1, finishes)
 }
 
 func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -49,6 +49,21 @@ func TestQuarantinedRaceCoverageCoordinatorDiscardsOnlySiblingOverlap(t *testing
 	assert.True(t, coordinator.finish(isolated))
 }
 
+func TestQuarantinedRaceReplayFamilyUsesCompleteIdentity(t *testing.T) {
+	testInfo := &commonInfo{moduleName: "module", suiteName: "suite.go"}
+	base := processRetrySubtreeResult{TestName: "TestCheckout/card", ModuleName: "module", SuiteName: "suite.go"}
+	for _, distinct := range []processRetrySubtreeResult{
+		{TestName: base.TestName, ModuleName: "other-module", SuiteName: base.SuiteName},
+		{TestName: base.TestName, ModuleName: base.ModuleName, SuiteName: "other-suite.go"},
+	} {
+		assert.NotEqual(t, quarantinedRaceFamilyKeyFor(testInfo, base, 1), quarantinedRaceFamilyKeyFor(testInfo, distinct, 1))
+	}
+	assert.Equal(t,
+		quarantinedRaceFamilyKeyFor(testInfo, base, 1),
+		quarantinedRaceFamilyKeyFor(testInfo, processRetrySubtreeResult{TestName: base.TestName}, 1),
+	)
+}
+
 func TestDirectQuarantinedRaceAttemptOwnersReturnsOnlyNearestFamilies(t *testing.T) {
 	result := func(name string) processRetrySubtreeResult {
 		return processRetrySubtreeResult{TestName: name, AttemptToFixOwn: true}
@@ -62,6 +77,30 @@ func TestDirectQuarantinedRaceAttemptOwnersReturnsOnlyNearestFamilies(t *testing
 	require.Len(t, owners, 2)
 	assert.Equal(t, "TestCheckout/card/owner", owners[0].TestName)
 	assert.Equal(t, "TestCheckout/card/sibling", owners[1].TestName)
+}
+
+func TestQuarantinedRaceParallelContinuationDisablesAggregateCoverage(t *testing.T) {
+	const root, owner = "TestCheckout/root", "TestCheckout/root/owner"
+	for _, parallel := range []bool{false, true} {
+		t.Run(fmt.Sprintf("parallel=%t", parallel), func(t *testing.T) {
+			cfg := &processRetrySubtreeConfig{
+				Version: processRetrySubtreeVersion, SelectedRoot: root, AttemptToFixRetries: 2, CollectAggregate: true,
+				Root: processRetrySubtreeDirective{TestName: root, ModuleName: "module", SuiteName: "suite", Quarantined: true},
+			}
+			attempt := processRetryAttemptResult{Result: processRetryResult{Subtests: []processRetrySubtreeResult{{
+				TestName: owner, ModuleName: "module", SuiteName: "suite", Parallel: parallel, AttemptToFix: true, AttemptToFixOwn: true,
+			}}}}
+			var runCfg *processRetrySubtreeConfig
+			_, failure := continueQuarantinedRaceDescendantFamilies(cfg, attempt, &[]quarantinedRaceInvocation{}, func(got *processRetrySubtreeConfig, runRoot string, _ int) processRetryAttemptResult {
+				runCfg = got
+				assert.Equal(t, map[bool]string{false: owner, true: root}[parallel], runRoot)
+				return processRetryAttemptResult{Result: processRetryResult{Status: processRetryStatusPass}, ExitStatusObserved: true}
+			})
+			require.Nil(t, failure)
+			require.NotNil(t, runCfg)
+			assert.Equal(t, !parallel, runCfg.CollectAggregate)
+		})
+	}
 }
 
 func TestQuarantinedRaceContinuationConfigPreservesDeeperAttemptOwner(t *testing.T) {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -1,0 +1,200 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func quarantinedRaceSkippableFixture(*testing.T) {}
+
+func TestQuarantinedRaceExactRunPatternAnchorsEveryComponent(t *testing.T) {
+	assert.Equal(t, `^TestCheckout$/^card\[1\]$/^visa\+debit$`, processRetryExactRunPattern("TestCheckout/card[1]/visa+debit"))
+	assert.Equal(t, "TestCheckout/.*", processRetryChildRunPattern("TestCheckout/.*", "TestCheckout/card"))
+}
+
+func TestQuarantinedRaceDirectiveResolutionUsesNearestAttemptOwner(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout/card",
+		Root: processRetrySubtreeDirective{
+			TestName:    "TestCheckout/card",
+			Quarantined: true,
+		},
+		Directives: []processRetrySubtreeDirective{
+			{TestName: "TestCheckout/card/visa", Quarantined: true, AttemptToFix: true},
+			{TestName: "TestCheckout/card/visa/credit", Quarantined: true},
+		},
+	}
+
+	directive, owner := cfg.resolveDirective("TestCheckout/card/visa")
+	require.True(t, directive.AttemptToFix)
+	assert.Equal(t, "TestCheckout/card/visa", owner)
+
+	directive, owner = cfg.resolveDirective("TestCheckout/card/visa/debit")
+	require.True(t, directive.AttemptToFix)
+	assert.Equal(t, "TestCheckout/card/visa", owner)
+
+	directive, owner = cfg.resolveDirective("TestCheckout/card/visa/credit")
+	assert.False(t, directive.AttemptToFix)
+	assert.Empty(t, owner)
+}
+
+func TestQuarantinedRaceITRDecisionPreservesSourceUnskippable(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		fn     func(*testing.T)
+		forced bool
+	}{
+		{name: "TestNormalPassingAfterRetryAlwaysFail", fn: TestNormalPassingAfterRetryAlwaysFail, forced: true},
+		{name: "quarantinedRaceSkippableFixture", fn: quarantinedRaceSkippableFixture},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &processRetrySubtreeConfig{ITR: []processRetrySubtreeITR{{TestName: tt.name}}}
+			fn := runtime.FuncForPC(reflect.ValueOf(tt.fn).Pointer())
+			skip, forced := cfg.itrDecision(tt.name, processRetrySubtreeDirective{}, fn)
+			assert.Equal(t, !tt.forced, skip)
+			assert.Equal(t, tt.forced, forced)
+		})
+	}
+}
+
+func TestQuarantinedRaceSubtreeConfigRejectsUntrustedDirectives(t *testing.T) {
+	valid := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout/card",
+		Root: processRetrySubtreeDirective{
+			TestName:    "TestCheckout/card",
+			Quarantined: true,
+		},
+		Directives: []processRetrySubtreeDirective{{TestName: "TestCheckout/card/visa", Quarantined: true}},
+	}
+	require.NoError(t, validateProcessRetrySubtreeConfig(valid, valid.SelectedRoot))
+
+	outside := *valid
+	outside.Directives = []processRetrySubtreeDirective{{TestName: "TestCheckout/paypal", Quarantined: true}}
+	require.Error(t, validateProcessRetrySubtreeConfig(&outside, outside.SelectedRoot))
+
+	duplicate := *valid
+	duplicate.Directives = append(append([]processRetrySubtreeDirective(nil), valid.Directives...), valid.Directives[0])
+	require.Error(t, validateProcessRetrySubtreeConfig(&duplicate, duplicate.SelectedRoot))
+
+	mismatched := *valid
+	mismatched.SelectedRoot = "TestCheckout/other"
+	require.Error(t, validateProcessRetrySubtreeConfig(&mismatched, valid.SelectedRoot))
+}
+
+func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
+	cfg := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout/card",
+		Root: processRetrySubtreeDirective{
+			TestName:    "TestCheckout/card",
+			Quarantined: true,
+		},
+	}
+	now := time.Now().UnixNano()
+	valid := processRetryResult{
+		Version:           1,
+		TestName:          cfg.SelectedRoot,
+		Attempt:           1,
+		RetryReason:       processRetrySubtreeReason,
+		MRunEpoch:         1,
+		InvocationOrdinal: 1,
+		Status:            processRetryStatusPass,
+		StartUnixNano:     now,
+		FinishUnixNano:    now + 10,
+		DurationNanos:     10,
+		Subtests: []processRetrySubtreeResult{{
+			TestName:       "TestCheckout/card/visa",
+			Status:         processRetryStatusPass,
+			StartUnixNano:  now + 1,
+			FinishUnixNano: now + 9,
+			DurationNanos:  8,
+			Quarantined:    true,
+		}},
+	}
+	expected := processRetryChildConfig{
+		TestName: cfg.SelectedRoot, Attempt: 1, RetryReason: processRetrySubtreeReason,
+		MRunEpoch: 1, InvocationOrdinal: 1, Subtree: cfg,
+	}
+	require.NoError(t, validateProcessRetryResult(valid, expected))
+
+	duplicate := valid
+	duplicate.Subtests = append(append([]processRetrySubtreeResult(nil), valid.Subtests...), valid.Subtests[0])
+	require.Error(t, validateProcessRetryResult(duplicate, expected))
+
+	outside := valid
+	outside.Subtests = []processRetrySubtreeResult{{
+		TestName: "TestCheckout/paypal", Status: processRetryStatusPass,
+		StartUnixNano: now + 1, FinishUnixNano: now + 9, DurationNanos: 8,
+	}}
+	require.Error(t, validateProcessRetryResult(outside, expected))
+
+	inconsistent := valid
+	inconsistent.Subtests[0].Failed = true
+	require.Error(t, validateProcessRetryResult(inconsistent, expected))
+}
+
+func TestQuarantinedRaceControlConfigCarriesValidatedSnapshot(t *testing.T) {
+	subtree := &processRetrySubtreeConfig{
+		Version:      processRetrySubtreeVersion,
+		SelectedRoot: "TestCheckout/card",
+		Root:         processRetrySubtreeDirective{TestName: "TestCheckout/card", Quarantined: true},
+	}
+	cfg := processRetryControlConfig{
+		Version: processRetryControlVersion, Transport: processRetryControlTransportUnixPipes,
+		TestName: subtree.SelectedRoot, Attempt: 1, RetryReason: processRetrySubtreeReason,
+		MRunEpoch: 1, InvocationOrdinal: 1, ReadEndpoint: 3, WriteEndpoint: 4,
+		ObservedGOMAXPROCS: 1, Subtree: subtree,
+	}
+	path := filepath.Join(t.TempDir(), "control.json")
+	require.NoError(t, writeProcessRetryControlConfig(path, cfg))
+	got, err := readProcessRetryControlConfig(path, processRetryChildConfig{
+		TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+		MRunEpoch: cfg.MRunEpoch, InvocationOrdinal: cfg.InvocationOrdinal, Subtree: subtree,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, subtree, got.Subtree)
+}
+
+func TestQuarantinedRaceAcceptsOnlyExplainedTestFailures(t *testing.T) {
+	validRace := processRetryAttemptResult{
+		ExitCode: 1, ExitStatusObserved: true,
+		Result: processRetryResult{Status: processRetryStatusFail, Failed: true, RaceDetected: true},
+	}
+	assert.False(t, processRetryInfrastructureFailure(validRace))
+
+	missing := processRetryAttemptResult{ExitCode: 0, ExitStatusObserved: true}
+	assert.True(t, processRetryInfrastructureFailure(missing))
+
+	inconsistent := processRetryAttemptResult{
+		ExitCode: 1, ExitStatusObserved: true,
+		Result: processRetryResult{Status: processRetryStatusPass},
+	}
+	assert.True(t, processRetryInfrastructureFailure(inconsistent))
+}
+
+func TestQuarantinedRaceReplayMarksTruncatedOutput(t *testing.T) {
+	attempt := processRetryAttemptFromSubtreeResult(processRetrySubtreeResult{
+		Status: processRetryStatusPass, OutputTail: "tail", OutputTruncated: true,
+	})
+	assert.Equal(t, processRetryOutputTruncationMarker+"tail", attempt.OutputTail)
+}
+
+func TestQuarantinedRaceProcessContextKeepsFailClosedSetup(t *testing.T) {
+	ctx := newQuarantinedRaceProcessContext(nil, 1, &atomic.Uint64{}, 0)
+	require.NotNil(t, ctx)
+	assert.Nil(t, ctx.launchTemplate)
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_race.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race.go
@@ -7,4 +7,8 @@
 
 package gotesting
 
+var quarantinedRaceParallelHookActive bool
+
 func quarantinedRaceProcessSupported() bool { return true }
+
+func activateQuarantinedRaceParallelHook() { quarantinedRaceParallelHookActive = true }

--- a/internal/civisibility/integrations/gotesting/quarantine_race.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_race.go
@@ -1,0 +1,10 @@
+//go:build race
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+func quarantinedRaceProcessSupported() bool { return true }

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -126,6 +126,8 @@ type commonPrivateFields struct {
 	barrier    *chan bool      // Barrier for parallel tests.
 	signal     *chan bool      // Signal channel for test completion.
 	sub        *[]*testing.T   // Queue of subtests to be run in parallel.
+
+	lastRaceErrors *atomic.Int64 // Race baseline reset by testing.T.Parallel after it resumes.
 }
 
 // AddLevel increase or decrease the testing.common.level field value, used by
@@ -273,6 +275,7 @@ func getTestPrivateFieldsFast(t *testing.T, layout *testingInternalsLayout) *com
 		signal:     fieldPtr[chan bool](commonBase, layout.common.signal),
 		sub:        fieldPtr[[]*testing.T](commonBase, layout.common.sub),
 	}
+	fields.lastRaceErrors = fieldPtr[atomic.Int64](commonBase, layout.common.lastRaceErrors)
 	runtime.KeepAlive(t)
 	return fields
 }
@@ -318,6 +321,9 @@ func getTestPrivateFieldsReflect(t *testing.T) *commonPrivateFields {
 	}
 	if ptr, err := getFieldPointerFrom(t, "sub"); err == nil {
 		testFields.sub = (*[]*testing.T)(ptr)
+	}
+	if ptr, err := getFieldPointerFrom(t, "lastRaceErrors"); err == nil && ptr != nil {
+		testFields.lastRaceErrors = (*atomic.Int64)(ptr)
 	}
 
 	return testFields

--- a/internal/civisibility/integrations/gotesting/reflections.go
+++ b/internal/civisibility/integrations/gotesting/reflections.go
@@ -127,7 +127,8 @@ type commonPrivateFields struct {
 	signal     *chan bool      // Signal channel for test completion.
 	sub        *[]*testing.T   // Queue of subtests to be run in parallel.
 
-	lastRaceErrors *atomic.Int64 // Race baseline reset by testing.T.Parallel after it resumes.
+	lastRaceErrors  *atomic.Int64 // Race baseline reset by testing.T.Parallel after it resumes.
+	raceErrorLogged *atomic.Bool  // Whether testing already reported a race for this test.
 }
 
 // AddLevel increase or decrease the testing.common.level field value, used by
@@ -276,6 +277,7 @@ func getTestPrivateFieldsFast(t *testing.T, layout *testingInternalsLayout) *com
 		sub:        fieldPtr[[]*testing.T](commonBase, layout.common.sub),
 	}
 	fields.lastRaceErrors = fieldPtr[atomic.Int64](commonBase, layout.common.lastRaceErrors)
+	fields.raceErrorLogged = fieldPtr[atomic.Bool](commonBase, layout.common.raceErrorLogged)
 	runtime.KeepAlive(t)
 	return fields
 }
@@ -324,6 +326,9 @@ func getTestPrivateFieldsReflect(t *testing.T) *commonPrivateFields {
 	}
 	if ptr, err := getFieldPointerFrom(t, "lastRaceErrors"); err == nil && ptr != nil {
 		testFields.lastRaceErrors = (*atomic.Int64)(ptr)
+	}
+	if ptr, err := getFieldPointerFrom(t, "raceErrorLogged"); err == nil && ptr != nil {
+		testFields.raceErrorLogged = (*atomic.Bool)(ptr)
 	}
 
 	return testFields

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -867,6 +867,7 @@ type processRetryAttemptResult struct {
 	BodyAdmitted                bool
 	ControlledTerminalCommitted bool
 	Cleanup                     func()
+	quarantinedRaceInvocations  []quarantinedRaceInvocation
 }
 
 type processRetryEffectiveStatus struct {
@@ -1771,11 +1772,10 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	if limiterResult.Cause != processRetryLimiterAcquired {
 		return finishSetupFailure(limiterResult.Err, limiterResult.Cause == processRetryLimiterParentDeadline)
 	}
-	// The control bridge reacquires from its goroutine while teardown can run
-	// on the caller, so slot ownership and late release must change atomically.
+	// The control bridge can release from its goroutine while teardown runs on
+	// the caller, so slot ownership must change atomically.
 	var limiterReleaseMu sync.Mutex
 	limiterRelease := limiterResult.Release
-	limiterStopped := false
 	releaseLimiterSlot := func() {
 		limiterReleaseMu.Lock()
 		release := limiterRelease
@@ -1785,33 +1785,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 			release()
 		}
 	}
-	setLimiterRelease := func(release processRetryLimiterRelease) {
-		limiterReleaseMu.Lock()
-		if limiterStopped {
-			limiterReleaseMu.Unlock()
-			release()
-			return
-		}
-		limiterRelease = release
-		limiterReleaseMu.Unlock()
-	}
-	stopLimiter := func() {
-		limiterReleaseMu.Lock()
-		limiterStopped = true
-		release := limiterRelease
-		limiterRelease = nil
-		limiterReleaseMu.Unlock()
-		if release != nil {
-			release()
-		}
-	}
-	defer stopLimiter()
-	limiterCtx := ctx
-	cancelLimiter := func() {}
-	if parentParallelBridge != nil {
-		limiterCtx, cancelLimiter = context.WithCancel(ctx)
-	}
-	defer cancelLimiter()
+	defer releaseLimiterSlot()
 	if processRetryShutdownRequested(shutdown) || processRetryShuttingDown() {
 		return finishSetupFailure(errProcessRetryShutdown, false)
 	}
@@ -2036,23 +2010,12 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 				if parentParallelBridge != nil {
 					control.parallelBridge = func() error {
 						// A child blocked in t.Parallel is not executing test code.
-						// Release its process slot so another isolated sibling can
-						// reach the same parent barrier, then reacquire before resume.
+						// Release its process slot so every isolated sibling can reach
+						// the same parent barrier. After release, Go's native parallel
+						// scheduler owns concurrency; reacquiring this limiter before
+						// resume would deadlock siblings that coordinate in their bodies.
 						releaseLimiterSlot()
-						if err := parentParallelBridge(); err != nil {
-							return err
-						}
-						reacquired := limiter.acquireWithShutdownLimit(
-							limiterCtx,
-							parentDeadlineHardCap,
-							shutdown,
-							limiterMaxConcurrency,
-						)
-						if reacquired.Cause != processRetryLimiterAcquired {
-							return reacquired.Err
-						}
-						setLimiterRelease(reacquired.Release)
-						return nil
+						return parentParallelBridge()
 					}
 				}
 				controlErrors = control.serveParent()

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"slices"
@@ -31,6 +32,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/envconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting/coverage"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/telemetry"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
@@ -109,6 +111,7 @@ type processRetryChildConfig struct {
 	ParentDeadlineUnixNano int64
 	ParentDeadlineOK       bool
 	ObservedGOMAXPROCS     int
+	Subtree                *processRetrySubtreeConfig
 	controlConfig          processRetryControlConfig
 	controlConfigLoaded    bool
 }
@@ -147,26 +150,34 @@ const (
 )
 
 type processRetryResult struct {
-	Version           int                `json:"version"`
-	TestName          string             `json:"test_name"`
-	Attempt           int                `json:"attempt"`
-	RetryReason       string             `json:"retry_reason"`
-	MRunEpoch         uint64             `json:"m_run_epoch,omitempty"`
-	InvocationOrdinal uint64             `json:"invocation_ordinal,omitempty"`
-	Status            processRetryStatus `json:"status"`
-	StartUnixNano     int64              `json:"start_unix_nano"`
-	FinishUnixNano    int64              `json:"finish_unix_nano"`
-	DurationNanos     int64              `json:"duration_nanos"`
-	Failed            bool               `json:"failed"`
-	Skipped           bool               `json:"skipped"`
-	Panic             bool               `json:"panic"`
-	RaceDetected      bool               `json:"race_detected,omitempty"`
-	RootParallel      bool               `json:"root_parallel,omitempty"`
-	ErrorType         string             `json:"error_type,omitempty"`
-	ErrorMessage      string             `json:"error_message,omitempty"`
-	ErrorStack        string             `json:"error_stack,omitempty"`
-	SkipReason        string             `json:"skip_reason,omitempty"`
-	ResultError       string             `json:"result_error,omitempty"`
+	Version           int                                `json:"version"`
+	TestName          string                             `json:"test_name"`
+	Attempt           int                                `json:"attempt"`
+	RetryReason       string                             `json:"retry_reason"`
+	MRunEpoch         uint64                             `json:"m_run_epoch,omitempty"`
+	InvocationOrdinal uint64                             `json:"invocation_ordinal,omitempty"`
+	Status            processRetryStatus                 `json:"status"`
+	StartUnixNano     int64                              `json:"start_unix_nano"`
+	FinishUnixNano    int64                              `json:"finish_unix_nano"`
+	DurationNanos     int64                              `json:"duration_nanos"`
+	Failed            bool                               `json:"failed"`
+	Skipped           bool                               `json:"skipped"`
+	Panic             bool                               `json:"panic"`
+	RaceDetected      bool                               `json:"race_detected,omitempty"`
+	RootParallel      bool                               `json:"root_parallel,omitempty"`
+	ErrorType         string                             `json:"error_type,omitempty"`
+	ErrorMessage      string                             `json:"error_message,omitempty"`
+	ErrorStack        string                             `json:"error_stack,omitempty"`
+	SkipReason        string                             `json:"skip_reason,omitempty"`
+	ResultError       string                             `json:"result_error,omitempty"`
+	OutputTail        string                             `json:"output_tail,omitempty"`
+	OutputTruncated   bool                               `json:"output_truncated,omitempty"`
+	Source            *processRetryTestSource            `json:"source,omitempty"`
+	Coverage          []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
+	Subtests          []processRetrySubtreeResult        `json:"subtests,omitempty"`
+	SkippedByITR      bool                               `json:"skipped_by_itr,omitempty"`
+	ITRForcedRun      bool                               `json:"itr_forced_run,omitempty"`
+	Modified          bool                               `json:"modified,omitempty"`
 }
 
 type processRetryErrorInfo struct {
@@ -245,6 +256,11 @@ func bootstrapProcessRetryChild() (processRetryChildConfig, error) {
 		cfg = enrichProcessRetryChildConfig(cfg, wire)
 		cfg.controlConfig = wire
 		cfg.controlConfigLoaded = true
+	} else if cfg.RetryReason == processRetrySubtreeReason {
+		return cfg, readErr
+	}
+	if cfg.RetryReason == processRetrySubtreeReason && cfg.Subtree == nil {
+		return cfg, errProcessRetryControlInvalid
 	}
 	if integrations.ProcessRetryChildTransportError() != nil {
 		return cfg, errors.New("retry child transport cleanup failed")
@@ -258,6 +274,7 @@ func enrichProcessRetryChildConfig(cfg processRetryChildConfig, wire processRetr
 	cfg.ParentDeadlineUnixNano = wire.ParentDeadlineUnixNano
 	cfg.ParentDeadlineOK = wire.ParentDeadlineOK
 	cfg.ObservedGOMAXPROCS = wire.ObservedGOMAXPROCS
+	cfg.Subtree = wire.Subtree
 	return cfg
 }
 
@@ -2443,13 +2460,39 @@ func finishProcessRetryTestEvent(
 	test := suite.CreateTest(testInfo.testName, integrations.WithTestStartTime(attempt.StartTime))
 	if testInfo.sourceFunc != nil {
 		test.SetTestFunc(testInfo.sourceFunc)
+	} else if source := attempt.Result.Source; source != nil {
+		relativePath := utils.GetRelativePathFromCITagsSourceRoot(source.RuntimePath)
+		test.SetTag(constants.TestSourceFile, relativePath)
+		test.SetTag(constants.TestSourceStartLine, source.RuntimeStartLine)
+		suite.SetTag(constants.TestSourceFile, relativePath)
+		if source.RuntimeEndLine > 0 {
+			test.SetTag(constants.TestSourceEndLine, source.RuntimeEndLine)
+		}
+		if codeOwners := utils.GetCodeOwners(); codeOwners != nil {
+			if match, found := codeOwners.Match("/" + relativePath); found {
+				test.SetTag(constants.TestCodeOwners, match.GetOwnersString())
+				suite.SetTag(constants.TestCodeOwners, match.GetOwnersString())
+			}
+		}
+		if source.Unskippable {
+			test.SetTag(constants.TestUnskippable, "true")
+			telemetry.ITRUnskippable(telemetry.TestEventType)
+		}
 	}
 	execMeta.test = test
+	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
 	test.SetTag(constants.TestRetryExecutionMode, "process")
 	if execMeta.isItrForcedRun {
 		test.SetTag(constants.TestForcedToRun, "true")
 		telemetry.ITRForcedRun(telemetry.TestEventType)
+	}
+	if execMeta.isItrSkipped {
+		test.SetTag(constants.TestSkippedByITR, "true")
+		telemetry.ITRSkipped(telemetry.TestEventType)
+		currentITRState().markActualSkip()
+		session.SetTag(constants.ITRTestsSkipped, "true")
+		session.SetTag(constants.ITRTestsSkippingCount, numOfTestsSkipped.Add(1))
 	}
 	effective := effectiveProcessRetryStatus(attempt, cancelExecution)
 	if admitContinuation != nil {
@@ -2931,6 +2974,25 @@ func instrumentProcessRetryChild(m *testing.M, cfg processRetryChildConfig) (boo
 		hardStopInvalidProcessRetryChild("control_protocol_failure")
 		return false, failureTestingMFinalizer
 	}
+	if cfg.Subtree != nil && (cfg.Subtree.CollectPerTest || cfg.Subtree.CollectAggregate) {
+		// The process child deliberately skips CI Visibility initialization,
+		// so initialize only Go's runtime coverage hooks. Coverage is returned
+		// in the validated result; the child never owns an upload transport.
+		coverage.InitializeCoverage(m, false)
+		if cfg.Subtree.CollectPerTest && !coverage.CanCollect() ||
+			cfg.Subtree.CollectAggregate && !coverage.CanComputeCoverageProfile() {
+			_ = control.Close()
+			writer.Write(processRetryNotRunResult(cfg, "coverage_initialization_failed"))
+			clearProcessRetryChildWorkloads(
+				getInternalTestArray(m),
+				getInternalBenchmarkArray(m),
+				getInternalFuzzTargetArray(m),
+				getInternalExampleArray(m),
+			)
+			hardStopInvalidProcessRetryChild("coverage_initialization_failed")
+			return false, failureTestingMFinalizer
+		}
+	}
 	releaseHookEpoch := activateTestingMHookEpoch(cfg.MRunEpoch)
 	var finalizeOnce sync.Once
 	finalize := func(exitCode int) int {
@@ -2982,8 +3044,9 @@ func configureProcessRetryChildWorkloads(
 
 	var selected testing.InternalTest
 	found := false
+	topLevelName, _ := topLevelTestName(cfg.TestName)
 	for _, test := range *tests {
-		if test.Name == cfg.TestName {
+		if test.Name == topLevelName {
 			selected = test
 			found = true
 			break
@@ -3106,14 +3169,19 @@ func processRetryNotRunResult(cfg processRetryChildConfig, resultError string) p
 }
 
 type processRetryChildObservation struct {
-	cfg       processRetryChildConfig
-	writer    *processRetryResultWriter
-	finalize  sync.Once
-	test      *testing.T
-	group     *retryAttemptGroup
-	execMeta  *testExecutionMetadata
-	result    retryAttemptResult
-	startTime time.Time
+	cfg          processRetryChildConfig
+	writer       *processRetryResultWriter
+	finalize     sync.Once
+	test         *testing.T
+	group        *retryAttemptGroup
+	execMeta     *testExecutionMetadata
+	result       retryAttemptResult
+	startTime    time.Time
+	subtree      *quarantinedRaceChildState
+	coverage     *coverage.ProcessTestCoverage
+	aggregate    *coverage.ProcessCoverageProfile
+	aggregateErr error
+	source       *processRetryTestSource
 }
 
 func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildConfig, writer *processRetryResultWriter, control *processRetryControl) (func(*testing.T), func()) {
@@ -3122,6 +3190,10 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		start := time.Now()
 		observation.test = t
 		observation.startTime = start
+		observation.source = processRetrySourceFromFunc(runtime.FuncForPC(reflect.ValueOf(original).Pointer()))
+		if cfg.Subtree != nil && cfg.Subtree.CollectAggregate {
+			observation.aggregate, observation.aggregateErr = coverage.BeginProcessCoverageProfile()
+		}
 
 		group, reason := newRetryAttemptGroupWithOutputObservation(t, false)
 		if reason != "" {
@@ -3142,10 +3214,46 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			attempt.metadata = execMeta
 			execMeta.identity = newTestIdentity("", "", cfg.TestName)
 			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
+			if cfg.Subtree != nil {
+				observation.subtree = newQuarantinedRaceChildState(cfg.Subtree)
+				execMeta.quarantinedRaceChild = observation.subtree
+			}
 			observation.execMeta = execMeta
 			return ""
 		}
-		attempt, result, reason := runFreshRetryAttemptInGroupWithCallbacks(group, prepare, original, nil)
+		childBody := original
+		topLevelName, _ := topLevelTestName(cfg.TestName)
+		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot == topLevelName {
+			childBody = func(t *testing.T) {
+				rootDirective := cfg.Subtree.Root
+				observation.execMeta.isDisabled = rootDirective.Disabled
+				observation.execMeta.isQuarantined = rootDirective.Quarantined
+				observation.execMeta.isAttemptToFix = rootDirective.AttemptToFix
+				observation.execMeta.isAModifiedTest = rootDirective.Modified
+				observation.execMeta.shouldOrchestrateAttemptToFix = cfg.Subtree.OwnsAttemptToFix
+				if cfg.Subtree.CollectPerTest && coverage.CanCollect() {
+					if fn := runtime.FuncForPC(reflect.ValueOf(original).Pointer()); fn != nil {
+						path, _ := fn.FileLine(fn.Entry())
+						observation.coverage = coverage.BeginProcessTestCoverage(path)
+					}
+				}
+				if rootDirective.Disabled && !rootDirective.AttemptToFix {
+					reason := constants.TestDisabledSkipReason
+					observation.execMeta.processRetrySkipReason.Store(&reason)
+					t.SkipNow()
+				}
+				if skip, forced := cfg.Subtree.itrDecision(cfg.Subtree.SelectedRoot, rootDirective, runtime.FuncForPC(reflect.ValueOf(original).Pointer())); skip {
+					observation.execMeta.isItrSkipped = true
+					reason := constants.SkippedByITRReason
+					observation.execMeta.processRetrySkipReason.Store(&reason)
+					t.SkipNow()
+				} else {
+					observation.execMeta.isItrForcedRun = forced
+				}
+				original(t)
+			}
+		}
+		attempt, result, reason := runFreshRetryAttemptInGroupWithCallbacks(group, prepare, childBody, nil)
 		if reason != "" || attempt == nil {
 			writer.Write(processRetryNotRunResult(cfg, "testing_t_reflection_drift"))
 			t.Fail()
@@ -3272,6 +3380,19 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 			result.SkipReason = *skipReason
 		}
 	}
+	if o.cfg.Subtree != nil {
+		if status == "" {
+			switch {
+			case result.Failed:
+				result.Status = processRetryStatusFail
+			case result.Skipped:
+				result.Status = processRetryStatusSkip
+			default:
+				result.Status = processRetryStatusPass
+			}
+		}
+		return o.buildSubtreeResult(result, status)
+	}
 	if status != "" {
 		result.Status = status
 		result.Failed = true
@@ -3293,6 +3414,9 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 }
 
 func processRetryChildOwnerMetadata(execMeta *testExecutionMetadata) *testExecutionMetadata {
+	if execMeta != nil && execMeta.quarantinedRaceChild != nil {
+		return execMeta
+	}
 	for execMeta != nil && execMeta.processRetryOwner != nil && execMeta.processRetryOwner != execMeta {
 		execMeta = execMeta.processRetryOwner
 	}
@@ -3337,6 +3461,10 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 		owner := processRetryChildOwnerMetadata(getTestMetadataFromPointer(*fields.parent))
 		if owner == nil {
 			original(t)
+			return
+		}
+		if owner.quarantinedRaceChild != nil {
+			runQuarantinedRaceChildSubtest(t, original, owner)
 			return
 		}
 
@@ -3473,7 +3601,7 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 	if err != nil {
 		return err
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	if len(payload) > processRetryWireMaxBytes(len(result.Subtests) > 0 || len(result.Coverage) > 0 || result.Source != nil) {
 		return errors.New("process_retry_result_too_large")
 	}
 	dir := filepath.Dir(resultPath)
@@ -3510,11 +3638,12 @@ func readProcessRetryResult(resultPath string, expected processRetryChildConfig)
 	}
 	defer file.Close()
 
-	payload, err := io.ReadAll(io.LimitReader(file, processRetryResultMaxBytes+1))
+	limit := processRetryWireMaxBytes(expected.Subtree != nil)
+	payload, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
 	if err != nil {
 		return processRetryResult{}, false, fmt.Errorf("%w: result file unreadable", errProcessRetryResultInvalid)
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	if len(payload) > limit {
 		return processRetryResult{}, false, fmt.Errorf("%w: result file too large", errProcessRetryResultInvalid)
 	}
 	var result processRetryResult
@@ -3555,9 +3684,17 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
 		!processRetryJSONStringFits(result.SkipReason, processRetrySkipReasonMaxBytes) ||
-		!processRetryJSONStringFits(result.ResultError, processRetryResultErrorMaxBytes) {
+		!processRetryJSONStringFits(result.ResultError, processRetryResultErrorMaxBytes) ||
+		!processRetryJSONStringFits(result.OutputTail, processRetrySubtreeOutputMaxBytes) {
 		return fmt.Errorf("%w: metadata field too large", errProcessRetryResultInvalid)
 	}
+	if err := validateProcessRetrySubtreeResultEnvelope(result, expected); err != nil {
+		return err
+	}
+	return validateProcessRetryResultStatus(result)
+}
+
+func validateProcessRetryResultStatus(result processRetryResult) error {
 	if result.Panic && (result.Status != processRetryStatusFail && !isProcessRetryControlledTerminalStatus(result.Status) || !result.Failed || result.ErrorType == "") {
 		return fmt.Errorf("%w: invalid panic mirrors", errProcessRetryResultInvalid)
 	}
@@ -3582,7 +3719,7 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 			return fmt.Errorf("%w: invalid controlled terminal mirrors", errProcessRetryResultInvalid)
 		}
 	case processRetryStatusNotRun:
-		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || !validProcessRetryResultError(result.ResultError) {
+		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 || result.SkippedByITR || result.ITRForcedRun || result.Modified || !validProcessRetryResultError(result.ResultError) {
 			return fmt.Errorf("%w: invalid not_run mirrors", errProcessRetryResultInvalid)
 		}
 	default:
@@ -3593,7 +3730,7 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure":
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "selected_root_not_run", "coverage_initialization_failed", "coverage_finalization_failed":
 		return true
 	default:
 		return false

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3228,6 +3228,20 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 					observation.subtree.beginAggregate = func() {
 						observation.aggregate, observation.aggregateErr = coverage.BeginProcessCoverageProfile()
 					}
+					observation.subtree.pauseAggregate = func() func() {
+						if observation.aggregateErr != nil || observation.aggregate == nil {
+							return nil
+						}
+						if err := observation.aggregate.Pause(); err != nil {
+							observation.aggregateErr = err
+							return nil
+						}
+						return func() {
+							if observation.aggregateErr == nil && observation.aggregate != nil {
+								observation.aggregateErr = observation.aggregate.Resume()
+							}
+						}
+					}
 					observation.subtree.finishAggregate = func() {
 						if observation.aggregateErr == nil && observation.aggregate != nil {
 							observation.aggregateErr = observation.aggregate.WriteDelta(processRetrySubtreeCoveragePath(cfg.ResultPath))

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3228,6 +3228,12 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 					observation.subtree.beginAggregate = func() {
 						observation.aggregate, observation.aggregateErr = coverage.BeginProcessCoverageProfile()
 					}
+					observation.subtree.finishAggregate = func() {
+						if observation.aggregateErr == nil && observation.aggregate != nil {
+							observation.aggregateErr = observation.aggregate.WriteDelta(processRetrySubtreeCoveragePath(cfg.ResultPath))
+						}
+						observation.aggregate = nil
+					}
 				}
 				observation.subtree.parallelBridge = control.childRootParallelBridge
 				execMeta.quarantinedRaceChild = observation.subtree

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3216,6 +3216,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			if cfg.Subtree != nil {
 				observation.subtree = newQuarantinedRaceChildState(cfg.Subtree)
 				execMeta.quarantinedRaceChild = observation.subtree
+				execMeta.processRetryCoverageMu = &sync.Mutex{}
 			}
 			observation.execMeta = execMeta
 			return ""

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3237,7 +3237,6 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 				}
 				observation.subtree.parallelBridge = control.childRootParallelBridge
 				execMeta.quarantinedRaceChild = observation.subtree
-				execMeta.processRetryCoverageMu = &sync.Mutex{}
 			}
 			observation.execMeta = execMeta
 			return ""

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3197,7 +3197,8 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		observation.test = t
 		observation.startTime = start
 		observation.source = processRetrySourceFromFunc(runtime.FuncForPC(reflect.ValueOf(original).Pointer()))
-		if cfg.Subtree != nil && cfg.Subtree.CollectAggregate {
+		topLevelName, _ := topLevelTestName(cfg.TestName)
+		if cfg.Subtree != nil && cfg.Subtree.CollectAggregate && cfg.Subtree.SelectedRoot == topLevelName {
 			observation.aggregate, observation.aggregateErr = coverage.BeginProcessCoverageProfile()
 		}
 
@@ -3222,6 +3223,11 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
 			if cfg.Subtree != nil {
 				observation.subtree = newQuarantinedRaceChildState(cfg.Subtree)
+				if cfg.Subtree.CollectAggregate && cfg.Subtree.SelectedRoot != topLevelName {
+					observation.subtree.beginAggregate = func() {
+						observation.aggregate, observation.aggregateErr = coverage.BeginProcessCoverageProfile()
+					}
+				}
 				observation.subtree.parallelBridge = control.childRootParallelBridge
 				execMeta.quarantinedRaceChild = observation.subtree
 				execMeta.processRetryCoverageMu = &sync.Mutex{}
@@ -3230,7 +3236,6 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			return ""
 		}
 		childBody := original
-		topLevelName, _ := topLevelTestName(cfg.TestName)
 		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot == topLevelName {
 			childBody = func(t *testing.T) {
 				rootDirective := cfg.Subtree.Root
@@ -3274,10 +3279,10 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 		} else {
 			observation.writeFinalResult()
 		}
-		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot != topLevelName && status != "" {
-			// A controlled terminal here belongs to a discovery ancestor. The
-			// nested result (including not_run) is recorded independently, and the
-			// parent-process ancestor executes separately.
+		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot != topLevelName {
+			// The top-level test is only a discovery carrier for a nested selected
+			// root. Its native status belongs to the ancestor, which executes and
+			// reports separately in the parent process.
 			return
 		}
 

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -153,6 +153,8 @@ const (
 type processRetryResult struct {
 	Version           int                                `json:"version"`
 	TestName          string                             `json:"test_name"`
+	ModuleName        string                             `json:"module_name,omitempty"`
+	SuiteName         string                             `json:"suite_name,omitempty"`
 	Attempt           int                                `json:"attempt"`
 	RetryReason       string                             `json:"retry_reason"`
 	MRunEpoch         uint64                             `json:"m_run_epoch,omitempty"`
@@ -3283,8 +3285,12 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			}
 			execMeta := createTestMetadata(attempt.test, nil)
 			attempt.metadata = execMeta
-			execMeta.identity = newTestIdentity("", "", cfg.TestName)
-			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
+			moduleName, suiteName := "", ""
+			if cfg.Subtree != nil {
+				moduleName, suiteName = utils.GetModuleAndSuiteName(reflect.ValueOf(original).Pointer())
+			}
+			execMeta.identity = newTestIdentity(moduleName, suiteName, cfg.TestName)
+			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, execMeta.identity, start, writer, control, attempt.raceBaseline)
 			if cfg.Subtree != nil {
 				observation.subtree = newQuarantinedRaceChildState(cfg.Subtree)
 				if cfg.Subtree.CollectAggregate && cfg.Subtree.SelectedRoot != topLevelName {
@@ -3456,6 +3462,8 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 	result := processRetryResult{
 		Version:           1,
 		TestName:          o.cfg.TestName,
+		ModuleName:        o.execMeta.identity.ModuleName,
+		SuiteName:         o.execMeta.identity.SuiteName,
 		Attempt:           o.cfg.Attempt,
 		RetryReason:       o.cfg.RetryReason,
 		MRunEpoch:         o.cfg.MRunEpoch,
@@ -3985,17 +3993,19 @@ type processRetryNoopTest struct {
 	integrations.Test
 	root      *testing.T
 	cfg       processRetryChildConfig
+	identity  *testIdentity
 	startTime time.Time
 	writer    *processRetryResultWriter
 	control   *processRetryControl
 	raceBase  int64
 }
 
-func newProcessRetryNoopTest(root *testing.T, cfg processRetryChildConfig, startTime time.Time, writer *processRetryResultWriter, control *processRetryControl, raceBase int64) integrations.Test {
+func newProcessRetryNoopTest(root *testing.T, cfg processRetryChildConfig, identity *testIdentity, startTime time.Time, writer *processRetryResultWriter, control *processRetryControl, raceBase int64) integrations.Test {
 	return &processRetryNoopTest{
 		Test:      integrations.NewProcessRetryNoopTest(cfg.TestName, startTime),
 		root:      root,
 		cfg:       cfg,
+		identity:  identity,
 		startTime: startTime,
 		writer:    writer,
 		control:   control,
@@ -4008,7 +4018,7 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 		return
 	}
 	finish := time.Now()
-	if t.writer.Write(processRetryResult{
+	result := processRetryResult{
 		Version:           1,
 		TestName:          t.cfg.TestName,
 		Attempt:           t.cfg.Attempt,
@@ -4026,7 +4036,12 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 		StartUnixNano:     t.startTime.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
 		DurationNanos:     finish.Sub(t.startTime).Nanoseconds(),
-	}) && t.control != nil {
+	}
+	if t.identity != nil {
+		result.ModuleName = t.identity.ModuleName
+		result.SuiteName = t.identity.SuiteName
+	}
+	if t.writer.Write(result) && t.control != nil {
 		_ = t.control.childControlledTerminal(processRetryStatusControlledPanicReady)
 	}
 }

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -1758,16 +1758,58 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		parentDeadlineHardCap = parentDeadlineTimer.C()
 		defer parentDeadlineTimer.Stop()
 	}
-	limiterResult := getProcessRetryLimiter().acquireWithShutdownLimit(
+	limiter := getProcessRetryLimiter()
+	limiterMaxConcurrency := processRetryMaxConcurrencyForBaseline(baseline, currentCPU)
+	limiterResult := limiter.acquireWithShutdownLimit(
 		ctx,
 		parentDeadlineHardCap,
 		shutdown,
-		processRetryMaxConcurrencyForBaseline(baseline, currentCPU),
+		limiterMaxConcurrency,
 	)
 	if limiterResult.Cause != processRetryLimiterAcquired {
 		return finishSetupFailure(limiterResult.Err, limiterResult.Cause == processRetryLimiterParentDeadline)
 	}
-	defer limiterResult.Release()
+	// The control bridge reacquires from its goroutine while teardown can run
+	// on the caller, so slot ownership and late release must change atomically.
+	var limiterReleaseMu sync.Mutex
+	limiterRelease := limiterResult.Release
+	limiterStopped := false
+	releaseLimiterSlot := func() {
+		limiterReleaseMu.Lock()
+		release := limiterRelease
+		limiterRelease = nil
+		limiterReleaseMu.Unlock()
+		if release != nil {
+			release()
+		}
+	}
+	setLimiterRelease := func(release processRetryLimiterRelease) {
+		limiterReleaseMu.Lock()
+		if limiterStopped {
+			limiterReleaseMu.Unlock()
+			release()
+			return
+		}
+		limiterRelease = release
+		limiterReleaseMu.Unlock()
+	}
+	stopLimiter := func() {
+		limiterReleaseMu.Lock()
+		limiterStopped = true
+		release := limiterRelease
+		limiterRelease = nil
+		limiterReleaseMu.Unlock()
+		if release != nil {
+			release()
+		}
+	}
+	defer stopLimiter()
+	limiterCtx := ctx
+	cancelLimiter := func() {}
+	if parentParallelBridge != nil {
+		limiterCtx, cancelLimiter = context.WithCancel(ctx)
+	}
+	defer cancelLimiter()
 	if processRetryShutdownRequested(shutdown) || processRetryShuttingDown() {
 		return finishSetupFailure(errProcessRetryShutdown, false)
 	}
@@ -1989,7 +2031,28 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 				attempt.Err = errors.Join(attempt.Err, errProcessRetryControlInvalid, err)
 				waitErr = forceKillAndWait(hooks.killTree)
 			} else {
-				control.parallelBridge = parentParallelBridge
+				if parentParallelBridge != nil {
+					control.parallelBridge = func() error {
+						// A child blocked in t.Parallel is not executing test code.
+						// Release its process slot so another isolated sibling can
+						// reach the same parent barrier, then reacquire before resume.
+						releaseLimiterSlot()
+						if err := parentParallelBridge(); err != nil {
+							return err
+						}
+						reacquired := limiter.acquireWithShutdownLimit(
+							limiterCtx,
+							parentDeadlineHardCap,
+							shutdown,
+							limiterMaxConcurrency,
+						)
+						if reacquired.Cause != processRetryLimiterAcquired {
+							return reacquired.Err
+						}
+						setLimiterRelease(reacquired.Release)
+						return nil
+					}
+				}
 				controlErrors = control.serveParent()
 			}
 		}

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -2484,6 +2484,11 @@ func finishProcessRetryTestEvent(
 	execMeta.test = test
 	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
+	// A validated process skip is already the outcome of the execution. In
+	// particular, replaying an exact disabled descendant must not turn that skip
+	// into the pre-execution metadata cancellation used by in-process tests.
+	disabledSkip := execMeta.isDisabled && !execMeta.isAttemptToFix && attempt.Result.Status == processRetryStatusSkip
+	cancelExecution = cancelExecution && !disabledSkip
 	test.SetTag(constants.TestRetryExecutionMode, "process")
 	if execMeta.isItrForcedRun {
 		test.SetTag(constants.TestForcedToRun, "true")

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3268,10 +3268,17 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			return
 		}
 		observation.result = result
-		if status := processRetryControlledTerminalStatus(result); status != "" {
+		status := processRetryControlledTerminalStatus(result)
+		if status != "" {
 			observation.writeControlledTerminalResult(control, status)
 		} else {
 			observation.writeFinalResult()
+		}
+		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot != topLevelName && status != "" {
+			// A controlled terminal here belongs to a discovery ancestor. The
+			// nested result (including not_run) is recorded independently, and the
+			// parent-process ancestor executes separately.
+			return
 		}
 
 		if result.failed || result.raceDetected || result.panicData != nil || result.cleanupPanicData != nil {

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -1693,6 +1693,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 	parentDeadlineOK bool,
 	baseline *processRetryLaunchBaseline,
 	shutdown <-chan struct{},
+	parentParallelBridge func() error,
 ) processRetryAttemptResult {
 	if ctx == nil {
 		ctx = context.Background()
@@ -1987,6 +1988,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 				attempt.Err = errors.Join(attempt.Err, errProcessRetryControlInvalid, err)
 				waitErr = forceKillAndWait(hooks.killTree)
 			} else {
+				control.parallelBridge = parentParallelBridge
 				controlErrors = control.serveParent()
 			}
 		}
@@ -3215,6 +3217,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			execMeta.test = newProcessRetryNoopTest(attempt.test, cfg, start, writer, control, attempt.raceBaseline)
 			if cfg.Subtree != nil {
 				observation.subtree = newQuarantinedRaceChildState(cfg.Subtree)
+				observation.subtree.parallelBridge = control.childRootParallelBridge
 				execMeta.quarantinedRaceChild = observation.subtree
 				execMeta.processRetryCoverageMu = &sync.Mutex{}
 			}
@@ -3322,7 +3325,8 @@ func (o *processRetryChildObservation) writeControlledTerminalResult(control *pr
 		if o.test == nil || o.execMeta == nil {
 			return
 		}
-		written = o.writer.Write(o.buildResult(status))
+		result := o.buildResult(status)
+		written = o.writer.Write(result) && result.Status == status
 	})
 	if written && control != nil {
 		_ = control.childControlledTerminal(status)
@@ -3330,6 +3334,11 @@ func (o *processRetryChildObservation) writeControlledTerminalResult(control *pr
 }
 
 func (o *processRetryChildObservation) buildResult(status processRetryStatus) processRetryResult {
+	if o.subtree != nil {
+		if err := o.subtree.waitParallelBridge(); err != nil {
+			return processRetryNotRunResult(o.cfg, "parallel_control_failed")
+		}
+	}
 	finish := o.startTime.Add(o.result.duration)
 	panicData := o.result.panicData
 	panicStack := o.result.panicStack

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3557,9 +3557,14 @@ func markProcessRetryChildFailed(tb testing.TB) {
 	if !ok {
 		return
 	}
-	if execMeta := processRetryChildOwnerMetadata(getTestMetadata(t)); execMeta != nil && execMeta.quarantinedRaceChild != nil &&
+	current := getTestMetadata(t)
+	if execMeta := processRetryChildOwnerMetadata(current); execMeta != nil && execMeta.quarantinedRaceChild != nil &&
 		!processRetryChildFailureIsPropagated() {
-		execMeta.quarantinedRaceChild.markUnmaskedFailure(t.Name())
+		moduleName, suiteName := "", ""
+		if current != nil && current.identity != nil {
+			moduleName, suiteName = current.identity.ModuleName, current.identity.SuiteName
+		}
+		execMeta.quarantinedRaceChild.markUnmaskedFailure(moduleName, suiteName, t.Name())
 	}
 	fields := getTestPrivateFields(t)
 	ancestry := make([]*commonPrivateFields, 0, 4)

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3320,6 +3320,9 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 				}
 				observation.subtree.parallelBridge = control.childRootParallelBridge
 				execMeta.quarantinedRaceChild = observation.subtree
+				if cfg.Subtree.OwnsAttemptToFix {
+					execMeta.processRetryAttemptOwner = cfg.Subtree.SelectedRoot
+				}
 			}
 			observation.execMeta = execMeta
 			return ""
@@ -3344,7 +3347,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 					observation.execMeta.processRetrySkipReason.Store(&reason)
 					t.SkipNow()
 				}
-				if skip, forced := cfg.Subtree.itrDecision(cfg.Subtree.SelectedRoot, rootDirective, runtime.FuncForPC(reflect.ValueOf(original).Pointer())); skip {
+				if skip, forced := cfg.Subtree.itrDecision(rootDirective.SuiteName, cfg.Subtree.SelectedRoot, rootDirective, runtime.FuncForPC(reflect.ValueOf(original).Pointer())); skip {
 					observation.execMeta.isItrSkipped = true
 					reason := constants.SkippedByITRReason
 					observation.execMeta.processRetrySkipReason.Store(&reason)
@@ -3559,7 +3562,7 @@ func markProcessRetryChildFailed(tb testing.TB) {
 	}
 	current := getTestMetadata(t)
 	if execMeta := processRetryChildOwnerMetadata(current); execMeta != nil && execMeta.quarantinedRaceChild != nil &&
-		!processRetryChildFailureIsPropagated() {
+		!processRetryChildFailureIsPropagated() && (current == nil || !current.processRetryManagedDescendant) {
 		moduleName, suiteName := "", ""
 		if current != nil && current.identity != nil {
 			moduleName, suiteName = current.identity.ModuleName, current.identity.SuiteName
@@ -3606,13 +3609,14 @@ func instrumentProcessRetryChildSubtest(original func(*testing.T)) func(*testing
 			original(t)
 			return
 		}
-		owner := processRetryChildOwnerMetadata(getTestMetadataFromPointer(*fields.parent))
+		parent := getTestMetadataFromPointer(*fields.parent)
+		owner := processRetryChildOwnerMetadata(parent)
 		if owner == nil {
 			original(t)
 			return
 		}
 		if owner.quarantinedRaceChild != nil {
-			runQuarantinedRaceChildSubtest(t, original, owner)
+			runQuarantinedRaceChildSubtest(t, original, parent)
 			return
 		}
 

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3952,7 +3952,7 @@ func validateProcessRetryResultStatus(result processRetryResult) error {
 
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "selected_root_not_run", "coverage_initialization_failed", "coverage_finalization_failed", processRetryResultErrorSubtreeTooLarge:
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "parallel_control_failed", "selected_root_not_run", "coverage_initialization_failed", "coverage_finalization_failed", processRetryResultErrorSubtreeTooLarge:
 		return true
 	default:
 		return false

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -132,6 +132,7 @@ const (
 	processRetrySkipReasonMaxBytes         = 8 * 1024
 	processRetryResultErrorMaxBytes        = 256
 	processRetryResultMaxBytes             = 64 * 1024
+	processRetryResultErrorSubtreeTooLarge = "subtree_result_too_large"
 	processRetryTruncationMarker           = "[dd-trace-go: process retry panic data truncated]"
 	processRetryMetadataTruncationMarker   = "[dd-trace-go: process retry metadata truncated]"
 	processRetryOutputTruncationMarker     = "\n[dd-trace-go: process retry output truncated]\n"
@@ -3623,12 +3624,9 @@ func processRetryJSONStringFits(value string, maxBytes int) bool {
 }
 
 func writeProcessRetryResultAtomically(resultPath string, result processRetryResult) error {
-	payload, err := json.Marshal(result)
+	payload, err := marshalProcessRetryResult(result)
 	if err != nil {
 		return err
-	}
-	if len(payload) > processRetryWireMaxBytes(len(result.Subtests) > 0 || len(result.Coverage) > 0 || result.Source != nil) {
-		return errors.New("process_retry_result_too_large")
 	}
 	dir := filepath.Dir(resultPath)
 	tmp, err := os.CreateTemp(dir, ".process-retry-result-*.tmp")
@@ -3652,6 +3650,113 @@ func writeProcessRetryResultAtomically(resultPath string, result processRetryRes
 	}
 	closed = true
 	return os.Rename(tmpName, resultPath)
+}
+
+func marshalProcessRetryResult(result processRetryResult) ([]byte, error) {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	subtree := len(result.Subtests) > 0 || len(result.Coverage) > 0 || result.Source != nil
+	limit := processRetryWireMaxBytes(subtree)
+	if len(payload) <= limit {
+		return payload, nil
+	}
+	if !subtree {
+		return nil, errors.New("process_retry_result_too_large")
+	}
+	if payload, ok, err := marshalBoundedProcessRetrySubtreeEnvelope(result, limit); err != nil {
+		return nil, err
+	} else if ok {
+		return payload, nil
+	}
+	// Preserve a valid protocol result when even the mandatory event structure
+	// cannot fit. The parent then fails closed with the explicit reason instead
+	// of misclassifying an absent file as a child-process failure.
+	fallback, err := json.Marshal(processRetryResult{
+		Version: result.Version, TestName: result.TestName, Attempt: result.Attempt, RetryReason: result.RetryReason,
+		MRunEpoch: result.MRunEpoch, InvocationOrdinal: result.InvocationOrdinal,
+		Status: processRetryStatusNotRun, ResultError: processRetryResultErrorSubtreeTooLarge,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(fallback) > limit {
+		return nil, errors.New("process_retry_result_too_large")
+	}
+	return fallback, nil
+}
+
+func marshalBoundedProcessRetrySubtreeEnvelope(result processRetryResult, maxBytes int) ([]byte, bool, error) {
+	const metadataFields = 4
+	// Keep every event and first fit diagnostics around the existing source and
+	// coverage data. Those optional fields are omitted only when that core alone
+	// exceeds the wire limit.
+	for _, preserveSourceAndCoverage := range [...]bool{true, false} {
+		core := cloneProcessRetrySubtreeEnvelope(result, preserveSourceAndCoverage)
+		truncateProcessRetryAggregateMetadata(&core, 0)
+		corePayload, err := json.Marshal(core)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(corePayload) > maxBytes {
+			continue
+		}
+
+		perEventBudget := (maxBytes - len(corePayload)) / (len(result.Subtests) + 1)
+		fieldLimit := perEventBudget / metadataFields
+		for {
+			bounded := cloneProcessRetrySubtreeEnvelope(result, preserveSourceAndCoverage)
+			truncateProcessRetryAggregateMetadata(&bounded, fieldLimit)
+			payload, err := json.Marshal(bounded)
+			if err != nil {
+				return nil, false, err
+			}
+			if len(payload) <= maxBytes {
+				return payload, true, nil
+			}
+			if fieldLimit == 0 {
+				break
+			}
+			fieldLimit /= 2
+		}
+	}
+	return nil, false, nil
+}
+
+func cloneProcessRetrySubtreeEnvelope(result processRetryResult, preserveSourceAndCoverage bool) processRetryResult {
+	result.Subtests = slices.Clone(result.Subtests)
+	if preserveSourceAndCoverage {
+		return result
+	}
+	result.Source = nil
+	result.Coverage = nil
+	for idx := range result.Subtests {
+		result.Subtests[idx].Source = nil
+		result.Subtests[idx].Coverage = nil
+	}
+	return result
+}
+
+func truncateProcessRetryAggregateMetadata(result *processRetryResult, maxBytes int) {
+	truncate := func(message, stack, skipReason, output string, outputTruncated, skippedByITR bool) (string, string, string, string, bool) {
+		message = truncateProcessRetryString(message, min(maxBytes, processRetryErrorMessageMaxBytes), processRetryMetadataTruncationMarker)
+		stack = truncateProcessRetryString(stack, min(maxBytes, processRetryErrorStackMaxBytes), processRetryMetadataTruncationMarker)
+		if !skippedByITR {
+			skipReason = truncateProcessRetryString(skipReason, min(maxBytes, processRetrySkipReasonMaxBytes), processRetryMetadataTruncationMarker)
+		}
+		output, truncated := truncateProcessRetrySubtreeOutputTo(output, min(maxBytes, processRetrySubtreeOutputMaxBytes))
+		return message, stack, skipReason, output, output != "" && (outputTruncated || truncated)
+	}
+	result.ErrorMessage, result.ErrorStack, result.SkipReason, result.OutputTail, result.OutputTruncated = truncate(
+		result.ErrorMessage, result.ErrorStack, result.SkipReason, result.OutputTail, result.OutputTruncated, result.SkippedByITR,
+	)
+	for idx := range result.Subtests {
+		subtest := &result.Subtests[idx]
+		subtest.ErrorMessage, subtest.ErrorStack, subtest.SkipReason, subtest.OutputTail, subtest.OutputTruncated = truncate(
+			subtest.ErrorMessage, subtest.ErrorStack, subtest.SkipReason, subtest.OutputTail, subtest.OutputTruncated, subtest.SkippedByITR,
+		)
+	}
 }
 
 func readProcessRetryResult(resultPath string, expected processRetryChildConfig) (processRetryResult, bool, error) {
@@ -3706,6 +3811,9 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 	if (result.MRunEpoch == 0) != (result.InvocationOrdinal == 0) {
 		return fmt.Errorf("%w: invalid invocation identity", errProcessRetryResultInvalid)
 	}
+	if result.ResultError == processRetryResultErrorSubtreeTooLarge && expected.Subtree == nil {
+		return fmt.Errorf("%w: unexpected subtree result error", errProcessRetryResultInvalid)
+	}
 	if !processRetryJSONStringFits(result.ErrorType, processRetryErrorTypeMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorMessage, processRetryErrorMessageMaxBytes) ||
 		!processRetryJSONStringFits(result.ErrorStack, processRetryErrorStackMaxBytes) ||
@@ -3756,7 +3864,7 @@ func validateProcessRetryResultStatus(result processRetryResult) error {
 
 func validProcessRetryResultError(reason string) bool {
 	switch reason {
-	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "selected_root_not_run", "coverage_initialization_failed", "coverage_finalization_failed":
+	case "", "missing_result_path", "missing_test_name", "missing_attempt", "invalid_attempt", "missing_retry_reason", "invalid_child_config", "testing_m_reflection_drift", "testing_t_reflection_drift", "control_protocol_failure", "selected_root_not_run", "coverage_initialization_failed", "coverage_finalization_failed", processRetryResultErrorSubtreeTooLarge:
 		return true
 	default:
 		return false

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3010,6 +3010,11 @@ func instrumentProcessRetryChild(m *testing.M, cfg processRetryChildConfig) (boo
 		hardStopInvalidProcessRetryChild("control_protocol_failure")
 		return false, failureTestingMFinalizer
 	}
+	if cfg.Subtree != nil {
+		// This happens before M.Run starts test goroutines. The hook remains off
+		// in parent processes and ordinary retry children for their whole lifetime.
+		activateQuarantinedRaceParallelHook()
+	}
 	if cfg.Subtree != nil && (cfg.Subtree.CollectPerTest || cfg.Subtree.CollectAggregate) {
 		// The process child deliberately skips CI Visibility initialization,
 		// so initialize only Go's runtime coverage hooks. Coverage is returned

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3549,6 +3549,10 @@ func markProcessRetryChildFailed(tb testing.TB) {
 	if !ok {
 		return
 	}
+	if execMeta := processRetryChildOwnerMetadata(getTestMetadata(t)); execMeta != nil && execMeta.quarantinedRaceChild != nil &&
+		!processRetryChildFailureIsPropagated() {
+		execMeta.quarantinedRaceChild.markUnmaskedFailure(t.Name())
+	}
 	fields := getTestPrivateFields(t)
 	ancestry := make([]*commonPrivateFields, 0, 4)
 	for fields != nil {
@@ -3557,6 +3561,28 @@ func markProcessRetryChildFailed(tb testing.TB) {
 	}
 	for _, fields := range slices.Backward(ancestry) {
 		fields.SetFailed(true)
+	}
+}
+
+// processRetryChildFailureIsPropagated distinguishes the original Fail call
+// from testing.common.Fail recursively propagating it through parent tests.
+func processRetryChildFailureIsPropagated() bool {
+	var pcs [16]uintptr
+	frames := runtime.CallersFrames(pcs[:runtime.Callers(2, pcs[:])])
+	failFrames := 0
+	for {
+		frame, more := frames.Next()
+		if frame.Function == "testing.(*common).Fail" {
+			failFrames++
+			if failFrames > 1 {
+				return true
+			}
+		} else if failFrames > 0 {
+			return false
+		}
+		if !more {
+			return false
+		}
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -2990,7 +2990,6 @@ func instrumentProcessRetryChild(m *testing.M, cfg processRetryChildConfig) (boo
 				getInternalExampleArray(m),
 			)
 			hardStopInvalidProcessRetryChild("coverage_initialization_failed")
-			return false, failureTestingMFinalizer
 		}
 	}
 	releaseHookEpoch := activateTestingMHookEpoch(cfg.MRunEpoch)

--- a/internal/civisibility/integrations/gotesting/retry_process_control.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_control.go
@@ -99,6 +99,8 @@ type processRetryControl struct {
 	terminal  processRetryControlledTerminalState
 	serveDone chan struct{}
 	wire      processRetryControlConfig
+
+	parallelBridge func() error
 }
 
 type processRetryControlledTerminalState struct {
@@ -386,6 +388,12 @@ func (c *processRetryControl) serveParent() <-chan error {
 			}
 			switch frame.Kind {
 			case processRetryControlParallelRequest:
+				if c.parallelBridge != nil {
+					if err := c.parallelBridge(); err != nil {
+						errorsCh <- err
+						return
+					}
+				}
 				if err := c.Send(processRetryControlParallelResume, ""); err != nil {
 					errorsCh <- err
 					return

--- a/internal/civisibility/integrations/gotesting/retry_process_control.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_control.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -48,18 +49,19 @@ var (
 )
 
 type processRetryControlConfig struct {
-	Version                int    `json:"version"`
-	Transport              string `json:"transport"`
-	TestName               string `json:"test_name"`
-	Attempt                int    `json:"attempt"`
-	RetryReason            string `json:"retry_reason"`
-	MRunEpoch              uint64 `json:"m_run_epoch,omitempty"`
-	InvocationOrdinal      uint64 `json:"invocation_ordinal,omitempty"`
-	ReadEndpoint           uint64 `json:"read_endpoint"`
-	WriteEndpoint          uint64 `json:"write_endpoint"`
-	ParentDeadlineUnixNano int64  `json:"parent_deadline_unix_nano"`
-	ParentDeadlineOK       bool   `json:"parent_deadline_ok"`
-	ObservedGOMAXPROCS     int    `json:"observed_gomaxprocs"`
+	Version                int                        `json:"version"`
+	Transport              string                     `json:"transport"`
+	TestName               string                     `json:"test_name"`
+	Attempt                int                        `json:"attempt"`
+	RetryReason            string                     `json:"retry_reason"`
+	MRunEpoch              uint64                     `json:"m_run_epoch,omitempty"`
+	InvocationOrdinal      uint64                     `json:"invocation_ordinal,omitempty"`
+	ReadEndpoint           uint64                     `json:"read_endpoint"`
+	WriteEndpoint          uint64                     `json:"write_endpoint"`
+	ParentDeadlineUnixNano int64                      `json:"parent_deadline_unix_nano"`
+	ParentDeadlineOK       bool                       `json:"parent_deadline_ok"`
+	ObservedGOMAXPROCS     int                        `json:"observed_gomaxprocs"`
+	Subtree                *processRetrySubtreeConfig `json:"subtree,omitempty"`
 }
 
 type processRetryControlFrame struct {
@@ -131,6 +133,7 @@ func newParentProcessRetryControl(cmd *exec.Cmd, cfg processRetryChildConfig) (*
 	transport.config.ParentDeadlineUnixNano = cfg.ParentDeadlineUnixNano
 	transport.config.ParentDeadlineOK = cfg.ParentDeadlineOK
 	transport.config.ObservedGOMAXPROCS = cfg.ObservedGOMAXPROCS
+	transport.config.Subtree = cfg.Subtree
 	if transport.config.ObservedGOMAXPROCS < 1 {
 		transport.config.ObservedGOMAXPROCS = processRetryCurrentCPU()
 	}
@@ -566,6 +569,7 @@ func writeProcessRetryControlConfig(path string, cfg processRetryControlConfig) 
 		RetryReason:       cfg.RetryReason,
 		MRunEpoch:         cfg.MRunEpoch,
 		InvocationOrdinal: cfg.InvocationOrdinal,
+		Subtree:           cfg.Subtree,
 	}); err != nil {
 		return err
 	}
@@ -573,7 +577,7 @@ func writeProcessRetryControlConfig(path string, cfg processRetryControlConfig) 
 	if err != nil {
 		return err
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	if len(payload) > processRetryWireMaxBytes(cfg.Subtree != nil) {
 		return errProcessRetryControlTooLarge
 	}
 	return os.WriteFile(path, payload, 0o600)
@@ -588,11 +592,12 @@ func readProcessRetryControlConfig(path string, expected processRetryChildConfig
 		return processRetryControlConfig{}, err
 	}
 	defer file.Close()
-	payload, err := io.ReadAll(io.LimitReader(file, processRetryResultMaxBytes+1))
+	limit := processRetryWireMaxBytes(expected.RetryReason == processRetrySubtreeReason)
+	payload, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
 	if err != nil {
 		return processRetryControlConfig{}, err
 	}
-	if len(payload) > processRetryResultMaxBytes {
+	if len(payload) > limit {
 		return processRetryControlConfig{}, errProcessRetryControlTooLarge
 	}
 	var cfg processRetryControlConfig
@@ -625,6 +630,16 @@ func validateProcessRetryControlConfig(cfg processRetryControlConfig, expected p
 		return errProcessRetryControlInvalid
 	}
 	if cfg.ObservedGOMAXPROCS < 1 || (!cfg.ParentDeadlineOK && cfg.ParentDeadlineUnixNano != 0) {
+		return errProcessRetryControlInvalid
+	}
+	if (cfg.Subtree != nil && cfg.RetryReason != processRetrySubtreeReason) ||
+		(cfg.Subtree == nil && cfg.RetryReason == processRetrySubtreeReason) {
+		return errProcessRetryControlInvalid
+	}
+	if err := validateProcessRetrySubtreeConfig(cfg.Subtree, cfg.TestName); err != nil {
+		return errors.Join(errProcessRetryControlInvalid, err)
+	}
+	if expected.Subtree != nil && !reflect.DeepEqual(cfg.Subtree, expected.Subtree) {
 		return errProcessRetryControlInvalid
 	}
 	switch cfg.Transport {

--- a/internal/civisibility/integrations/gotesting/retry_process_control.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_control.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/DataDog/dd-trace-go/v2/internal/locking"
 )
 
@@ -600,7 +601,7 @@ func readProcessRetryControlConfig(path string, expected processRetryChildConfig
 		return processRetryControlConfig{}, err
 	}
 	defer file.Close()
-	limit := processRetryWireMaxBytes(expected.RetryReason == processRetrySubtreeReason)
+	limit := processRetryWireMaxBytes(expected.RetryReason == processRetrySubtreeReason || expected.RetryReason == constants.AttemptToFixRetryReason)
 	payload, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
 	if err != nil {
 		return processRetryControlConfig{}, err
@@ -640,8 +641,8 @@ func validateProcessRetryControlConfig(cfg processRetryControlConfig, expected p
 	if cfg.ObservedGOMAXPROCS < 1 || (!cfg.ParentDeadlineOK && cfg.ParentDeadlineUnixNano != 0) {
 		return errProcessRetryControlInvalid
 	}
-	if (cfg.Subtree != nil && cfg.RetryReason != processRetrySubtreeReason) ||
-		(cfg.Subtree == nil && cfg.RetryReason == processRetrySubtreeReason) {
+	if cfg.Subtree == nil && cfg.RetryReason == processRetrySubtreeReason ||
+		cfg.Subtree != nil && cfg.RetryReason != processRetrySubtreeReason && cfg.RetryReason != constants.AttemptToFixRetryReason {
 		return errProcessRetryControlInvalid
 	}
 	if err := validateProcessRetrySubtreeConfig(cfg.Subtree, cfg.TestName); err != nil {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -108,7 +108,7 @@ type deferredProcessRetryGroup struct {
 	raceProcess           *quarantinedRaceProcessContext
 	raceSubtree           *processRetrySubtreeConfig
 	raceDescendantFailed  bool
-	raceReplay            quarantinedRaceReplayState
+	raceReplay            *quarantinedRaceReplayState
 }
 
 type deferredProcessRetryEvent struct {
@@ -975,6 +975,10 @@ func enqueueDeferredProcessRetryGroup(execOpts *executionOptions) bool {
 		raceProcess:           execOpts.executionMetadata.quarantinedRaceProcess,
 		raceSubtree:           quarantinedRaceSubtree,
 	}
+	group.raceReplay = execOpts.executionMetadata.quarantinedRaceReplay.Swap(nil)
+	if quarantinedRaceSubtree != nil && group.raceReplay == nil {
+		group.raceReplay = &quarantinedRaceReplayState{}
+	}
 	group.metadata.identity = &group.identity
 	group.testInfo.identity = &group.identity
 	group.tailEvent = &deferredProcessRetryEvent{
@@ -1043,6 +1047,9 @@ func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessR
 		group.shutdown(),
 		nil,
 	)
+	if subtree != nil {
+		attempt = finalizeQuarantinedRaceInvocation(subtree, attempt)
+	}
 	if subtree == nil || processRetryInfrastructureFailure(attempt) || subtree.AttemptToFixRetries <= 0 || quarantinedRaceFailfastStopsContinuation(attempt) {
 		return attempt
 	}
@@ -1132,7 +1139,7 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		g.tailEvent = nextTail
 	}
 	if len(raceInvocations) > 0 {
-		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, raceInvocations, false, &g.raceReplay)
+		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, raceInvocations, false, g.raceReplay)
 	}
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,
@@ -1289,7 +1296,9 @@ func (g *deferredProcessRetryGroup) finish() {
 	if g == nil {
 		return
 	}
-	g.raceReplay.finish()
+	if g.raceReplay != nil {
+		g.raceReplay.finish()
+	}
 	g.closeTailEvent(true)
 	if g.raceProcess != nil {
 		g.raceProcess.clearAncestorOutcomes(g.raceSubtree)
@@ -1361,7 +1370,13 @@ func deferOrCloseInstrumentedTestEvent(
 }
 
 func completeDeferredProcessRetryEvent(execMeta *testExecutionMetadata) {
-	if execMeta == nil || execMeta.deferredRetryEvent == nil {
+	if execMeta == nil {
+		return
+	}
+	if execMeta.deferredRetryEvent == nil {
+		if replay := execMeta.quarantinedRaceReplay.Swap(nil); replay != nil {
+			replay.finish()
+		}
 		return
 	}
 	event := execMeta.deferredRetryEvent
@@ -1377,6 +1392,9 @@ func completeDeferredProcessRetryEvent(execMeta *testExecutionMetadata) {
 	}
 	admission.abort()
 	if group != nil {
+		if group.raceReplay != nil {
+			group.raceReplay.finish()
+		}
 		if group.reservation != nil {
 			group.reservation.refund()
 			group.reservation = nil

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1025,6 +1025,7 @@ func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessR
 		group.parentDeadlineOK,
 		group.launchBaseline,
 		group.shutdown(),
+		nil,
 	)
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -105,6 +105,8 @@ type deferredProcessRetryGroup struct {
 	rootParallel          bool
 	nativeMaxParallel     int
 	efdFaultySessionGuard earlyFlakeDetectionFaultySession
+	raceProcess           *quarantinedRaceProcessContext
+	raceSubtree           *processRetrySubtreeConfig
 }
 
 type deferredProcessRetryEvent struct {
@@ -910,6 +912,14 @@ func enqueueDeferredProcessRetryGroup(execOpts *executionOptions) bool {
 	}
 	metadataCopy := *metadata
 	testInfo := *options.testInfo
+	quarantinedRaceSubtree, err := buildDeferredQuarantinedRaceSubtreeConfig(
+		execOpts.executionMetadata.quarantinedRaceProcess,
+		&testInfo,
+		execOpts.executionMetadata,
+	)
+	if err != nil {
+		return false
+	}
 	panicMessage := execOpts.lastObservation.panicMessage
 	if execOpts.lastObservation.panicData != nil && panicMessage == "" {
 		panicMessage = fmt.Sprint(execOpts.lastObservation.panicData)
@@ -960,6 +970,8 @@ func enqueueDeferredProcessRetryGroup(execOpts *executionOptions) bool {
 		rootParallel:          execOpts.lastObservation.rootParallel,
 		nativeMaxParallel:     nativeMaxParallel,
 		efdFaultySessionGuard: options.efdFaultySessionGuard,
+		raceProcess:           execOpts.executionMetadata.quarantinedRaceProcess,
+		raceSubtree:           quarantinedRaceSubtree,
 	}
 	group.metadata.identity = &group.identity
 	group.testInfo.identity = &group.identity
@@ -1012,6 +1024,7 @@ func (g *deferredProcessRetryGroup) prepareAttempt(allowEFDTransition bool) (def
 }
 
 func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessRetryGroup, prepared deferredProcessRetryPreparedAttempt) processRetryAttemptResult {
+	subtree := group.quarantinedRaceSubtreeForAttempt(prepared.index)
 	return runProcessRetryAttemptWithBaselineAndShutdown(
 		ctx,
 		processRetryChildConfig{
@@ -1020,6 +1033,7 @@ func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessR
 			RetryReason:       prepared.retryReason,
 			MRunEpoch:         group.mRunEpoch,
 			InvocationOrdinal: group.invocationOrdinal,
+			Subtree:           subtree,
 		},
 		group.parentDeadline,
 		group.parentDeadlineOK,
@@ -1062,6 +1076,11 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		g.closeTailEvent(false)
 		g.tailEvent = nextTail
 	}
+	if g.raceSubtree != nil {
+		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, []quarantinedRaceInvocation{{
+			cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
+		}}, false)
+	}
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,
 		failed:         effective.Failed,
@@ -1079,6 +1098,15 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		attempt.Cleanup()
 	}
 	return continueGroup
+}
+
+func (g *deferredProcessRetryGroup) quarantinedRaceSubtreeForAttempt(index int) *processRetrySubtreeConfig {
+	if g == nil || g.raceSubtree == nil {
+		return nil
+	}
+	cfg := *g.raceSubtree
+	cfg.AncestorAttemptIndex = index
+	return &cfg
 }
 
 func (g *deferredProcessRetryGroup) admitEarlyFlakeDetectionContinuation() bool {
@@ -1194,6 +1222,9 @@ func (g *deferredProcessRetryGroup) finish() {
 		return
 	}
 	g.closeTailEvent(true)
+	if g.raceProcess != nil {
+		g.raceProcess.clearAncestorOutcomes(g.raceSubtree)
+	}
 	if g.suite != nil && g.module != nil {
 		checkModuleAndSuite(g.module, g.suite)
 		g.suite = nil

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -108,6 +108,7 @@ type deferredProcessRetryGroup struct {
 	raceProcess           *quarantinedRaceProcessContext
 	raceSubtree           *processRetrySubtreeConfig
 	raceDescendantFailed  bool
+	raceReplay            quarantinedRaceReplayState
 }
 
 type deferredProcessRetryEvent struct {
@@ -1042,7 +1043,7 @@ func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessR
 		group.shutdown(),
 		nil,
 	)
-	if subtree == nil || processRetryInfrastructureFailure(attempt) || subtree.AttemptToFixRetries <= 0 {
+	if subtree == nil || processRetryInfrastructureFailure(attempt) || subtree.AttemptToFixRetries <= 0 || quarantinedRaceFailfastStopsContinuation(attempt) {
 		return attempt
 	}
 	invocations := []quarantinedRaceInvocation{{cfg: subtree, attempt: attempt, attemptIndex: prepared.index}}
@@ -1088,7 +1089,20 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 	// time a late setup failure is observable, native M.Run and the original
 	// testing.T have completed, so represent the admitted continuation exactly once.
 	terminal := deferredProcessRetryAttemptTerminal(attempt)
+	stopAfterSubtreeFailure := g.raceSubtree != nil && quarantinedRaceFailfastStopsContinuation(attempt)
 	continueGroup := continuationAdmitted && !terminal
+	var raceInvocations []quarantinedRaceInvocation
+	if g.raceSubtree != nil {
+		raceInvocations = attempt.quarantinedRaceInvocations
+		if len(raceInvocations) == 0 {
+			raceInvocations = []quarantinedRaceInvocation{{
+				cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
+			}}
+		}
+		for _, invocation := range raceInvocations {
+			g.observeQuarantinedRaceSubtree(invocation.attempt.Result.Subtests)
+		}
+	}
 	effective, nextTail := deferProcessRetryTestEventWithAdmission(&g.testInfo, execMeta, attempt, func(effective processRetryEffectiveStatus) {
 		g.retryCount--
 		g.outcomes.observe(effective.Failed, effective.Skipped)
@@ -1098,6 +1112,9 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		execMeta.anyExecutionFailed = g.outcomes.anyFailed()
 		if decideContinuation {
 			continueGroup = !terminal && deferredProcessRetryShouldContinue(execMeta, effective.Failed, effective.Skipped, g.retryCount)
+			if continueGroup && stopAfterSubtreeFailure {
+				continueGroup = false
+			}
 			if continueGroup {
 				continueGroup = g.admitEarlyFlakeDetectionContinuation()
 			}
@@ -1114,17 +1131,8 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		g.closeTailEvent(false)
 		g.tailEvent = nextTail
 	}
-	if g.raceSubtree != nil {
-		invocations := attempt.quarantinedRaceInvocations
-		if len(invocations) == 0 {
-			invocations = []quarantinedRaceInvocation{{
-				cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
-			}}
-		}
-		for _, invocation := range invocations {
-			g.observeQuarantinedRaceSubtree(invocation.attempt.Result.Subtests)
-		}
-		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, invocations, false)
+	if len(raceInvocations) > 0 {
+		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, raceInvocations, false, &g.raceReplay)
 	}
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,
@@ -1149,10 +1157,11 @@ func (g *deferredProcessRetryGroup) observeQuarantinedRaceSubtree(results []proc
 	if g == nil || g.raceDescendantFailed {
 		return
 	}
-	// Independently owned, non-quarantined Attempt-to-Fix descendants retain
-	// their normal package-failure semantics even when the deferred root passes.
+	// Non-quarantined descendants in an independently owned Attempt-to-Fix
+	// family retain normal package-failure semantics even when their owner and
+	// the deferred root pass.
 	g.raceDescendantFailed = slices.ContainsFunc(results, func(result processRetrySubtreeResult) bool {
-		return result.Failed && result.AttemptToFixOwn && !result.Quarantined && !result.Disabled
+		return result.Failed && (result.AttemptToFixOwn || result.AttemptToFix) && !result.Quarantined && !result.Disabled
 	})
 }
 
@@ -1280,6 +1289,7 @@ func (g *deferredProcessRetryGroup) finish() {
 	if g == nil {
 		return
 	}
+	g.raceReplay.finish()
 	g.closeTailEvent(true)
 	if g.raceProcess != nil {
 		g.raceProcess.clearAncestorOutcomes(g.raceSubtree)

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1026,7 +1026,7 @@ func (g *deferredProcessRetryGroup) prepareAttempt(allowEFDTransition bool) (def
 
 func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessRetryGroup, prepared deferredProcessRetryPreparedAttempt) processRetryAttemptResult {
 	subtree := group.quarantinedRaceSubtreeForAttempt(prepared.index)
-	return runProcessRetryAttemptWithBaselineAndShutdown(
+	attempt := runProcessRetryAttemptWithBaselineAndShutdown(
 		ctx,
 		processRetryChildConfig{
 			TestName:          group.identity.FullName,
@@ -1042,6 +1042,43 @@ func runDeferredProcessRetryAttempt(ctx context.Context, group *deferredProcessR
 		group.shutdown(),
 		nil,
 	)
+	if subtree == nil || processRetryInfrastructureFailure(attempt) || subtree.AttemptToFixRetries <= 0 {
+		return attempt
+	}
+	invocations := []quarantinedRaceInvocation{{cfg: subtree, attempt: attempt, attemptIndex: prepared.index}}
+	_, failure := continueQuarantinedRaceDescendantFamilies(
+		subtree, attempt, &invocations, func(continuationCfg *processRetrySubtreeConfig, runRoot string, idx int) processRetryAttemptResult {
+			baseline := captureProcessRetryLaunchBaselineFromTemplate(group.launchBaseline)
+			baseline.argsSnapshot.runSelector = processRetryExactRunPattern(runRoot)
+			return finalizeQuarantinedRaceInvocation(continuationCfg, runProcessRetryAttemptWithBaselineAndShutdown(
+				ctx,
+				processRetryChildConfig{
+					TestName:          continuationCfg.SelectedRoot,
+					Attempt:           idx + 1,
+					RetryReason:       processRetrySubtreeReason,
+					MRunEpoch:         group.mRunEpoch,
+					InvocationOrdinal: group.raceProcess.invocations.Add(1),
+					Subtree:           continuationCfg,
+				},
+				group.parentDeadline,
+				group.parentDeadlineOK,
+				baseline,
+				group.shutdown(),
+				nil,
+			))
+		},
+	)
+	attempt.quarantinedRaceInvocations = invocations
+	if failure != nil {
+		attempt.Err = errors.Join(attempt.Err, failure.attempt.Err)
+		attempt.ExitCode = failure.attempt.ExitCode
+		attempt.ExitStatusObserved = failure.attempt.ExitStatusObserved
+		attempt.SetupFailure = attempt.SetupFailure || failure.attempt.SetupFailure
+		attempt.TimedOut = attempt.TimedOut || failure.attempt.TimedOut
+		attempt.Unreaped = attempt.Unreaped || failure.attempt.Unreaped
+		attempt.ContainmentLost = attempt.ContainmentLost || failure.attempt.ContainmentLost
+	}
+	return attempt
 }
 
 func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProcessRetryCompletedAttempt, decideContinuation, continuationAdmitted bool) bool {
@@ -1078,10 +1115,16 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		g.tailEvent = nextTail
 	}
 	if g.raceSubtree != nil {
-		g.observeQuarantinedRaceSubtree(attempt.Result.Subtests)
-		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, []quarantinedRaceInvocation{{
-			cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
-		}}, false)
+		invocations := attempt.quarantinedRaceInvocations
+		if len(invocations) == 0 {
+			invocations = []quarantinedRaceInvocation{{
+				cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
+			}}
+		}
+		for _, invocation := range invocations {
+			g.observeQuarantinedRaceSubtree(invocation.attempt.Result.Subtests)
+		}
+		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, invocations, false)
 	}
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -107,6 +107,7 @@ type deferredProcessRetryGroup struct {
 	efdFaultySessionGuard earlyFlakeDetectionFaultySession
 	raceProcess           *quarantinedRaceProcessContext
 	raceSubtree           *processRetrySubtreeConfig
+	raceDescendantFailed  bool
 }
 
 type deferredProcessRetryEvent struct {
@@ -1077,6 +1078,7 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		g.tailEvent = nextTail
 	}
 	if g.raceSubtree != nil {
+		g.observeQuarantinedRaceSubtree(attempt.Result.Subtests)
 		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, []quarantinedRaceInvocation{{
 			cfg: g.quarantinedRaceSubtreeForAttempt(completed.prepared.index), attempt: attempt, attemptIndex: completed.prepared.index,
 		}}, false)
@@ -1098,6 +1100,17 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 		attempt.Cleanup()
 	}
 	return continueGroup
+}
+
+func (g *deferredProcessRetryGroup) observeQuarantinedRaceSubtree(results []processRetrySubtreeResult) {
+	if g == nil || g.raceDescendantFailed {
+		return
+	}
+	// Independently owned, non-quarantined Attempt-to-Fix descendants retain
+	// their normal package-failure semantics even when the deferred root passes.
+	g.raceDescendantFailed = slices.ContainsFunc(results, func(result processRetrySubtreeResult) bool {
+		return result.Failed && result.AttemptToFixOwn && !result.Quarantined && !result.Disabled
+	})
 }
 
 func (g *deferredProcessRetryGroup) quarantinedRaceSubtreeForAttempt(index int) *processRetrySubtreeConfig {
@@ -1184,6 +1197,9 @@ func (g *deferredProcessRetryGroup) packageFailed() bool {
 		return false
 	}
 	if g.terminalFailure {
+		return true
+	}
+	if g.raceDescendantFailed {
 		return true
 	}
 	if g.metadata.isAttemptToFix {

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -317,6 +317,7 @@ func TestDeferredProcessRetryAggregatePolicy(t *testing.T) {
 		{name: "ftr final fail", metadata: processRetryMetadataSnapshot{isFlakyTestRetriesEnabled: true}, observations: [][2]bool{{true, false}, {true, false}}, failed: true},
 		{name: "a2f any failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true, shouldOrchestrateAttemptToFix: true}, observations: [][2]bool{{true, false}, {false, false}}, failed: true},
 		{name: "a2f descendant failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true}, observations: [][2]bool{{false, false}}, descendants: []processRetrySubtreeResult{{Failed: true, AttemptToFixOwn: true}}, failed: true},
+		{name: "inherited a2f descendant failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true}, observations: [][2]bool{{false, false}}, descendants: []processRetrySubtreeResult{{Failed: true, AttemptToFix: true}}, failed: true},
 		{name: "quarantined a2f descendant masks failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true}, observations: [][2]bool{{false, false}}, descendants: []processRetrySubtreeResult{{Failed: true, AttemptToFixOwn: true, Quarantined: true}}},
 		{name: "quarantined masks failure", metadata: processRetryMetadataSnapshot{isQuarantined: true}, observations: [][2]bool{{true, false}}},
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -308,6 +308,7 @@ func TestDeferredProcessRetryAggregatePolicy(t *testing.T) {
 		name         string
 		metadata     processRetryMetadataSnapshot
 		observations [][2]bool
+		descendants  []processRetrySubtreeResult
 		failed       bool
 	}{
 		{name: "efd failure then pass", metadata: processRetryMetadataSnapshot{isEarlyFlakeDetectionEnabled: true, isANewTest: true}, observations: [][2]bool{{true, false}, {false, false}}},
@@ -315,6 +316,8 @@ func TestDeferredProcessRetryAggregatePolicy(t *testing.T) {
 		{name: "ftr final pass", metadata: processRetryMetadataSnapshot{isFlakyTestRetriesEnabled: true}, observations: [][2]bool{{true, false}, {false, false}}},
 		{name: "ftr final fail", metadata: processRetryMetadataSnapshot{isFlakyTestRetriesEnabled: true}, observations: [][2]bool{{true, false}, {true, false}}, failed: true},
 		{name: "a2f any failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true, shouldOrchestrateAttemptToFix: true}, observations: [][2]bool{{true, false}, {false, false}}, failed: true},
+		{name: "a2f descendant failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true}, observations: [][2]bool{{false, false}}, descendants: []processRetrySubtreeResult{{Failed: true, AttemptToFixOwn: true}}, failed: true},
+		{name: "quarantined a2f descendant masks failure", metadata: processRetryMetadataSnapshot{isAttemptToFix: true}, observations: [][2]bool{{false, false}}, descendants: []processRetrySubtreeResult{{Failed: true, AttemptToFixOwn: true, Quarantined: true}}},
 		{name: "quarantined masks failure", metadata: processRetryMetadataSnapshot{isQuarantined: true}, observations: [][2]bool{{true, false}}},
 	}
 	for _, test := range tests {
@@ -325,6 +328,7 @@ func TestDeferredProcessRetryAggregatePolicy(t *testing.T) {
 				group.latest.failed = observation[0]
 				group.latest.skipped = observation[1]
 			}
+			group.observeQuarantinedRaceSubtree(test.descendants)
 			require.Equal(t, test.failed, group.packageFailed())
 		})
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1219,6 +1219,9 @@ func TestProcessRetryResultErrorValidation(t *testing.T) {
 	}
 	base := processRetryNotRunResult(cfg, "invalid_child_config")
 	require.NoError(t, validateProcessRetryResult(base, cfg))
+	parallelControl := base
+	parallelControl.ResultError = "parallel_control_failed"
+	require.NoError(t, validateProcessRetryResult(parallelControl, cfg))
 
 	unknown := base
 	unknown.ResultError = "unknown_reason"

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -3063,6 +3063,7 @@ func TestRunProcessRetryAttemptStopsActiveChildOnShutdown(t *testing.T) {
 			false,
 			captureProcessRetryLaunchBaselineForTesting(),
 			shutdown,
+			nil,
 		)
 	}()
 	<-started
@@ -6166,8 +6167,14 @@ func TestProcessRetryControlAdmissionParallelAndTerminalCommit(t *testing.T) {
 	require.False(t, childExited)
 	require.NoError(t, waitErr)
 
+	var parallelBridges atomic.Int32
+	parent.parallelBridge = func() error {
+		parallelBridges.Add(1)
+		return nil
+	}
 	serveErrors := parent.serveParent()
 	require.NoError(t, child.childRootParallelBridge())
+	require.EqualValues(t, 1, parallelBridges.Load())
 	start := time.Now()
 	finish := start.Add(time.Millisecond)
 	require.NoError(t, writeProcessRetryResultAtomically(cfg.ResultPath, processRetryResult{

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1567,7 +1567,7 @@ func TestProcessRetryNoopTestContextAndSessionChain(t *testing.T) {
 		Attempt:     1,
 		RetryReason: constants.AutoTestRetriesRetryReason,
 	}
-	ciTest := newProcessRetryNoopTest(t, cfg, time.Now(), nil, nil, retryAttemptRaceErrors())
+	ciTest := newProcessRetryNoopTest(t, cfg, nil, time.Now(), nil, nil, retryAttemptRaceErrors())
 
 	require.Equal(t, context.Background(), ciTest.Context())
 	require.Equal(t, "TestSelected", ciTest.Name())

--- a/internal/civisibility/integrations/gotesting/retry_test_helpers_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_test_helpers_test.go
@@ -109,7 +109,7 @@ func runProcessRetryAttemptWithBaseline(
 	parentDeadlineOK bool,
 	baseline *processRetryLaunchBaseline,
 ) processRetryAttemptResult {
-	return runProcessRetryAttemptWithBaselineAndShutdown(ctx, cfg, parentDeadline, parentDeadlineOK, baseline, nil)
+	return runProcessRetryAttemptWithBaselineAndShutdown(ctx, cfg, parentDeadline, parentDeadlineOK, baseline, nil, nil)
 }
 
 func waitProcessRetryChild(

--- a/internal/civisibility/integrations/gotesting/subtests/main_test.go
+++ b/internal/civisibility/integrations/gotesting/subtests/main_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+	gotesting "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
 
@@ -29,6 +31,12 @@ const (
 
 // TestMain forces subtest-specific features on and orchestrates scenario subprocesses so this suite exercises the flag-enabled paths.
 func TestMain(m *testing.M) {
+	if reason, ok := integrations.LookupProcessRetryChildTransport(constants.CIVisibilityInternalRetryProcessReason); ok && reason == "quarantined_race" {
+		// A quarantined subtree child must reach RunM before this package's scenario
+		// harness initializes another mock session. Ordinary process retries retain
+		// the harness so their descendant spans keep the existing behavior.
+		os.Exit(gotesting.RunM(m))
+	}
 	prevDD, hadDD := os.LookupEnv(constants.CIVisibilitySubtestFeaturesEnabled)
 
 	if scenario := os.Getenv(subtestScenarioEnv); scenario != "" {

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -52,6 +52,7 @@ var processRetryUnitTestPrefixes = []string{
 	"TestWriteProcessRetry",
 	"TestFinalizeProcessRetry",
 	"TestCombineProcessRetry",
+	"TestQuarantinedRace",
 }
 
 const retryParityUnitTestPrefix = "TestProcessRetryParity"
@@ -107,6 +108,8 @@ func TestMain(m *testing.M) {
 	} else if internal.BoolEnv("TestIntelligentTestRunnerWithCoverageBackfill", false) {
 		fmt.Printf(scenarioStarted, "TestIntelligentTestRunnerWithCoverageBackfill")
 		runIntelligentTestRunnerWithCoverageBackfillTests(m)
+	} else if quarantinedRaceIsolationFixtureSelected() {
+		runQuarantinedRaceIsolationFixture(m)
 	} else if internal.BoolEnv(processRetryNativeLifecycleFixtureEnv, false) &&
 		os.Getenv(processRetryChildResultScenarioEnv) != processRetryOrdinaryDescendantHelperScenario {
 		os.Exit(runProcessRetryChild(m))
@@ -1621,6 +1624,7 @@ func setUpHTTPServer(
 				TestsSkipping:           itrEnabled,
 				KnownTestsEnabled:       enableKnownTests,
 				ImpactedTestsEnabled:    impactedTests,
+				CodeCoverage:            quarantinedRaceIsolationFixtureSelected(),
 			}
 
 			response.Data.Attributes.TestManagement.Enabled = testManagement

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -409,8 +409,8 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 
 		// Check for code coverage if enabled.
 		if testing.CoverMode() != "" {
-			cov, corrected, publishCoverage := finalizeITRCoverageBackfill()
 			isolatedCoverageMerged, err := coverage.FinalizeProcessCoverageProfiles()
+			cov, corrected, publishCoverage := 0.0, false, true
 			if err != nil {
 				// A child profile that cannot be merged makes the parent report
 				// incomplete. Treat it as infrastructure failure, never as a
@@ -418,6 +418,7 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 				log.Error("civisibility.cov: failed to merge isolated process coverage: %s", err.Error())
 				exitCode = processRetryFailureExitCode
 			} else {
+				cov, corrected, publishCoverage = finalizeITRCoverageBackfill()
 				uploadFinalCoverageReport(settings)
 			}
 			if err != nil || !publishCoverage {

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -353,6 +353,21 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 	if !coverageInitialized && testing.CoverMode() != "" {
 		coverage.InitializeCoverage(m, false)
 	}
+	if processModeEnabled && quarantinedRaceProcessSupported() &&
+		settings != nil && settings.TestManagement.Enabled && internal.BoolEnv(constants.CIVisibilityTestManagementEnabledEnvironmentVariable, true) {
+		// This context is deliberately narrower than the general retry backend:
+		// only explicitly opted-in quarantined tests in race binaries move their
+		// first execution out of process. The parent remains the sole owner of CI
+		// Visibility events and retries; children execute one selected subtree.
+		// Keep the context when process setup failed so an eligible test fails
+		// closed instead of silently running its body in the parent.
+		wrapperOpts.quarantinedRaceProcess = newQuarantinedRaceProcessContext(
+			wrapperOpts.processRetryLaunchTemplate,
+			wrapperOpts.mRunEpoch,
+			wrapperOpts.mRunInvocations,
+			settings.TestManagement.AttemptToFixRetries,
+		)
+	}
 
 	ddm := (*M)(m)
 
@@ -395,6 +410,14 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 		// Check for code coverage if enabled.
 		if testing.CoverMode() != "" {
 			cov, corrected, publishCoverage := finalizeITRCoverageBackfill()
+			isolatedCoverageMerged, err := coverage.FinalizeProcessCoverageProfiles()
+			if err != nil {
+				// A child profile that cannot be merged makes the parent report
+				// incomplete. Treat it as infrastructure failure, never as a
+				// quarantined test outcome.
+				log.Error("civisibility.cov: failed to merge isolated process coverage: %s", err.Error())
+				exitCode = processRetryFailureExitCode
+			}
 			uploadFinalCoverageReport(settings)
 			if !publishCoverage {
 				session.Close(exitCode)
@@ -405,7 +428,7 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 				}
 				return exitCode
 			}
-			if !corrected {
+			if isolatedCoverageMerged || !corrected {
 				// let's try first with our coverage package
 				cov = coverage.GetCoverage()
 			}
@@ -670,6 +693,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 			defer deleteTestMetadata(t)
 		}
 		execMeta.identity = testInfo.identity
+		execMeta.quarantinedRaceProcess = wrapperOpts.quarantinedRaceProcess
 
 		// Create or retrieve the module, suite, and test for CI visibility.
 		module := session.GetOrCreateModule(testInfo.moduleName)

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -417,9 +417,10 @@ func instrumentTestingMWithOptions(m *testing.M, wrapperOpts additionalFeatureWr
 				// quarantined test outcome.
 				log.Error("civisibility.cov: failed to merge isolated process coverage: %s", err.Error())
 				exitCode = processRetryFailureExitCode
+			} else {
+				uploadFinalCoverageReport(settings)
 			}
-			uploadFinalCoverageReport(settings)
-			if !publishCoverage {
+			if err != nil || !publishCoverage {
 				session.Close(exitCode)
 				coverage.CleanupRuntimeCoverageSnapshot()
 				integrations.ExitCiVisibility()

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -173,11 +173,7 @@ func (ddt *T) SkipNow() {
 // parallel with each other.
 func (ddt *T) Parallel() {
 	t := (*testing.T)(ddt)
-	handled, resume := instrumentTestingParallel(t)
-	if resume != nil {
-		defer resume()
-	}
-	if !handled {
+	if !instrumentTestingParallel(t) {
 		t.Parallel()
 	}
 }

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -173,7 +173,11 @@ func (ddt *T) SkipNow() {
 // parallel with each other.
 func (ddt *T) Parallel() {
 	t := (*testing.T)(ddt)
-	if !instrumentTestingParallel(t) {
+	handled, resume := instrumentTestingParallel(t)
+	if resume != nil {
+		defer resume()
+	}
+	if !handled {
 		t.Parallel()
 	}
 }

--- a/internal/civisibility/integrations/manual_api_sourcecache.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/impactedtests"
 )
 
 var (
@@ -92,6 +93,29 @@ type impactedTestClassifier interface {
 // classifies fn as modified without requiring a test event to be created first.
 func IsTestFuncModified(testName string, fn *runtime.Func) bool {
 	return isTestFuncModified(GetImpactedTestsAnalyzer(), testName, fn)
+}
+
+// IsTestFuncModifiedWithAnalyzer classifies a test with an explicitly owned
+// analyzer, allowing an isolated test process to avoid CI Visibility startup.
+func IsTestFuncModifiedWithAnalyzer(analyzer *impactedtests.ImpactedTestAnalyzer, testName string, fn *runtime.Func) bool {
+	if analyzer == nil {
+		return false
+	}
+	return isTestFuncModified(analyzer, testName, fn)
+}
+
+// TestFuncSourceMetadata returns the cached source metadata needed to recreate
+// an isolated test event without creating that event in the child process.
+func TestFuncSourceMetadata(fn *runtime.Func) (startLine, endLine int, unskippable bool) {
+	metadata := loadSourceFunctionMetadata(fn)
+	startLine = metadata.runtimeStartLine
+	if metadata.resolution.endLine >= metadata.resolution.startLine && metadata.resolution.startLine > 0 {
+		startLine = metadata.resolution.startLine
+		endLine = metadata.resolution.endLine
+	}
+	unskippable = metadata.fileMetadata.parseOK &&
+		(metadata.fileMetadata.suiteUnskippable || metadata.resolution.functionUnskippable)
+	return
 }
 
 func isTestFuncModified(analyzer impactedTestClassifier, testName string, fn *runtime.Func) bool {

--- a/internal/civisibility/integrations/manual_api_sourcecache_test.go
+++ b/internal/civisibility/integrations/manual_api_sourcecache_test.go
@@ -73,6 +73,26 @@ func TestIsTestFuncModifiedUsesResolvedSourceRange(t *testing.T) {
 	require.GreaterOrEqual(t, classifier.endLine, classifier.startLine)
 }
 
+func TestIsTestFuncModifiedWithAnalyzerRejectsMissingAnalyzer(t *testing.T) {
+	assert.False(t, IsTestFuncModifiedWithAnalyzer(nil, "TestSourceFixture", namedSourceFixtureRuntimeFunc()))
+}
+
+func TestTestFuncSourceMetadataDoesNotRequireTestEvent(t *testing.T) {
+	resetSourceCacheTestState(t)
+	start, end, unskippable := TestFuncSourceMetadata(runtime.FuncForPC(reflect.ValueOf(suiteUnskippableFixtureFunc).Pointer()))
+	assert.Positive(t, start)
+	assert.GreaterOrEqual(t, end, start)
+	assert.True(t, unskippable)
+	_, _, unskippable = TestFuncSourceMetadata(runtime.FuncForPC(reflect.ValueOf(declarationUnskippableFixtureFunc).Pointer()))
+	assert.True(t, unskippable)
+	_, _, unskippable = TestFuncSourceMetadata(namedSourceFixtureRuntimeFunc())
+	assert.False(t, unskippable)
+	start, end, unskippable = TestFuncSourceMetadata(nil)
+	assert.Zero(t, start)
+	assert.Zero(t, end)
+	assert.False(t, unskippable)
+}
+
 // resetSourceCacheTestState installs repository metadata so sourcecache tests also work with -trimpath.
 func resetSourceCacheTestState(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## What does this PR do?

This PR fixes quarantined tests under `go test -race` by running each independently selected quarantined test subtree in its own synchronous child process, while keeping CI Visibility reporting and retry ownership in the parent process.

The behavior is deliberately opt-in and only applies when all of the following are true:

- CI Visibility is enabled.
- Test Management is enabled and the selected test is effectively quarantined.
- The test binary was built with `-race`.
- `DD_CIVISIBILITY_RETRY_EXECUTION_MODE=process` is explicitly configured.

Normal tests, non-race executions, other retry modes, and non-quarantined tests retain their existing behavior.

## Why?

The Go race detector records failures at process scope. A quarantined test can therefore be reported as skipped by CI Visibility while its race failure still contaminates the parent test process and fails the package.

Running several quarantined tests in one replacement process would preserve the same ownership problem between those tests. This implementation instead gives every quarantined subtree, including subsequent Attempt to Fix attempts, a fresh process boundary.

Infrastructure and protocol failures fail closed: the selected test is not silently rerun in the parent, because that would discard the isolation guarantee.

## Subtest examples

Given this tree:

```text
TestCheckout
├── card
│   ├── visa
│   └── mastercard
└── paypal
```

### Quarantined subtree

If `card` is quarantined:

- The parent process continues to run `paypal`.
- One child process executes the complete `card` subtree.
- The child reports the observed subtree to the parent.
- The parent emits the CI Visibility events for `card`, `visa`, and `mastercard`.

### Exact quarantined leaf

If only `card/visa` is quarantined:

- The parent still executes the non-quarantined `card/mastercard` sibling.
- The child re-enters `TestCheckout/card` only as required to reach `visa`.
- The child does not execute `mastercard`.
- The parent emits one coherent set of CI Visibility events for the root, ancestor, quarantined leaf, and sibling.

The child is selected with the component-anchored equivalent of:

```text
-test.run=^TestCheckout$/^card$/^visa$
```

This preserves the ancestors required by Go’s testing package without accidentally matching sibling paths. The first `visa` result comes from that subtree execution; any remaining Attempt to Fix attempts run in fresh child processes.

## Reporting and coverage ownership

- The parent remains the sole owner of the CI Visibility session, module, suite, test events, aggregation, and retry policy.
- Replay marks the last observed event in each Attempt to Fix family as final, including inherited descendants keyed to their owning family's generation and dynamic descendants absent from later root invocations.
- Exact managed descendants keep their failed CI Visibility event without changing the enclosing `t.Run` result; failures added by the selected root or unmanaged siblings remain visible. Failure ownership is tracked per ancestor path, so concurrent managed siblings cannot leak transient native failure bits into each other. Direct child-process output is attached to each failed managed boundary so stdout, stderr, and race diagnostics are retained.
- With `-test.failfast`, any failure observed in the initial subtree—including a masked managed descendant—stops before any root or descendant continuation process is launched.
- Children do not start CI Visibility transport or recursively create more child processes.
- Status, timing, errors, panic and race output, skip reason, the resolved module and suite identity of each callback, source metadata, Codeowners, ITR metadata, and modified-test metadata are returned through a bounded and validated protocol.
- A nested selected root panic, cleanup panic, or bare `Goexit` remains a committed test outcome; its discovery-carrier exit is normalized instead of becoming an isolation failure.
- Unambiguous child coverage deltas are attributed to the reported tests and merged once into the parent’s aggregate `-coverprofile` during `M.Run` finalization, before ITR coverage backfill is applied.

Go coverage counters are process-global, while CI Visibility needs coverage attributed to individual tests. Nested collectors can overlap inclusively, but concurrently running sibling bodies cannot be attributed safely. The isolated subtree therefore preserves native `t.Parallel` concurrency and race detection; if sibling coverage intervals overlap, only their ambiguous per-test deltas are discarded. Aggregate coverage remains captured for the isolated workload. When a nested selected root calls `t.Parallel`, aggregate collection pauses while the root is suspended so discovery-ancestor work is not merged into the isolated profile.

Queued parallel descendants complete before the selected root is snapshotted, so the reported subtree includes their failures, individual timing, and coverage. The selected root duration follows native testing semantics: it excludes the wait at the parallel-descendant barrier but retains cleanup time. A suspended isolated root also releases its process-concurrency slot and reacquires it before the child resumes, so parallel quarantined siblings cannot deadlock when process concurrency is one. Serial descendant-owned Attempt to Fix continuations re-enter the exact owner without repeating enclosing sibling side effects. Parallel owners re-enter their enclosing selected root only when needed to recreate native scheduling siblings; recording and reporting remain bounded to the managed descendant subtree. This is only the lifecycle handoff required for a coherent subtree result; it does not provide general scheduler parity.

Parallel behavior outside this narrow opt-in path remains unchanged.

## Intentional non-goals

This is not a general remote implementation of Go’s `testing` package. It does not attempt to provide:

- Exact `test2json` or stdout ordering.
- General scheduler parity.
- Environment mutation or `T.Attr` replay.
- Batching several quarantined roots into one child.
- Process isolation for non-quarantined tests.
- Broader behavior changes outside race-enabled, process-mode quarantine execution.

## Relationship to the previous draft

This is a deliberately smaller replacement for the broader experiment in [#5154](https://github.com/DataDog/dd-trace-go/pull/5154).

It retains the useful process-control seam from that work, while narrowing the product contract to the behavior we need: independent process isolation for quarantined race-test subtrees with parent-owned CI Visibility reporting.

## Validation

- `go test ./internal/civisibility/integrations/gotesting/... -count=1`
- `go test -race ./internal/civisibility/integrations/gotesting/... -count=1`
- Focused race end-to-end testing with and without `-coverprofile`
- Exact quarantined-leaf regression covering ancestor and sibling execution
- Managed-descendant masking regressions, including concurrent exact managed siblings, a concurrently failing unmanaged sibling, a selected-root failure during suspension, and direct process output
- Descendant-owned Attempt to Fix regressions covering a required parallel scheduling sibling and a serial owner that must not repeat siblings
- Nested selected-root body panic, cleanup panic, and bare `Goexit` regressions
- Retry-family finality regression across repeated owner generations
- Cross-file descendant callback regression preserving its own CI Visibility suite
- Failfast regressions for root-owned and descendant-owned Attempt to Fix families, including a masked managed child
- Isolated coverage merge-before-backfill regression
- Parallel-descendant finalization and descendant-body-panic regressions
- Orchestrion integration coverage for the `t.Parallel` hook contract
- Focused process-control, quarantine, Test Management, and coverage tests
- `go vet ./internal/civisibility/integrations/gotesting/...`
- `go vet ./internal/civisibility/integrations`
- `make lint/go`
- Linux and Windows cross-compilation of the modified Go testing integration

The end-to-end coverage includes passing, failing, panic, race, skip, nested subtree, exact descendant, Attempt to Fix, distinct child PIDs, parent-only CI Visibility lifecycle events, source metadata, `t.Parallel`, and child coverage merged into the parent profile.





