### PR TITLE
fix(contrib/twmb/franz-go): release finished consume span pointers from activeSpans

### DIFF
--- a/contrib/twmb/franz-go/kgo.go
+++ b/contrib/twmb/franz-go/kgo.go
@@ -63,6 +63,9 @@ func (h *tracingHook) finishAndClearActiveSpans() {
 	for _, span := range h.activeSpans {
 		span.Finish()
 	}
+	// clear zeroes out the backing array so finished spans aren't kept alive
+	// by stale pointers past the truncated length (see issue #5192).
+	clear(h.activeSpans)
 	h.activeSpans = h.activeSpans[:0]
 	h.activeSpansMu.Unlock()
 }

--- a/contrib/twmb/franz-go/kgo_test.go
+++ b/contrib/twmb/franz-go/kgo_test.go
@@ -326,6 +326,36 @@ func TestConsumeSpansFinishedOnClose(t *testing.T) {
 	assert.Equal(t, "kafka.consume", spans[1].OperationName())
 }
 
+// TestFinishAndClearActiveSpansReleasesRetainedSpans is a regression test for
+// issue #5192: activeSpans[:0] only reset the slice length, leaving every
+// finished span's pointer alive in the backing array until a later, larger
+// poll happened to overwrite that slot.
+func TestFinishAndClearActiveSpansReleasesRetainedSpans(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	h := newTracingHook()
+
+	const bigPoll = 1000
+	for range bigPoll {
+		span, _ := tracer.StartSpanFromContext(context.Background(), "test")
+		h.activeSpans = append(h.activeSpans, span)
+	}
+
+	h.finishAndClearActiveSpans()
+	require.Empty(t, h.activeSpans)
+
+	// Peek past len (legal up to cap) to confirm the backing array no
+	// longer references the finished spans.
+	retained := 0
+	for _, s := range h.activeSpans[:cap(h.activeSpans)] {
+		if s != nil {
+			retained++
+		}
+	}
+	assert.Zero(t, retained, "finished spans should not be retained in the activeSpans backing array")
+}
+
 func TestProduceDSMPathway(t *testing.T) {
 	topic := topicName(t)
 	createTopicWithCleanup(t, topic)


### PR DESCRIPTION
## Summary

- `tracingHook.finishAndClearActiveSpans` truncated `activeSpans` with `activeSpans[:0]`, which only resets the slice's length — the backing array still holds every finished `*tracer.Span` pointer, so the GC can't collect them.
- Since `append` only grows capacity and never shrinks it, the retained set is bounded by the largest poll the process has ever seen and never shrinks back down; each retained span keeps its tag/metric maps and `SpanContext` alive.
- Fix: `clear()` the slice before truncating so the backing array no longer references the finished spans.

Fixes #5192

## Test plan

- [x] Added `TestFinishAndClearActiveSpansReleasesRetainedSpans`, a regression test that fills `activeSpans` with 1,000 spans, calls `finishAndClearActiveSpans`, then peeks past `len` (up to `cap`) to assert no span pointers remain in the backing array.
  - Verified the test fails against the pre-fix code (`retained == 1000`) and passes against the fix (`retained == 0`).
- [x] `go build ./...` and `go vet ./...` pass for `contrib/twmb/franz-go`.
- [x] `golangci-lint run ./contrib/twmb/franz-go/...` reports 0 issues.
- [ ] Full `INTEGRATION=1` suite (requires a local Kafka broker via `docker compose up kafka`) — not run in this environment due to no network access to pull the Kafka image; CI's contrib matrix job runs this with `INTEGRATION: true`.