### PR TITLE
fix(openfeature): isolate malformed flag configuration

### DIFF
--- a/openfeature/evaluator.go
+++ b/openfeature/evaluator.go
@@ -8,7 +8,6 @@ package openfeature
 import (
 	"crypto/md5"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -142,7 +141,7 @@ func evaluateFlag(flag *flag, defaultValue any, context map[string]any, now time
 }
 
 // evaluateConfiguredFlag evaluates a flag from a parsed configuration. Invalid
-// SemVer comparands return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
+// flags return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
 func evaluateConfiguredFlag(
 	config *universalFlagsConfiguration,
 	flagKey string,
@@ -155,14 +154,11 @@ func evaluateConfiguredFlag(
 		return evaluateFlag(flag, defaultValue, context, now)
 	}
 	if configErr, invalid := config.invalidFlags[flagKey]; invalid {
-		if errors.Is(configErr, errInvalidSemverComparand) {
-			return evaluationResult{
-				Value:  defaultValue,
-				Reason: of.ErrorReason,
-				Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
-			}
+		return evaluationResult{
+			Value:  defaultValue,
+			Reason: of.ErrorReason,
+			Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
 		}
-		return evaluationResult{Value: defaultValue, Reason: of.DefaultReason}
 	}
 	return evaluationResult{
 		Value:  defaultValue,

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -361,8 +361,9 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 				TargetingKey *string        `json:"targetingKey"`
 				Attributes   map[string]any `json:"attributes"`
 				Result       struct {
-					Value  any    `json:"value"`
-					Reason string `json:"reason"`
+					Value     any          `json:"value"`
+					Reason    string       `json:"reason"`
+					ErrorCode of.ErrorCode `json:"errorCode"`
 				} `json:"result"`
 			}
 			if err := json.Unmarshal(data, &cases); err != nil {
@@ -387,6 +388,12 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 					}
 					if tc.Result.Reason != "" && result.Reason != of.Reason(tc.Result.Reason) {
 						t.Errorf("reason: got %q, want %q", result.Reason, tc.Result.Reason)
+					}
+					actualErrorCode := of.ProviderResolutionDetail{
+						ResolutionError: toResolutionError(result.Error),
+					}.ResolutionDetail().ErrorCode
+					if tc.Result.ErrorCode != "" && actualErrorCode != tc.Result.ErrorCode {
+						t.Errorf("error code: got %q, want %q", actualErrorCode, tc.Result.ErrorCode)
 					}
 				})
 			}

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -162,9 +162,9 @@ func validateFlag(flagKey string, flag *flag) error {
 					if shardRange == nil {
 						return fmt.Errorf("flag %q allocation %d split %d has nil shard range", flagKey, i, j)
 					}
-					if shardRange.Start < 0 || shardRange.End < 0 {
-						return fmt.Errorf("flag %q allocation %d split %d has shard with negative range bounds",
-							flagKey, i, j)
+					if shardRange.Start < 0 || shardRange.Start >= shardRange.End || shardRange.End > shard.TotalShards {
+						return fmt.Errorf("flag %q allocation %d split %d has invalid shard range [%d, %d) for total %d",
+							flagKey, i, j, shardRange.Start, shardRange.End, shard.TotalShards)
 					}
 				}
 			}
@@ -214,6 +214,28 @@ func validateFlag(flagKey string, flag *flag) error {
 				}
 
 				switch condition.Operator {
+				case operatorLT, operatorLTE, operatorGT, operatorGTE:
+					if err := validateVariantType(condition.Value, valueTypeNumeric); err != nil {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires numeric value: %w",
+							flagKey, i, condition.Operator, err)
+					}
+				case operatorOneOf, operatorNotOneOf:
+					values, ok := condition.Value.([]any)
+					if !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires a string array",
+							flagKey, i, condition.Operator)
+					}
+					for _, value := range values {
+						if _, ok := value.(string); !ok {
+							return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires a string array",
+								flagKey, i, condition.Operator)
+						}
+					}
+				case operatorIsNull:
+					if _, ok := condition.Value.(bool); !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires boolean value",
+							flagKey, i, condition.Operator)
+					}
 				case operatorSemverEQ, operatorSemverNEQ, operatorSemverLT,
 					operatorSemverLTE, operatorSemverGT, operatorSemverGTE:
 					comparand, ok := condition.Value.(string)
