### PR TITLE
fix(appsec): acknowledge streamed ext_proc response bodies

### DIFF
--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -576,6 +576,8 @@ func TestAppSecBodyParsingEnabled(t *testing.T) {
 		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, res.GetResponse())
 		require.Equal(t, uint32(0), res.GetImmediateResponse().GetGrpcStatus().Status)
 		require.Equal(t, envoytypes.StatusCode(418), res.GetImmediateResponse().GetStatus().Code) // 418 because of the rule file
+		var blockBody map[string]any
+		require.NoError(t, json.Unmarshal(res.GetImmediateResponse().GetBody(), &blockBody))
 		require.Len(t, res.GetImmediateResponse().GetHeaders().SetHeaders, 2)
 		requireSetHeader(t, res.GetImmediateResponse().GetHeaders().SetHeaders, "Content-Type", "application/json")
 		require.NoError(t, err)
@@ -628,6 +630,8 @@ func TestAppSecBodyParsingEnabled(t *testing.T) {
 		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, res.GetResponse())
 		require.Equal(t, uint32(0), res.GetImmediateResponse().GetGrpcStatus().Status)
 		require.Equal(t, envoytypes.StatusCode(418), res.GetImmediateResponse().GetStatus().Code) // 418 because of the rule file
+		var blockBody map[string]any
+		require.NoError(t, json.Unmarshal(res.GetImmediateResponse().GetBody(), &blockBody))
 		require.Len(t, res.GetImmediateResponse().GetHeaders().SetHeaders, 2)
 		requireSetHeader(t, res.GetImmediateResponse().GetHeaders().SetHeaders, "Content-Type", "application/json")
 		require.NoError(t, err)
@@ -675,6 +679,14 @@ func TestAppSecBodyParsingEnabled(t *testing.T) {
 		require.NoError(t, err)
 		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, response.GetResponse())
 		require.Equal(t, envoytypes.StatusCode(418), response.GetImmediateResponse().GetStatus().Code)
