### PR TITLE
fix(llmobs): decode dataset records from the v2 attributes envelope

### DIFF
--- a/internal/llmobs/transport/dne.go
+++ b/internal/llmobs/transport/dne.go
@@ -213,21 +213,6 @@ type (
 	CreateExperimentResponse = Response[ExperimentView]
 )
 
-// DatasetRecordItemV2 is the wire format for a single item in the v2 dataset-records list response.
-// The v2 endpoint returns a flat object (id, input, expected_output, metadata at the top level),
-// unlike the unstable endpoint which wraps fields under "attributes".
-type DatasetRecordItemV2 struct {
-	ID             string `json:"id"`
-	Input          any    `json:"input"`
-	ExpectedOutput any    `json:"expected_output"`
-	Metadata       any    `json:"metadata"`
-}
-
-type GetDatasetRecordsResponseV2 struct {
-	Data []DatasetRecordItemV2 `json:"data"`
-	Meta ResponseMeta          `json:"meta"`
-}
-
 func (c *Transport) GetDatasetByName(ctx context.Context, name, projectID string) (*DatasetView, error) {
 	q := url.Values{}
 	q.Set("filter[name]", name)
@@ -395,19 +380,19 @@ func (c *Transport) GetDatasetRecordsPage(ctx context.Context, projectID, datase
 		return nil, "", fmt.Errorf("unexpected status %d: %s", result.statusCode, string(result.body))
 	}
 
-	var recordsResp GetDatasetRecordsResponseV2
+	// The v2 records endpoint speaks JSON:API like the rest of these endpoints:
+	// each item carries id at the top level and the record fields under
+	// "attributes".
+	var recordsResp GetDatasetRecordsResponse
 	if err := json.Unmarshal(result.body, &recordsResp); err != nil {
 		return nil, "", fmt.Errorf("failed to decode json response: %w", err)
 	}
 
 	records := make([]DatasetRecordView, 0, len(recordsResp.Data))
 	for _, r := range recordsResp.Data {
-		records = append(records, DatasetRecordView{
-			ID:             r.ID,
-			Input:          r.Input,
-			ExpectedOutput: r.ExpectedOutput,
-			Metadata:       r.Metadata,
-		})
+		rec := r.Attributes
+		rec.ID = r.ID
+		records = append(records, rec)
 	}
 
 	return records, recordsResp.Meta.After, nil

--- a/llmobs/dataset/dataset_test.go
+++ b/llmobs/dataset/dataset_test.go
@@ -628,8 +628,11 @@ func TestDatasetPull(t *testing.T) {
 				"data": [
 					{
 						"id": "record-1",
-						"input": "This is a simple string input, not a map",
-						"expected_output": "Some output"
+						"type": "datasets",
+						"attributes": {
+							"input": "This is a simple string input, not a map",
+							"expected_output": "Some output"
+						}
 					}
 				],
 				"meta": {}
@@ -711,9 +714,12 @@ func TestDatasetPull(t *testing.T) {
 				"data": [
 					{
 						"id": "record-1",
-						"input": {"question": "What is AI?"},
-						"expected_output": "Artificial Intelligence",
-						"metadata": "simple string metadata from UI"
+						"type": "datasets",
+						"attributes": {
+							"input": {"question": "What is AI?"},
+							"expected_output": "Artificial Intelligence",
+							"metadata": "simple string metadata from UI"
+						}
 					}
 				],
 				"meta": {}
@@ -808,15 +814,13 @@ func TestDatasetPull(t *testing.T) {
 					"data": [
 						{
 							"id": "record-1",
-							"input": {"question": "Q1"},
-							"expected_output": "A1",
-							"metadata": {}
+							"type": "datasets",
+							"attributes": {"input": {"question": "Q1"}, "expected_output": "A1", "metadata": {}}
 						},
 						{
 							"id": "record-2",
-							"input": {"question": "Q2"},
-							"expected_output": "A2",
-							"metadata": {}
+							"type": "datasets",
+							"attributes": {"input": {"question": "Q2"}, "expected_output": "A2", "metadata": {}}
 						}
 					],
 					"meta": {
@@ -829,9 +833,8 @@ func TestDatasetPull(t *testing.T) {
 					"data": [
 						{
 							"id": "record-3",
-							"input": {"question": "Q3"},
-							"expected_output": "A3",
-							"metadata": {}
+							"type": "datasets",
+							"attributes": {"input": {"question": "Q3"}, "expected_output": "A3", "metadata": {}}
 						}
 					],
 					"meta": {
@@ -844,9 +847,8 @@ func TestDatasetPull(t *testing.T) {
 					"data": [
 						{
 							"id": "record-4",
-							"input": {"question": "Q4"},
-							"expected_output": "A4",
-							"metadata": {}
+							"type": "datasets",
+							"attributes": {"input": {"question": "Q4"}, "expected_output": "A4", "metadata": {}}
 						}
 					],
 					"meta": {}
@@ -932,7 +934,11 @@ func TestDatasetPull(t *testing.T) {
 			capturedHeaders = r.Header.Clone()
 			rawJSON := `{
 				"data": [
-					{"id":"record-1","input":{"q":"v2 record"},"expected_output":"ans"}
+					{
+						"id": "record-1",
+						"type": "datasets",
+						"attributes": {"input": {"q": "v2 record"}, "expected_output": "ans"}
+					}
 				],
 				"meta": {}
 			}`
@@ -1276,32 +1282,42 @@ func registerMockHandlers(coll *llmobstest.Collector) {
 	coll.HandleFunc("/api/v2/llm-obs/v1/", handleMockDatasetRecordsV2)
 }
 
-// handleMockDatasetRecordsV2 serves the v2 dataset-records endpoint. The v2 wire
-// format is a flat record object (id, input, expected_output, metadata) with no
-// "attributes" wrapper and no per-record version field.
+// handleMockDatasetRecordsV2 serves the v2 dataset-records endpoint. Its wire
+// format is JSON:API: id at the top level of each item, record fields under
+// "attributes", and no per-record version field.
+//
+// The body is a literal rather than something marshalled from the transport's
+// own types. A fixture built from the types under test keeps passing when those
+// types stop matching the API, which is what hid this bug.
 func handleMockDatasetRecordsV2(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/records") {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	recordsResponse := llmobstransport.GetDatasetRecordsResponseV2{
-		Data: []llmobstransport.DatasetRecordItemV2{
+	const rawJSON = `{
+		"data": [
 			{
-				ID:             "record-1",
-				Input:          map[string]any{"question": "What is AI?"},
-				ExpectedOutput: "Artificial Intelligence",
+				"id": "record-1",
+				"type": "datasets",
+				"attributes": {
+					"input": {"question": "What is AI?"},
+					"expected_output": "Artificial Intelligence"
+				}
 			},
 			{
-				ID:             "record-2",
-				Input:          map[string]any{"question": "What is ML?"},
-				ExpectedOutput: "Machine Learning",
-			},
-		},
-	}
-	respData, _ := json.Marshal(recordsResponse)
+				"id": "record-2",
+				"type": "datasets",
+				"attributes": {
+					"input": {"question": "What is ML?"},
+					"expected_output": "Machine Learning"
+				}
+			}
+		],
+		"meta": {}
+	}`
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(respData)
+	w.Write([]byte(rawJSON))
 }
 
 // createMockHandler creates a mock handler for dataset-related requests


### PR DESCRIPTION
### What does this PR do?

Fixes `dataset.Pull` returning records with empty `Input`, `ExpectedOutput` and `Metadata`. Only the record IDs came back, so a pulled dataset could not be used to run an experiment.

### Motivation

Regression introduced in #4814, which moved the records fetch to the stable v2 path to pick up `filter[version]` support and added a response type on the assumption that endpoint returns a flat object. It doesn't. Like the other endpoints in this file it uses the JSON:API envelope: `id` at the top level, the record fields nested under `attributes`. Only `id` decoded, and everything else was silently dropped.

The Python tracer's client for the same endpoint reads them the same way the fix now does, taking `id` from the top level and `input` / `expected_output` / `metadata` from `attributes` (`ddtrace/llmobs/_writer.py`), and its recorded response fixtures show that wire format.

This also means `WithPullVersion`, the feature #4814 shipped, has never returned usable records. Verified against a live dataset with three versions: pinned pulls now return every record with all fields populated, and report the pinned version rather than the current one.

The test covering this built its fake response by marshalling the transport's own types, so it agreed with the code instead of with the API and stayed green regardless of what the endpoint returned. It now asserts against a literal response body.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
