### PR TITLE
ci(system-tests): build apim-callout:dev image for system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,6 +124,7 @@ jobs:
       - build-weblog-images
       - build-service-extensions-callout
       - build-haproxy
+      - build-apim-callout
     strategy:
       matrix:
         weblog-variant:
@@ -242,6 +243,14 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: haproxy-spoa-image-linux-amd64
             image_name: haproxy-spoa
+          - weblog-variant: apim
+            scenario: DEFAULT
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
+          - weblog-variant: apim
+            scenario: APPSEC_BLOCKING
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}
@@ -304,7 +313,7 @@ jobs:
         run: npm install -g @datadog/datadog-ci
 
       - name: Download pre-built weblog image
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: weblog-image-${{ matrix.weblog-variant }}
@@ -314,21 +323,21 @@ jobs:
         run: ls -la binaries
 
       - name: Build weblog
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.image_artifact }}
 
       - name: Load ${{ matrix.weblog-variant }} image
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         run: docker load -i ${{ matrix.image_artifact }}.tar
       
       - name: Set ${{ matrix.image_name }} image name
-        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' }}
+        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim' }}
         run: echo "ghcr.io/datadog/dd-trace-go/${{ matrix.image_name }}:dev" > binaries/golang-${{ matrix.image_name }}-image
 
       - name: Build runner
@@ -383,6 +392,21 @@ jobs:
       image: ghcr.io/datadog/dd-trace-go/haproxy-spoa
       dockerfile: ./contrib/haproxy/stream-processing-offload/cmd/spoa/Dockerfile
       artifact_prefix: haproxy-spoa-image
+      commit_sha: ${{ github.sha }}
+      tags: >-
+        dev
+      push: ${{ github.ref == 'refs/heads/main' }}
+      platforms: '["linux/amd64"]'
+
+  # Pushing an image tagged with "dev" only on commit to main,
+  # otherwise build and use the image from the artifact.
+  build-apim-callout:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
+    uses: ./.github/workflows/docker-build-and-push.yml
+    with:
+      image: ghcr.io/datadog/dd-trace-go/apim-callout
+      dockerfile: ./contrib/azure/apim-callout/cmd/apim-callout/Dockerfile
+      artifact_prefix: apim-callout-image
       commit_sha: ${{ github.sha }}
       tags: >-
         dev


### PR DESCRIPTION
## Summary

Add a `build-apim-callout` job to `.github/workflows/system-tests.yml`, mirroring the existing `build-haproxy` and `build-service-extensions-callout` jobs. This builds the `apim-callout` Docker image tagged `dev` on main, and as a PR artifact otherwise.

This unblocks system-tests' `apim` weblog variant to test the **commit under test** instead of the last release.

## Changes (all in `system-tests.yml`)

1. **New `build-apim-callout` job** — calls `docker-build-and-push.yml` with `image: ghcr.io/datadog/dd-trace-go/apim-callout`, `dockerfile: ./contrib/azure/apim-callout/cmd/apim-callout/Dockerfile`, `tags: dev`, `push: ${{ github.ref == 'refs/heads/main' }}`.

2. **Added to `system-tests.needs`** — `build-apim-callout` added after `build-haproxy`.

3. **Two matrix entries** — `weblog-variant: apim` with `DEFAULT` and `APPSEC_BLOCKING` scenarios, matching `supported_scenarios` in system-tests' `weblog_metadata.yml`.

4. **Five variant gates extended** — lines 307/317 (exclusions: `!= 'apim'`) and lines 321/327/331 (inclusions: `|| == 'apim'`), so apim skips weblog download/build and instead downloads the artifact, `docker load`s it, and writes `binaries/golang-apim-callout-image`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/system-tests.yml'))"` passes (valid YAML)
- Diff is purely additive (+29, -5), mirrors two working precedents (envoy, haproxy)
- Only `.github/workflows/system-tests.yml` modified

## Ordering constraint

`:dev` is pushed **only on merge to main**. After this PR merges:
1. `build-apim-callout` runs on main and pushes `:dev`
2. Re-probe: `docker manifest inspect ghcr.io/datadog/dd-trace-go/apim-callout:dev` must return 200
3. Only then add the `load-binary.sh` line in system-tests (follow-up PR)

## Risk

Low. Additive, mirrors two working precedents, touches no shared job.