+		var blockBody map[string]any
+		require.NoError(t, json.Unmarshal(response.GetImmediateResponse().GetBody(), &blockBody))
+		require.NoError(t, stream.CloseSend())
+		_, _ = stream.Recv()
+		finished := mt.FinishedSpans()
+		require.Len(t, finished, 1)
+		checkForAppsecEvent(t, finished, map[string]int{"headers-003": 1})
+		require.Equal(t, "true", finished[0].Tag("appsec.blocked"))
 	})
 
 	t.Run("no-monitoring-event-on-request-body-bad-content-type", func(t *testing.T) {
@@ -1141,6 +1153,7 @@ func TestResponseBodyEndOfStreamIsAcknowledged(t *testing.T) {
 	response, err = stream.Recv()
 	require.Nil(t, response)
 	require.ErrorIs(t, err, io.EOF)
+	require.Len(t, mt.FinishedSpans(), 1)
 }
 
 func TestResponseBodyTruncationIsAcknowledgedUntilEndOfStream(t *testing.T) {
@@ -1166,6 +1179,7 @@ func TestResponseBodyTruncationIsAcknowledgedUntilEndOfStream(t *testing.T) {
 	require.NoError(t, err)
 
 	assertContinue := func(body []byte, endOfStream bool) {
+		t.Helper()
 		require.NoError(t, stream.Send(&envoyextproc.ProcessingRequest{
 			Request: &envoyextproc.ProcessingRequest_ResponseBody{
 				ResponseBody: &envoyextproc.HttpBody{Body: body, EndOfStream: endOfStream},
@@ -1185,6 +1199,7 @@ func TestResponseBodyTruncationIsAcknowledgedUntilEndOfStream(t *testing.T) {
 	response, err := stream.Recv()
 	require.Nil(t, response)
 	require.ErrorIs(t, err, io.EOF)
+	require.Len(t, mt.FinishedSpans(), 1)
 }
 
 func TestGeneratedSpan(t *testing.T) {

--- a/contrib/envoyproxy/go-control-plane/envoy_test.go
+++ b/contrib/envoyproxy/go-control-plane/envoy_test.go
@@ -647,6 +647,36 @@ func TestAppSecBodyParsingEnabled(t *testing.T) {
 		require.Equal(t, "true", span.Tag("appsec.blocked"))
 	})
 
+	t.Run("blocking-event-on-response-headers-with-truncated-body", func(t *testing.T) {
+		bodySize := 2
+		rig, err := newEnvoyAppsecRig(t, EnvoyIntegration, false, &bodySize)
+		require.NoError(t, err)
+		defer rig.Close()
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		stream, err := rig.client.Process(context.Background())
+		require.NoError(t, err)
+		sendProcessingRequestHeaders(t, stream, map[string]string{"User-Agent": "Chrome"}, "OPTION", "/", false)
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		sendProcessingResponseHeaders(t, stream, map[string]string{"test": "match-response-header", "Content-Type": "application/json"}, "200", true)
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		require.NoError(t, stream.Send(&envoyextproc.ProcessingRequest{
+			Request: &envoyextproc.ProcessingRequest_ResponseBody{
+				ResponseBody: &envoyextproc.HttpBody{Body: []byte("body")},
+			},
+		}))
+
+		response, err := stream.Recv()
+		require.NoError(t, err)
+		require.IsType(t, &envoyextproc.ProcessingResponse_ImmediateResponse{}, response.GetResponse())
+		require.Equal(t, envoytypes.StatusCode(418), response.GetImmediateResponse().GetStatus().Code)
+	})
+
 	t.Run("no-monitoring-event-on-request-body-bad-content-type", func(t *testing.T) {
 		client, mt, cleanup := setup()
 		defer cleanup()
@@ -1070,6 +1100,91 @@ func TestAppSecBodyParsingActivation(t *testing.T) {
 		require.NotContains(t, span.Tags(), "appsec.event")
 		require.NotContains(t, span.Tags(), "_dd.appsec.json")
 	})
+}
+
+func TestResponseBodyEndOfStreamIsAcknowledged(t *testing.T) {
+	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/user_rules.json")
+	t.Setenv("DD_APPSEC_WAF_TIMEOUT", "10ms")
+	testutils.StartAppSec(t)
+
+	// Given
+	bodySize := 256
+	rig, err := newEnvoyAppsecRig(t, GCPServiceExtensionIntegration, false, &bodySize)
+	require.NoError(t, err)
+	defer rig.Close()
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	stream, err := rig.client.Process(context.Background())
+	require.NoError(t, err)
+	sendProcessingRequestHeaders(t, stream, nil, "GET", "/", false)
+	_, err = stream.Recv()
+	require.NoError(t, err)
+	sendProcessingResponseHeaders(t, stream, map[string]string{"Content-Type": "application/json"}, "200", true)
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	// When
+	err = stream.Send(&envoyextproc.ProcessingRequest{
+		Request: &envoyextproc.ProcessingRequest_ResponseBody{
+			ResponseBody: &envoyextproc.HttpBody{Body: []byte("{}"), EndOfStream: true},
+		},
+	})
+	require.NoError(t, err)
+
+	// Then
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	require.IsType(t, &envoyextproc.ProcessingResponse_ResponseBody{}, response.GetResponse())
+	require.Equal(t, envoyextproc.CommonResponse_CONTINUE, response.GetResponseBody().GetResponse().GetStatus())
+
+	response, err = stream.Recv()
+	require.Nil(t, response)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestResponseBodyTruncationIsAcknowledgedUntilEndOfStream(t *testing.T) {
+	t.Setenv("DD_APPSEC_RULES", "../../../internal/appsec/testdata/user_rules.json")
+	t.Setenv("DD_APPSEC_WAF_TIMEOUT", "10ms")
+	testutils.StartAppSec(t)
+
+	// Given
+	bodySize := 2
+	rig, err := newEnvoyAppsecRig(t, GCPServiceExtensionIntegration, false, &bodySize)
+	require.NoError(t, err)
+	defer rig.Close()
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	stream, err := rig.client.Process(context.Background())
+	require.NoError(t, err)
+	sendProcessingRequestHeaders(t, stream, nil, "GET", "/", false)
+	_, err = stream.Recv()
+	require.NoError(t, err)
+	sendProcessingResponseHeaders(t, stream, map[string]string{"Content-Type": "application/json"}, "200", true)
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	assertContinue := func(body []byte, endOfStream bool) {
+		require.NoError(t, stream.Send(&envoyextproc.ProcessingRequest{
+			Request: &envoyextproc.ProcessingRequest_ResponseBody{
+				ResponseBody: &envoyextproc.HttpBody{Body: body, EndOfStream: endOfStream},
+			},
+		}))
+		response, recvErr := stream.Recv()
+		require.NoError(t, recvErr)
+		require.IsType(t, &envoyextproc.ProcessingResponse_ResponseBody{}, response.GetResponse())
+		require.Equal(t, envoyextproc.CommonResponse_CONTINUE, response.GetResponseBody().GetResponse().GetStatus())
+	}
+
+	// When / Then
+	assertContinue([]byte("too large"), false)
+	assertContinue([]byte("ignored"), false)
+	assertContinue(nil, true)
+
+	response, err := stream.Recv()
+	require.Nil(t, response)
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestGeneratedSpan(t *testing.T) {
@@ -1612,9 +1727,12 @@ func end2EndStreamRequest(t *testing.T, stream envoyextproc.ExternalProcessor_Pr
 	// 2- Send the response body
 	msgResponseBodySent := sendProcessingResponseBodyStreamed(t, stream, []byte(responseBody), 1)
 
-	// minus 1 because the last message is the end of stream, and the connection will be closed after that
-	// because no appsec event will be found
-	for i := 0; i < msgResponseBodySent-1; i++ {
+	responsesToRead := msgResponseBodySent
+	if blockOnResponseBody {
+		// Leave the blocking response for the caller to assert.
+		responsesToRead--
+	}
+	for i := 0; i < responsesToRead; i++ {
 		res, err = stream.Recv()
 		require.NoError(t, err)
 		require.Equal(t, envoyextproc.CommonResponse_CONTINUE, res.GetResponseBody().GetResponse().GetStatus())

--- a/instrumentation/appsec/proxy/message_processor.go
+++ b/instrumentation/appsec/proxy/message_processor.go
@@ -172,6 +172,9 @@ func (mp *Processor) OnRequestBody(req HTTPBody, reqState *RequestState) error {
 	}
 
 	blocked := processBody(reqState.Context, reqState.requestBuffer, req.GetBody(), req.GetEndOfStream(), appsec.MonitorParsedHTTPBody, "request")
+	if reqState.requestBuffer.analyzed {
+		reqState.requestBuffer.buffer = nil
+	}
 	if blocked != nil && !mp.BlockingUnavailable {
 		mp.instr.Logger().Debug("external_processing: request blocked, end the stream")
 		actionOpts := reqState.BlockAction()
@@ -259,15 +262,27 @@ func (mp *Processor) OnResponseBody(resp HTTPBody, reqState *RequestState) error
 
 	blocked := processBody(reqState.Context, reqState.responseBuffer, resp.GetBody(), resp.GetEndOfStream(), appsec.MonitorHTTPResponseBody, "response")
 	if reqState.responseBuffer.analyzed {
-		reqState.Close() // Call Close to ensure the response headers are analyzed
+		reqState.responseBuffer.buffer = nil
+		reqState.finalizeResponse()
 
 		if (reqState.State == MessageTypeBlocked || blocked != nil) && !mp.BlockingUnavailable {
 			mp.instr.Logger().Debug("external_processing: request blocked, end the stream")
 			if err := mp.BlockMessageFunc(reqState.Context, reqState.BlockAction()); err != nil {
 				return fmt.Errorf("error creating block message: %w", err)
 			}
+			return io.EOF
 		}
-		return io.EOF
+		if resp.GetEndOfStream() {
+			reqState.Close()
+		}
+
+		if err := mp.ContinueMessageFunc(reqState.Context, ContinueActionOptions{MessageType: MessageTypeResponseBody}); err != nil {
+			return err
+		}
+		if resp.GetEndOfStream() {
+			return io.EOF
+		}
+		return nil
 	}
 
 	return mp.ContinueMessageFunc(reqState.Context, ContinueActionOptions{MessageType: MessageTypeResponseBody})

--- a/instrumentation/appsec/proxy/message_processor.go
+++ b/instrumentation/appsec/proxy/message_processor.go
@@ -173,11 +173,12 @@ func (mp *Processor) OnRequestBody(req HTTPBody, reqState *RequestState) error {
 
 	blocked := processBody(reqState.Context, reqState.requestBuffer, req.GetBody(), req.GetEndOfStream(), appsec.MonitorParsedHTTPBody, "request")
 	if reqState.requestBuffer.analyzed {
+		// The WAF analysis is synchronous, so the retained prefix is no longer needed.
 		reqState.requestBuffer.buffer = nil
 	}
 	if blocked != nil && !mp.BlockingUnavailable {
 		mp.instr.Logger().Debug("external_processing: request blocked, end the stream")
-		actionOpts := reqState.BlockAction()
+		actionOpts := reqState.blockActionLocked()
 		if err := mp.BlockMessageFunc(reqState.Context, actionOpts); err != nil {
 			return fmt.Errorf("error creating block message: %w", err)
 		}
@@ -223,15 +224,16 @@ func (mp *Processor) OnResponseHeaders(res ResponseHeaders, reqState *RequestSta
 
 	// Run the waf on the response headers only when we are sure to not receive a response body
 	if res.GetEndOfStream() || !mp.isBodySupported(reqState.wrappedResponseWriter.Header().Get("Content-Type")) {
-		reqState.Close()
+		_ = reqState.closeLocked()
 		if !mp.BlockingUnavailable && reqState.State == MessageTypeBlocked {
-			if err := mp.BlockMessageFunc(reqState.Context, reqState.BlockAction()); err != nil {
+			if err := mp.BlockMessageFunc(reqState.Context, reqState.blockActionLocked()); err != nil {
 				return fmt.Errorf("error creating block message: %w", err)
 			}
 			return io.EOF
 		}
 
 		mp.instr.Logger().Debug("message_processor: finishing request with status code: %v\n", reqState.fakeResponseWriter.status)
+		// No body message is in flight, so the ext_proc stream can close after response headers.
 		return io.EOF
 	}
 
@@ -257,27 +259,38 @@ func (mp *Processor) OnResponseBody(resp HTTPBody, reqState *RequestState) error
 	if mp.computedBodyParsingSizeLimit.Load() <= 0 || reqState.State != MessageTypeResponseBody {
 		mp.instr.Logger().Error("message_processor: the body parsing has been wrongly configured. " +
 			"Please refer to the official documentation for guidance on the proper settings or contact support.")
+		reqState.finalizeResponse()
+		if resp.GetEndOfStream() {
+			_ = reqState.closeLocked()
+		}
+		if err := mp.ContinueMessageFunc(reqState.Context, ContinueActionOptions{MessageType: MessageTypeResponseBody}); err != nil {
+			return fmt.Errorf("error creating continue response for response body: %w", err)
+		}
+		if !resp.GetEndOfStream() {
+			return nil
+		}
 		return io.EOF
 	}
 
 	blocked := processBody(reqState.Context, reqState.responseBuffer, resp.GetBody(), resp.GetEndOfStream(), appsec.MonitorHTTPResponseBody, "response")
 	if reqState.responseBuffer.analyzed {
+		// The WAF analysis is synchronous, so the retained prefix is no longer needed.
 		reqState.responseBuffer.buffer = nil
 		reqState.finalizeResponse()
 
 		if (reqState.State == MessageTypeBlocked || blocked != nil) && !mp.BlockingUnavailable {
 			mp.instr.Logger().Debug("external_processing: request blocked, end the stream")
-			if err := mp.BlockMessageFunc(reqState.Context, reqState.BlockAction()); err != nil {
+			if err := mp.BlockMessageFunc(reqState.Context, reqState.blockActionLocked()); err != nil {
 				return fmt.Errorf("error creating block message: %w", err)
 			}
 			return io.EOF
 		}
 		if resp.GetEndOfStream() {
-			reqState.Close()
+			_ = reqState.closeLocked()
 		}
 
 		if err := mp.ContinueMessageFunc(reqState.Context, ContinueActionOptions{MessageType: MessageTypeResponseBody}); err != nil {
-			return err
+			return fmt.Errorf("error creating continue response for response body: %w", err)
 		}
 		if resp.GetEndOfStream() {
 			return io.EOF

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -10,7 +10,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -189,4 +192,58 @@ func TestOnBody_SubmitsBodySize_ByDirection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequestStateCloseConcurrentWithLockedFinalize(t *testing.T) {
+	var afterHandleCalls atomic.Int64
+	insideAfterHandle := make(chan struct{})
+	rs := &RequestState{
+		Mu:    new(sync.Mutex),
+		State: MessageTypeResponseBody,
+		afterHandle: func() {
+			if afterHandleCalls.Add(1) == 1 {
+				close(insideAfterHandle)
+				time.Sleep(200 * time.Millisecond)
+			}
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		rs.Mu.Lock()
+		defer rs.Mu.Unlock()
+		rs.finalizeResponse()
+	}()
+	go func() {
+		defer wg.Done()
+		<-insideAfterHandle
+		_ = rs.Close()
+	}()
+	wg.Wait()
+
+	require.EqualValues(t, 1, afterHandleCalls.Load())
+}
+
+func TestOnResponseBodyMisconfigurationAcknowledgesMessage(t *testing.T) {
+	continueCalls := 0
+	mp := NewProcessor(ProcessorConfig{
+		ContinueMessageFunc: func(context.Context, ContinueActionOptions) error {
+			continueCalls++
+			return nil
+		},
+	}, instrumentation.Load(instrumentation.PackageEnvoyProxyGoControlPlane))
+	defer mp.Close()
+
+	state := RequestState{
+		Mu:          new(sync.Mutex),
+		Context:     context.Background(),
+		afterHandle: func() {},
+		State:       MessageTypeResponseBody,
+	}
+	err := mp.OnResponseBody(fakeBody{eos: true}, &state)
+
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 1, continueCalls)
 }

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -157,6 +157,7 @@ func TestOnBody_SubmitsBodySize_ByDirection(t *testing.T) {
 					if direction == "request" {
 						err = mp.OnRequestBody(fakeBody{b: tt.body, eos: tt.eos}, &reqState)
 						require.NoError(t, err)
+						require.Empty(t, reqState.requestBuffer.buffer)
 					}
 
 					err = mp.OnResponseHeaders(fakeResponseHeaders{eos: direction != "response", headers: map[string][]string{"Content-Type": {"application/json"}}}, &reqState)
@@ -164,6 +165,11 @@ func TestOnBody_SubmitsBodySize_ByDirection(t *testing.T) {
 					if direction == "response" {
 						require.NoError(t, err)
 						err = mp.OnResponseBody(fakeBody{b: tt.body, eos: tt.eos}, &reqState)
+						if !tt.eos {
+							require.NoError(t, err)
+							require.Empty(t, reqState.responseBuffer.buffer)
+							err = mp.OnResponseBody(fakeBody{eos: true}, &reqState)
+						}
 					}
 					require.ErrorIs(t, err, io.EOF)
 

--- a/instrumentation/appsec/proxy/request_state.go
+++ b/instrumentation/appsec/proxy/request_state.go
@@ -38,7 +38,8 @@ type RequestState struct {
 	responseBuffer *bodyBuffer
 
 	// Processing state
-	State MessageType
+	State             MessageType
+	responseFinalized bool
 }
 
 // newRequestState creates a new request state. clientIP carries an identity the
@@ -135,13 +136,21 @@ func (rs *RequestState) Close() error {
 		defer rs.Mu.Unlock()
 	}
 
-	rs.afterHandle()
+	rs.finalizeResponse()
 
 	if rs.State.Ongoing() {
 		rs.State = MessageTypeFinished
 	}
 
 	return nil
+}
+
+func (rs *RequestState) finalizeResponse() {
+	if rs.responseFinalized {
+		return
+	}
+	rs.afterHandle()
+	rs.responseFinalized = true
 }
 
 func (rs *RequestState) Span() (*tracer.Span, bool) {

--- a/instrumentation/appsec/proxy/request_state.go
+++ b/instrumentation/appsec/proxy/request_state.go
@@ -38,7 +38,8 @@ type RequestState struct {
 	responseBuffer *bodyBuffer
 
 	// Processing state
-	State             MessageType
+	State MessageType
+	// responseFinalized guards the once-only response analysis and span finalization.
 	responseFinalized bool
 }
 
@@ -93,7 +94,13 @@ func (rs *RequestState) PropagationHeaders() (http.Header, error) {
 
 // BlockAction marks the request as blocked and completes it.
 func (rs *RequestState) BlockAction() BlockActionOptions {
-	rs.Close()
+	rs.Mu.Lock()
+	defer rs.Mu.Unlock()
+	return rs.blockActionLocked()
+}
+
+func (rs *RequestState) blockActionLocked() BlockActionOptions {
+	_ = rs.closeLocked()
 	if rs.fakeResponseWriter.status == 0 {
 		panic("cannot block request without a status code")
 	}
@@ -131,11 +138,12 @@ func (rs *RequestState) CloseBeforeResponse() {
 
 // Close finalizes the request processing.
 func (rs *RequestState) Close() error {
-	// Allows us to be called multiple times without deadlocking
-	if rs.Mu.TryLock() {
-		defer rs.Mu.Unlock()
-	}
+	rs.Mu.Lock()
+	defer rs.Mu.Unlock()
+	return rs.closeLocked()
+}
 
+func (rs *RequestState) closeLocked() error {
 	rs.finalizeResponse()
 
 	if rs.State.Ongoing() {
@@ -145,6 +153,7 @@ func (rs *RequestState) Close() error {
 	return nil
 }
 
+// finalizeResponse runs deferred response analysis exactly once. The caller must hold rs.Mu.
 func (rs *RequestState) finalizeResponse() {
 	if rs.responseFinalized {
 		return


### PR DESCRIPTION
### What does this PR do?

- Sends a response-body `CONTINUE` acknowledgement before closing the ext_proc stream at end-of-stream.
- Keeps truncated response streams open long enough to acknowledge every subsequent body message.
- Finalizes deferred response-header analysis once, preserves immediate blocking, and releases analyzed request/response buffers.
- Adds wire-level regression coverage for terminal EOS, truncation draining, and blocking at the truncation boundary.

### Motivation

Envoy STREAMED ext_proc mode requires exactly one `ProcessingResponse` for every `ProcessingRequest`. Closing the stream immediately after response-body analysis dropped the terminal acknowledgement and could trigger ext_proc timeout/fail-open behavior.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag. Not applicable: the protocol behavior is covered by the in-process Envoy gRPC stream tests.
- [ ] There is a benchmark for any new code, or changes to existing code. Not applicable: no performance-sensitive algorithm was introduced.
- [ ] If this interacts with the agent in a new way, a system test has been added. Not applicable: Agent interaction is unchanged.
- [x] New code is free of linting errors.
- [x] New code doesn't break existing tests. Verified with race-enabled proxy, Envoy, HAProxy, Azure APIM, and Gateway API suites.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. No generated files changed.
- [x] Non-trivial go.mod changes are reviewed by @DataDog/dd-trace-go-guild. No go.mod changes.
