### PR TITLE
perf(ddtrace/tracer): pre-size the per-span tag map from the option count

### DIFF
--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -1213,7 +1213,7 @@ func WithDynamicInstrumentationEnabled(enabled bool) StartOption {
 func Tag(k string, v any) StartSpanOption {
 	return func(cfg *StartSpanConfig) {
 		if cfg.Tags == nil {
-			cfg.Tags = map[string]any{}
+			cfg.Tags = make(map[string]any, cfg.tagsHint)
 		}
 		cfg.Tags[k] = v
 	}

--- a/ddtrace/tracer/span_config.go
+++ b/ddtrace/tracer/span_config.go
@@ -16,6 +16,9 @@ type StartSpanOption func(cfg *StartSpanConfig)
 // StartSpanConfig holds the configuration for starting a new span. It is usually passed
 // around by reference to one or more StartSpanOption functions which shape it into its
 // final form.
+//
+// Construct StartSpanConfig using keyed fields (StartSpanConfig{Tags: ...}); unkeyed
+// literals are not supported and may stop compiling in a future version.
 type StartSpanConfig struct {
 	// Parent holds the SpanContext that should be used as a parent for the
 	// new span. If nil, implementations should return a root span.
@@ -39,6 +42,12 @@ type StartSpanConfig struct {
 
 	// SpanLink represents a causal relationship between two spans. A span can have multiple links.
 	SpanLinks []SpanLink
+
+	// tagsHint is a capacity hint for Tags, set by spanStart from the number of
+	// applied options so the first Tag-family write can size the map instead of
+	// starting unsized and rehashing once a caller passes several individual
+	// Tag options. Zero means no hint (Tags is created unsized, as before).
+	tagsHint int
 }
 
 // NewStartSpanConfig allows to build a base config struct. It accepts the same options as StartSpan.

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -916,6 +916,11 @@ func (t *tracer) pushChunk(trace *chunk) {
 // +checklocksignore — Initialization time, span not yet shared.
 func spanStart(operationName string, sharedAttrs *traceinternal.SpanAttributes, poolEnabled bool, options ...StartSpanOption) *Span {
 	var opts StartSpanConfig
+	// A caller passing N options is our best cheap signal for how many
+	// Tag-family options it might include; Tag uses this to size Tags on
+	// its first write instead of starting unsized and rehashing once the
+	// tag count grows past a small map's initial capacity.
+	opts.tagsHint = len(options)
 	for _, fn := range options {
 		if fn == nil {
 			continue

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -2649,6 +2649,33 @@ func BenchmarkStartSpan(b *testing.B) {
 	}
 }
 
+// BenchmarkStartSpanManyTags exercises the shape spanStart's tagsHint targets:
+// several individual Tag options in one call, rather than a single
+// WithStartSpanConfig/WithTags. This is the common shape for contribs that
+// set each tag as its own option (e.g. component, span.kind, db.system,
+// host, port, resource.name) and for any third-party integration using the
+// plain Tag/ServiceName/ResourceName option API.
+func BenchmarkStartSpanManyTags(b *testing.B) {
+	tracer, _, _, stop, err := startTestTracer(b, WithLogger(log.DiscardLogger{}), WithSamplerRate(0))
+	assert.Nil(b, err)
+	defer stop()
+
+	b.ResetTimer()
+	for b.Loop() {
+		tracer.StartSpan("valkey.command",
+			Tag("component", "valkey-io/valkey-go"),
+			Tag("span.kind", "client"),
+			Tag("db.system", "valkey"),
+			Tag("out.host", "127.0.0.1"),
+			Tag("out.port", "6379"),
+			Tag("out.db", "0"),
+			Tag("resource.name", "GET"),
+			Tag("db.user", "default"),
+			Tag("valkey.raw_command", "GET foo"),
+		)
+	}
+}
+
 func BenchmarkStartSpanConcurrent(b *testing.B) {
 	tracer, _, _, stop, err := startTestTracer(b, WithLogger(log.DiscardLogger{}), WithSampler(NewRateSampler(0)))
 	assert.NoError(b, err)


### PR DESCRIPTION
### What does this PR do?

`Tag()` creates `StartSpanConfig.Tags` lazily and completely unsized on its
first write. A caller passing several individual `Tag` options (the common
shape for contribs that haven't adopted `WithStartSpanConfig`/`WithTags`,
and for any third-party integration using the plain option API) pays a map
rehash once the tag count grows past a small map's initial group capacity.

`spanStart` already knows `len(options)` before applying any option, so
this records that count as a capacity hint on `StartSpanConfig`; `Tag`
consults it on its first write instead of starting unsized. The hint is an
unexported field, only consulted by the existing lazy-init check — a caller
that sets zero tags still leaves `Tags` nil exactly as before, so no
allocation is added for tag-less spans.

Adds `BenchmarkStartSpanManyTags`, mirroring the pre-migration valkey shape
(nine individual `Tag()` calls, no `WithStartSpanConfig`/`WithTags`).
`benchstat -count=20`: **-50.09% ns/op** (p=0.000), **B/op -7.78%**
(p=0.000), **-1 alloc/op** (31→30, p=0.000). `make apidiff` reports no
change (the new field is unexported).

**Sequencing note for reviewers:** this has no interaction with the
separate `WithStartSpanConfig` tag-precedence fix, in either merge order.
`Tags` stays lazy — nil until a `Tag`-family option actually writes to it —
so this change doesn't alter when `WithStartSpanConfig`'s
aliasing-vs-copy branch is taken; it only changes the capacity used on the
first write, once that write happens.

Also documents that `StartSpanConfig` must be constructed with keyed
fields — this is its first unexported field, so it's the point where an
external unkeyed literal would stop compiling. That case has no
compatibility guarantee under the Go spec, and `apidiff`'s own scope
explicitly excludes it (confirmed against apidiff's source: it only
diffs the exported surface). The doc comment sets the expectation
going forward.

**Considered and reverted:** an earlier revision of this PR added a
per-entry-point correction (`withTagsHint`, prepended in
`StartSpanFromContext`/`StartSpanFromPropagatedContext`/`StartChild`) for
a real overcounting edge case: those three each append their own non-tag
options (`ChildOf`/`withContext`) *after* the caller's options, so a call
with ≤8 tags but enough appended options to reach 9 crossed the map's
group boundary and forced a larger table than needed (e.g. 7
`Tag()` calls through `StartSpanFromContext` with an active parent →
hint of 9). The correction itself regressed the CI benchmark gate harder
than the bug it fixed: 0 improvements, 16 regressions
(`BenchmarkStartRequestSpan` + 4 `QueryObfuscation` variants,
`BenchmarkOTelApiWithCustomTags`), from a closure now allocated on
*every* call through those three entry points regardless of tag count. A
follow-up lookup-table fix removed the allocation-count regression but
left a ~7% B/op one (needing one extra option slot) that would still
trip the CI gate's 2% significance threshold — closing that fully would
require threading the hint through the exported `Tracer` interface, a
much bigger compatibility cost than the edge case it fixes. Reverted
back to the plain `len(options)` hint; verified byte-for-byte identical
to `main` on every currently-gated benchmark. The overcounting case is
accepted as a known, narrow trade-off rather than something worth taxing
every call for.

### Motivation

Found while investigating and migrating 12 contribs (#5007) to the
`WithStartSpanConfig`-cached-config pattern. That migration only helps
call sites we've touched; this fix helps every contrib and third-party
integration that still sets tags via individual `Tag()` calls, with zero
per-contrib work.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
