### PR TITLE
ci(system-tests): build apim-callout:dev image for system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,6 +124,7 @@ jobs:
       - build-weblog-images
       - build-service-extensions-callout
       - build-haproxy
+      - build-apim-callout
     strategy:
       matrix:
         weblog-variant:
@@ -242,6 +243,14 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: haproxy-spoa-image-linux-amd64
             image_name: haproxy-spoa
+          - weblog-variant: apim
+            scenario: DEFAULT
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
+          - weblog-variant: apim
+            scenario: APPSEC_BLOCKING
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}
@@ -304,7 +313,7 @@ jobs:
         run: npm install -g @datadog/datadog-ci
 
       - name: Download pre-built weblog image
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: weblog-image-${{ matrix.weblog-variant }}
@@ -314,21 +323,21 @@ jobs:
         run: ls -la binaries
 
       - name: Build weblog
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.image_artifact }}
 
       - name: Load ${{ matrix.weblog-variant }} image
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         run: docker load -i ${{ matrix.image_artifact }}.tar
       
       - name: Set ${{ matrix.image_name }} image name
-        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' }}
+        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim' }}
         run: echo "ghcr.io/datadog/dd-trace-go/${{ matrix.image_name }}:dev" > binaries/golang-${{ matrix.image_name }}-image
 
       - name: Build runner
@@ -383,6 +392,21 @@ jobs:
       image: ghcr.io/datadog/dd-trace-go/haproxy-spoa
       dockerfile: ./contrib/haproxy/stream-processing-offload/cmd/spoa/Dockerfile
       artifact_prefix: haproxy-spoa-image
+      commit_sha: ${{ github.sha }}
+      tags: >-
+        dev
+      push: ${{ github.ref == 'refs/heads/main' }}
+      platforms: '["linux/amd64"]'
+
+  # Pushing an image tagged with "dev" only on commit to main,
+  # otherwise build and use the image from the artifact.
+  build-apim-callout:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'DataDog/dd-trace-go')
+    uses: ./.github/workflows/docker-build-and-push.yml
+    with:
+      image: ghcr.io/datadog/dd-trace-go/apim-callout
+      dockerfile: ./contrib/azure/apim-callout/cmd/apim-callout/Dockerfile
+      artifact_prefix: apim-callout-image
       commit_sha: ${{ github.sha }}
       tags: >-
         dev

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,7 +124,6 @@ jobs:
       - build-weblog-images
       - build-service-extensions-callout
       - build-haproxy
-      - build-apim-callout
     strategy:
       matrix:
         weblog-variant:
@@ -243,14 +242,6 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: haproxy-spoa-image-linux-amd64
             image_name: haproxy-spoa
-          - weblog-variant: apim
-            scenario: DEFAULT
-            image_artifact: apim-callout-image-linux-amd64
-            image_name: apim-callout
-          - weblog-variant: apim
-            scenario: APPSEC_BLOCKING
-            image_artifact: apim-callout-image-linux-amd64
-            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}
@@ -313,7 +304,7 @@ jobs:
         run: npm install -g @datadog/datadog-ci
 
       - name: Download pre-built weblog image
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: weblog-image-${{ matrix.weblog-variant }}
@@ -323,21 +314,21 @@ jobs:
         run: ls -la binaries
 
       - name: Build weblog
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.image_artifact }}
 
       - name: Load ${{ matrix.weblog-variant }} image
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
         run: docker load -i ${{ matrix.image_artifact }}.tar
       
       - name: Set ${{ matrix.image_name }} image name
-        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim' }}
+        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' }}
         run: echo "ghcr.io/datadog/dd-trace-go/${{ matrix.image_name }}:dev" > binaries/golang-${{ matrix.image_name }}-image
 
       - name: Build runner


### PR DESCRIPTION
## Summary

Add a `build-apim-callout` job to `.github/workflows/system-tests.yml`, mirroring the existing `build-haproxy` and `build-service-extensions-callout` jobs.

Purpose: publish `ghcr.io/datadog/dd-trace-go/apim-callout:dev`, which does not currently exist. `service-extensions-callout:dev` and `haproxy-spoa:dev` both exist; `apim-callout` publishes only `latest` and `v2.7.1-docker.1 … v2.9.2`. This unblocks system-tests' `apim` weblog variant to test against a current build instead of the last release.

The gap is not in `docker-images-release.yml` — that already handles apim fully. The gap is here, where `:dev` is built for the other two proxies but not apim.

## Change

One job added, nothing else touched:

```yaml
build-apim-callout:
  uses: ./.github/workflows/docker-build-and-push.yml
  with:
    image: ghcr.io/datadog/dd-trace-go/apim-callout
    dockerfile: ./contrib/azure/apim-callout/cmd/apim-callout/Dockerfile
    artifact_prefix: apim-callout-image
    tags: dev
    push: ${{ github.ref == 'refs/heads/main' }}
    platforms: '["linux/amd64"]'
```

Behavior, identical to the two existing precedents:
- **on `main`** → pushes `:dev` to ghcr
- **on a PR** → builds without pushing, validating the Dockerfile

`docker-build-and-push.yml` has no `target` input, so this builds the Dockerfile's last stage (`runtime`, not `e2e`) — which is what we want, since `e2e` bakes `DD_APPSEC_RULES=/app/rules.json`.

## Scope note

This PR deliberately does **not** add `apim` weblog matrix entries to the `system-tests` job. Consequently it also does not touch the five variant gate conditions or the `system-tests` `needs:` list — those are only meaningful when an `apim` matrix entry exists. Net diff is `+15, -0`.

Running apim scenarios inside dd-trace-go's own system-tests matrix can follow separately if wanted; it is not required to publish `:dev`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/system-tests.yml'))"` → valid
- `contrib/azure/apim-callout/cmd/apim-callout/Dockerfile` confirmed present
- Purely additive; no existing job modified
- On this PR, `build-apim-callout` should run and **not** push

## Follow-up (after merge, in order)

1. On merge, `build-apim-callout` runs on main and pushes `:dev`
2. Confirm: `docker manifest inspect ghcr.io/datadog/dd-trace-go/apim-callout:dev` → 200
3. Only then add the `apim-callout:dev` line to system-tests' `utils/scripts/load-binary.sh`

Step 3 must not land before step 2, or system-tests will point at a tag that 404s.

## Risk

Low. One additive job mirroring two working precedents; no shared job touched.