@@ -231,6 +253,16 @@ func validateFlag(flagKey string, flag *flag) error {
 			}
 		}
 	}
+
+	for variationKey, variation := range flag.Variations {
+		if variation == nil {
+			return fmt.Errorf("flag %q variation %q is nil", flagKey, variationKey)
+		}
+		if err := validateVariantType(variation.Value, flag.VariationType); err != nil {
+			return fmt.Errorf("flag %q variation %q has invalid value: %w", flagKey, variationKey, err)
+		}
+	}
+
 	return nil
 }
 

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -153,7 +153,10 @@ func validateFlag(flagKey string, flag *flag) error {
 				return fmt.Errorf("flag %q allocation %d split %d is nil", flagKey, i, j)
 			}
 
-			for _, shard := range split.Shards {
+			for k, shard := range split.Shards {
+				if shard == nil {
+					return fmt.Errorf("flag %q allocation %d split %d shard %d is nil", flagKey, i, j, k)
+				}
 				if shard.TotalShards <= 0 || uint64(shard.TotalShards) > uint64(^uint32(0)) {
 					return fmt.Errorf("flag %q allocation %d split %d has shard with invalid TotalShards %d",
 						flagKey, i, j, shard.TotalShards)
@@ -257,6 +260,9 @@ func validateFlag(flagKey string, flag *flag) error {
 	for variationKey, variation := range flag.Variations {
 		if variation == nil {
 			return fmt.Errorf("flag %q variation %q is nil", flagKey, variationKey)
+		}
+		if variation.Key != variationKey {
+			return fmt.Errorf("flag %q variation key mismatch: map key %q != variation.Key %q", flagKey, variationKey, variation.Key)
 		}
 		if err := validateVariantType(variation.Value, flag.VariationType); err != nil {
 			return fmt.Errorf("flag %q variation %q has invalid value: %w", flagKey, variationKey, err)

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -351,6 +351,25 @@ func TestValidateFlag(t *testing.T) {
 		}
 	})
 
+	t.Run("nil shard in split", func(t *testing.T) {
+		flag := &flag{
+			Key:           "test-flag",
+			VariationType: valueTypeBoolean,
+			Variations: map[string]*variant{
+				"on": {Key: "on", Value: true},
+			},
+			Allocations: []*allocation{
+				{
+					Splits: []*split{
+						{Shards: []*shard{nil}, VariationKey: "on"},
+					},
+				},
+			},
+		}
+
+		require.ErrorContains(t, validateFlag("test-flag", flag), "shard 0 is nil")
+	})
+
 	t.Run("split references non-existent variation", func(t *testing.T) {
 		flag := &flag{
 			Key:           "test-flag",
@@ -412,6 +431,18 @@ func TestValidateFlag(t *testing.T) {
 				t.Errorf("expected %s to be valid, got error: %v", testCase.typeName, err)
 			}
 		}
+	})
+
+	t.Run("variation key mismatch", func(t *testing.T) {
+		flag := &flag{
+			Key:           "test-flag",
+			VariationType: valueTypeBoolean,
+			Variations: map[string]*variant{
+				"on": {Key: "off", Value: true},
+			},
+		}
+
+		require.ErrorContains(t, validateFlag("test-flag", flag), "variation key mismatch")
 	})
 }
 

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -387,26 +387,29 @@ func TestValidateFlag(t *testing.T) {
 	})
 
 	t.Run("all variation types are valid", func(t *testing.T) {
-		validTypes := []valueType{
-			valueTypeBoolean,
-			valueTypeString,
-			valueTypeInteger,
-			valueTypeNumeric,
-			valueTypeJSON,
+		validTypes := []struct {
+			typeName valueType
+			value    any
+		}{
+			{typeName: valueTypeBoolean, value: true},
+			{typeName: valueTypeString, value: "test-value"},
+			{typeName: valueTypeInteger, value: 1},
+			{typeName: valueTypeNumeric, value: 1.5},
+			{typeName: valueTypeJSON, value: map[string]any{"key": "value"}},
 		}
 
-		for _, vType := range validTypes {
+		for _, testCase := range validTypes {
 			flag := &flag{
 				Key:           "test-flag",
-				VariationType: vType,
+				VariationType: testCase.typeName,
 				Variations: map[string]*variant{
-					"v1": {Key: "v1", Value: "test-value"},
+					"v1": {Key: "v1", Value: testCase.value},
 				},
 			}
 
 			err := validateFlag("test-flag", flag)
 			if err != nil {
-				t.Errorf("expected %s to be valid, got error: %v", vType, err)
+				t.Errorf("expected %s to be valid, got error: %v", testCase.typeName, err)
 			}
 		}
 	})
@@ -594,7 +597,57 @@ func TestProcessConfigUpdate(t *testing.T) {
 
 		invalidResult := evaluateConfiguredFlag(updatedConfig, "invalid-flag", false, nil, time.Now())
 		require.Equal(t, false, invalidResult.Value)
-		require.Equal(t, "DEFAULT", string(invalidResult.Reason))
+		require.Equal(t, "ERROR", string(invalidResult.Reason))
+		require.ErrorIs(t, invalidResult.Error, errParseError)
+	})
+
+	t.Run("configuration replacement clears rejected flags", func(t *testing.T) {
+		provider := newDatadogProvider(ProviderConfig{})
+		first := []byte(`{
+			"format": "SERVER",
+			"flags": {
+				"rejected-old": {
+					"key": "rejected-old",
+					"enabled": true,
+					"variationType": "BOOLEAN",
+					"variations": {"on": {"key": "on", "value": true}},
+					"allocations": "invalid"
+				},
+				"active-old": {
+					"key": "active-old",
+					"enabled": true,
+					"variationType": "BOOLEAN",
+					"variations": {"on": {"key": "on", "value": true}},
+					"allocations": []
+				}
+			}
+		}`)
+		require.Equal(t, rc.ApplyStateAcknowledged, processConfigUpdate(provider, "test-path", first).State)
+		require.Contains(t, provider.getConfiguration().invalidFlags, "rejected-old")
+
+		second := []byte(`{
+			"format": "SERVER",
+			"flags": {
+				"active-new": {
+					"key": "active-new",
+					"enabled": true,
+					"variationType": "BOOLEAN",
+					"variations": {"on": {"key": "on", "value": true}},
+					"allocations": []
+				}
+			}
+		}`)
+		require.Equal(t, rc.ApplyStateAcknowledged, processConfigUpdate(provider, "test-path", second).State)
+
+		updatedConfig := provider.getConfiguration()
+		require.NotContains(t, updatedConfig.Flags, "active-old")
+		require.NotContains(t, updatedConfig.invalidFlags, "rejected-old")
+
+		oldRejectedResult := evaluateConfiguredFlag(updatedConfig, "rejected-old", false, nil, time.Now())
+		require.Equal(t, false, oldRejectedResult.Value)
+		require.Equal(t, "ERROR", string(oldRejectedResult.Reason))
+		require.ErrorIs(t, oldRejectedResult.Error, errFlagNotFound)
+		require.NotErrorIs(t, oldRejectedResult.Error, errParseError)
 	})
 
 	t.Run("configuration deletion", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

The canonical FFE corpus now verifies that a malformed flag does not block valid siblings and that rejected keys remain distinguishable from missing keys.

## Changes

- bump `ffe-system-test-data` to `ea8b5cc5ce335109f11f3efbc5fd608f98a3ca54`
- validate each flag independently and retain rejected keys
- return the caller default with `ERROR/PARSE_ERROR` for malformed flags
- keep absent keys on `FLAG_NOT_FOUND`
- cover rejected-state replacement and canonical error codes

## Decisions

- replace active and rejected state atomically on every configuration refresh
- validate malformed variants, operators, shard bounds, regexes, and SemVer comparands during ingestion
- keep SemVer build metadata out of precedence comparisons

## Validation

- `go test ./openfeature -count=1`
- `go test -race ./openfeature -count=1`
- `git diff --check`