### PR TITLE
perf(ddtrace/opentelemetry): batch baggage in oteltracer.Start

### DIFF
--- a/ddtrace/baggage/baggage.go
+++ b/ddtrace/baggage/baggage.go
@@ -33,6 +33,12 @@ func withBaggage(ctx context.Context, baggage map[string]string) context.Context
 
 // Set sets or updates a single baggage key/value pair in the context.
 // If the key already exists, this function overwrites the existing value.
+//
+// Set clones the entire baggage map on every call. Use it for one-off,
+// standalone updates. If you're writing more than one key as part of the same
+// logical update (e.g. reconciling baggage from another source), call SetAll
+// once instead of Set in a loop — looping Set reclones the whole map on every
+// iteration, which is O(N) clones for N keys instead of one.
 func Set(ctx context.Context, key, value string) context.Context {
 	bm, ok := baggageMap(ctx)
 	if !ok || bm == nil {
@@ -47,8 +53,10 @@ func Set(ctx context.Context, key, value string) context.Context {
 
 // SetAll merges multiple key/value pairs into the baggage in a single context write.
 // Equivalent to calling Set once per entry in values, but only clones the baggage map
-// once instead of once per key. Prefer this over a Set loop when writing more than one
-// key at a time, e.g. when reconciling baggage from another source.
+// once instead of once per key. Prefer this over a Set loop whenever the key/value
+// pairs are already available together, e.g. when reconciling baggage extracted from
+// another source (headers, another baggage format, etc.) rather than a single
+// standalone update.
 func SetAll(ctx context.Context, values map[string]string) context.Context {
 	if len(values) == 0 {
 		return ctx

--- a/ddtrace/baggage/baggage.go
+++ b/ddtrace/baggage/baggage.go
@@ -45,6 +45,25 @@ func Set(ctx context.Context, key, value string) context.Context {
 	return withBaggage(ctx, bm)
 }
 
+// SetAll merges multiple key/value pairs into the baggage in a single context write.
+// Equivalent to calling Set once per entry in values, but only clones the baggage map
+// once instead of once per key. Prefer this over a Set loop when writing more than one
+// key at a time, e.g. when reconciling baggage from another source.
+func SetAll(ctx context.Context, values map[string]string) context.Context {
+	if len(values) == 0 {
+		return ctx
+	}
+
+	bm, ok := baggageMap(ctx)
+	merged := make(map[string]string, len(bm)+len(values))
+	if ok {
+		maps.Copy(merged, bm)
+	}
+	maps.Copy(merged, values)
+
+	return withBaggage(ctx, merged)
+}
+
 // Get retrieves the value associated with a baggage key.
 // If the key isn't found, it returns an empty string.
 func Get(ctx context.Context, key string) (string, bool) {

--- a/ddtrace/baggage/baggage_test.go
+++ b/ddtrace/baggage/baggage_test.go
@@ -70,6 +70,40 @@ func TestBaggageFunctions(t *testing.T) {
 		}
 	})
 
+	t.Run("SetAll merges into existing baggage", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = Set(ctx, "existing", "value")
+		ctx = SetAll(ctx, map[string]string{"a": "1", "b": "2"})
+
+		all := All(ctx)
+		assert.Equal(t, map[string]string{"existing": "value", "a": "1", "b": "2"}, all)
+	})
+
+	t.Run("SetAll overwrites existing keys", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = Set(ctx, "key", "original")
+		ctx = SetAll(ctx, map[string]string{"key": "updated"})
+
+		got, _ := Get(ctx, "key")
+		assert.Equal(t, "updated", got)
+	})
+
+	t.Run("SetAll with empty map is a no-op", func(t *testing.T) {
+		ctx := Set(context.Background(), "key", "value")
+		result := SetAll(ctx, map[string]string{})
+
+		assert.True(t, ctx == result, "SetAll with no values should return the same context") //nolint
+	})
+
+	t.Run("SetAll does not allow external mutation", func(t *testing.T) {
+		m := map[string]string{"key": "original"}
+		ctx := SetAll(context.Background(), m)
+		m["key"] = "mutated"
+
+		got, _ := Get(ctx, "key")
+		assert.Equal(t, "original", got)
+	})
+
 	t.Run("Remove", func(t *testing.T) {
 		ctx := context.Background()
 

--- a/ddtrace/baggage/baggage_test.go
+++ b/ddtrace/baggage/baggage_test.go
@@ -219,6 +219,33 @@ func TestBaggageMapAccessorsMakeCopies(t *testing.T) {
 	})
 }
 
+// TestSetAllAllocationsDoNotScaleWithKeyCount is a regression test for a bug where
+// callers looped Set() once per key to merge a batch of baggage (see #5158): each
+// Set() call clones the entire map, so merging N keys did N clones instead of one.
+// SetAll's allocation count per call should stay flat as the batch size grows; if it
+// starts scaling linearly again (e.g. SetAll gets reimplemented as a Set loop), this
+// test should fail.
+func TestSetAllAllocationsDoNotScaleWithKeyCount(t *testing.T) {
+	base := Set(context.Background(), "existing", "value")
+
+	allocsForBatch := func(n int) float64 {
+		values := make(map[string]string, n)
+		for i := range n {
+			values[fmt.Sprintf("key%d", i)] = "v"
+		}
+		return testing.AllocsPerRun(20, func() {
+			_ = SetAll(base, values)
+		})
+	}
+
+	small := allocsForBatch(2)
+	large := allocsForBatch(200)
+
+	assert.LessOrEqual(t, large, small*2,
+		"SetAll allocations scaled with batch size (%v allocs for 2 keys vs %v allocs for 200 keys); "+
+			"expected a single clone per call regardless of key count", small, large)
+}
+
 // guarantees we also test the Clear→Set path
 func TestConcurrentAccessAndClear(t *testing.T) {
 	base := Set(context.Background(), "init", "val")

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -102,9 +102,12 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 
 	// Merge baggage from otel and dd, update Datadog baggage, and update the context.
 	mergedBag := mergeBaggageFromContext(ctx)
-	for _, m := range mergedBag.Members() {
-		ctx = baggage.Set(ctx, m.Key(), m.Value())
+	members := mergedBag.Members()
+	ddBag := make(map[string]string, len(members))
+	for _, m := range members {
+		ddBag[m.Key()] = m.Value()
 	}
+	ctx = baggage.SetAll(ctx, ddBag)
 	ctx = otelbaggage.ContextWithBaggage(ctx, mergedBag)
 
 	os := oteltrace.Span(&span{

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -139,6 +139,9 @@ func mergeBaggageFromContext(ctx context.Context) (otelbaggage.Baggage, map[stri
 		}
 	}
 	members := otelBag.Members()
+	if len(members) == 0 {
+		return otelBag, nil
+	}
 	ddBag := make(map[string]string, len(members))
 	for _, m := range members {
 		ddBag[m.Key()] = m.Value()

--- a/ddtrace/opentelemetry/tracer.go
+++ b/ddtrace/opentelemetry/tracer.go
@@ -101,12 +101,7 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	s := tracer.StartSpan(spanName, ddopts...)
 
 	// Merge baggage from otel and dd, update Datadog baggage, and update the context.
-	mergedBag := mergeBaggageFromContext(ctx)
-	members := mergedBag.Members()
-	ddBag := make(map[string]string, len(members))
-	for _, m := range members {
-		ddBag[m.Key()] = m.Value()
-	}
+	mergedBag, ddBag := mergeBaggageFromContext(ctx)
 	ctx = baggage.SetAll(ctx, ddBag)
 	ctx = otelbaggage.ContextWithBaggage(ctx, mergedBag)
 
@@ -124,9 +119,11 @@ func (t *oteltracer) Start(ctx context.Context, spanName string, opts ...oteltra
 	return ctx, os
 }
 
-// mergeBaggageFromContext merges Datadog baggage found on the context into the OpenTelemetry baggage found on the context.
-// adding key-value pairs only if the key doesn't already exist in the OpenTelemetry baggage. It ensures no existing values are overwritten.
-func mergeBaggageFromContext(ctx context.Context) otelbaggage.Baggage {
+// mergeBaggageFromContext merges Datadog baggage found on the context into the OpenTelemetry baggage found on the context,
+// adding key-value pairs only if the key doesn't already exist in the OpenTelemetry baggage. It ensures no existing values
+// are overwritten. It returns the merged OTel baggage along with the equivalent map[string]string used to update Datadog
+// baggage.
+func mergeBaggageFromContext(ctx context.Context) (otelbaggage.Baggage, map[string]string) {
 	otelBag := otelbaggage.FromContext(ctx)
 	for key, value := range baggage.All(ctx) {
 		if otelBag.Member(key).Value() == "" {
@@ -141,7 +138,12 @@ func mergeBaggageFromContext(ctx context.Context) otelbaggage.Baggage {
 			}
 		}
 	}
-	return otelBag
+	members := otelBag.Members()
+	ddBag := make(map[string]string, len(members))
+	for _, m := range members {
+		ddBag[m.Key()] = m.Value()
+	}
+	return otelBag, ddBag
 }
 
 type otelCtxToDDCtx struct {

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -93,12 +93,12 @@ func startRequestSpan(r *http.Request, ipTags map[string]string, opts ...tracer.
 
 	parentCtx, extractErr := tracer.Extract(tracer.HTTPHeadersCarrier(r.Header))
 	if extractErr == nil && parentCtx != nil {
-		ctx2 := r.Context()
+		items := make(map[string]string)
 		parentCtx.ForeachBaggageItem(func(k, v string) bool {
-			ctx2 = baggage.Set(ctx2, k, v)
+			items[k] = v
 			return true
 		})
-		r = r.WithContext(ctx2)
+		r = r.WithContext(baggage.SetAll(r.Context(), items))
 	}
 
 	nopts := make([]tracer.StartSpanOption, 0, len(opts)+1+len(ipTags))


### PR DESCRIPTION
## What does this PR do?

`oteltracer.Start` merges OTel and Datadog-native baggage on every span start, then writes the merged set into `ddtrace/baggage` by calling `Set()` once per key. But `Set()` clones the entire baggage map on every call, so this cost O(N×M) map clones/`context.WithValue` allocations for a request with N spans and M baggage members — most of them redundant rewrites of unchanged values.

This PR:

- Adds `baggage.SetAll(ctx, map[string]string)`, which merges a whole batch of keys into the baggage with a single clone and a single `context.WithValue`.
- Updates `oteltracer.Start` to call `SetAll` once instead of looping `Set()`.
- Changes `mergeBaggageFromContext`'s signature to `(otelbaggage.Baggage, map[string]string)`, so it returns the DD-format map directly (it already walks the merged members once internally). This keeps `Start()` as pure orchestration — merge, `SetAll`, `ContextWithBaggage` — with no member-extraction loop left in the hot path, and keeps `ddtrace/baggage` free of any dependency on the OTel bridge package.
- Applies the same batching fix to `instrumentation/httptrace`, which restored baggage extracted from incoming request headers via the same `Set`-per-key pattern.
- Clarifies `Set`'s and `SetAll`'s godocs to cross-reference each other, so future contributors don't reintroduce a `Set`-per-key loop.

No behavior change — same end-state baggage contents, fewer allocations per span.

## Motivation

Fixes #5158. Builds on the fix proposed in #5157 (credit to @yuyangguo42): a request with many spans was accumulating a disproportionate number of `baggage.baggageKey`-typed `context.WithValue` nodes, because the write-back loop re-cloned the whole baggage map once per key on every span, even when baggage hadn't changed since the previous span. Batching the write-back into a single clone removes that redundant allocation and context-chain growth without changing observed baggage contents.

## Testing

- [x] `go test ./ddtrace/opentelemetry/... ./ddtrace/baggage/... ./instrumentation/httptrace/...` passes
- [x] `go vet` / `gofmt` clean on changed files
- [x] Added `TestSetAllAllocationsDoNotScaleWithKeyCount` (`ddtrace/baggage/baggage_test.go`) as a regression test for the bug this PR fixes. It uses `testing.AllocsPerRun` to assert `SetAll`'s allocation count stays flat as the batch size grows (2 keys vs. 200 keys), rather than scaling linearly the way a `Set`-per-key loop would.
  - Validated the test actually catches the regression: temporarily reimplemented `SetAll` as a `Set`-per-key loop and reran the test, which failed with **995 allocations for 200 keys vs. 6 allocations for 2 keys** (linear growth). Reverting to the real `SetAll` implementation, allocation count stays flat regardless of batch size and the test passes.
