### PR TITLE
feat(llmobs): support manual agent versioning

### DIFF
--- a/internal/llmobs/llmobs.go
+++ b/internal/llmobs/llmobs.go
@@ -848,6 +848,14 @@ func (l *LLMObs) StartSpan(ctx context.Context, kind SpanKind, name string, cfg 
 		}
 	}
 
+	if cfg.AgentVersion != "" {
+		if kind != SpanKindAgent {
+			log.Warn("llmobs: agent version can only be set on agent spans, ignoring")
+		} else {
+			span.llmCtx.tags = updateMapKeys(span.llmCtx.tags, map[string]string{TagKeyAgentVersion: cfg.AgentVersion})
+		}
+	}
+
 	if span.sessionID == "" {
 		span.sessionID = span.propagatedSessionID()
 	}

--- a/internal/llmobs/llmobs_test.go
+++ b/internal/llmobs/llmobs_test.go
@@ -865,6 +865,66 @@ func TestSpanAnnotate(t *testing.T) {
 			},
 		},
 		{
+			name: "agent-span-with-version-from-config",
+			kind: llmobs.SpanKindAgent,
+			config: llmobs.StartSpanConfig{
+				AgentVersion: "v3",
+			},
+			wantMeta: map[string]any{
+				"span.kind": "agent",
+			},
+			wantTags: []string{
+				"agent_version:v3",
+			},
+		},
+		{
+			name: "agent-span-with-annotated-version",
+			kind: llmobs.SpanKindAgent,
+			annotations: llmobs.SpanAnnotations{
+				AgentVersion: "v3",
+			},
+			wantMeta: map[string]any{
+				"span.kind": "agent",
+			},
+			wantTags: []string{
+				"agent_version:v3",
+			},
+		},
+		{
+			name: "agent-span-annotated-version-overrides-config",
+			kind: llmobs.SpanKindAgent,
+			config: llmobs.StartSpanConfig{
+				AgentVersion: "v1",
+			},
+			annotations: llmobs.SpanAnnotations{
+				AgentVersion: "v2",
+			},
+			wantMeta: map[string]any{
+				"span.kind": "agent",
+			},
+			wantTags: []string{
+				"agent_version:v2",
+			},
+		},
+		{
+			// A version supplied for a non-agent span is dropped, so the tag stays absent
+			// (findTag returns "" for a missing key).
+			name: "non-agent-span-drops-version",
+			kind: llmobs.SpanKindTool,
+			config: llmobs.StartSpanConfig{
+				AgentVersion: "v3",
+			},
+			annotations: llmobs.SpanAnnotations{
+				AgentVersion: "v3",
+			},
+			wantMeta: map[string]any{
+				"span.kind": "tool",
+			},
+			wantTags: []string{
+				"agent_version:",
+			},
+		},
+		{
 			name: "llm-span-with-full-prompt",
 			kind: llmobs.SpanKindLLM,
 			annotations: llmobs.SpanAnnotations{

--- a/internal/llmobs/span.go
+++ b/internal/llmobs/span.go
@@ -18,6 +18,8 @@ import (
 const (
 	// TagKeySessionID is the tag key used to set the session ID for LLMObs spans.
 	TagKeySessionID = "session_id"
+	// TagKeyAgentVersion is the tag key used to set the user-supplied agent version on agent spans.
+	TagKeyAgentVersion = "agent_version"
 )
 
 // StartSpanConfig contains configuration options for starting an LLMObs span.
@@ -34,6 +36,8 @@ type StartSpanConfig struct {
 	StartTime time.Time
 	// Name of the tracing integration.
 	Integration string
+	// AgentVersion sets the user-supplied agent version. Only applies to agent spans.
+	AgentVersion string
 }
 
 // FinishSpanConfig contains configuration options for finishing an LLMObs span.
@@ -216,6 +220,10 @@ type SpanAnnotations struct {
 
 	// AgentManifest is the agent manifest for agent spans.
 	AgentManifest string
+
+	// AgentVersion is the user-supplied agent version for agent spans. It is set as an
+	// agent_version tag on the agent span only, never on its children.
+	AgentVersion string
 
 	// Metadata contains arbitrary metadata key-value pairs.
 	Metadata map[string]any
@@ -412,6 +420,14 @@ func (s *Span) Annotate(a SpanAnnotations) {
 			log.Warn("llmobs: agent manifest can only be annotated on agent spans, ignoring")
 		} else {
 			s.llmCtx.agentManifest = a.AgentManifest
+		}
+	}
+
+	if a.AgentVersion != "" {
+		if s.spanKind != SpanKindAgent {
+			log.Warn("llmobs: agent version can only be annotated on agent spans, ignoring")
+		} else {
+			s.llmCtx.tags = updateMapKeys(s.llmCtx.tags, map[string]string{TagKeyAgentVersion: a.AgentVersion})
 		}
 	}
 

--- a/llmobs/option.go
+++ b/llmobs/option.go
@@ -96,6 +96,15 @@ func WithIntegration(integration string) StartSpanOption {
 	}
 }
 
+// WithAgentVersion sets the user-supplied version of the agent, recorded as an
+// agent_version tag on the agent span itself and not on its children.
+// Only applicable to agent spans; ignored with a warning on any other span kind.
+func WithAgentVersion(version string) StartSpanOption {
+	return func(c *illmobs.StartSpanConfig) {
+		c.AgentVersion = version
+	}
+}
+
 // ------------- Finish options -------------
 
 // FinishSpanOption configures span finishing. Use with span.Finish().
@@ -194,6 +203,15 @@ func WithIntent(intent string) AnnotateOption {
 func WithAnnotatedIntent(intent string) AnnotateOption {
 	return func(a *illmobs.SpanAnnotations) {
 		a.Intent = intent
+	}
+}
+
+// WithAnnotatedAgentVersion sets the user-supplied version of the agent, recorded as an
+// agent_version tag on the agent span itself and not on its children.
+// Only applicable to agent spans; ignored with a warning on any other span kind.
+func WithAnnotatedAgentVersion(version string) AnnotateOption {
+	return func(a *illmobs.SpanAnnotations) {
+		a.AgentVersion = version
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds manual agent versioning to the LLM Observability SDK, porting the Python support from https://github.com/DataDog/dd-trace-py/pull/19490.

A user-supplied version can now be attached to an agent span at start or via annotation:

```go
// at span start
span, ctx := llmobs.StartAgentSpan(ctx, "my_agent", llmobs.WithAgentVersion("v3"))

// or later, via annotation
span.Annotate(llmobs.WithAnnotatedAgentVersion("v3"))
```

Both emit a single `agent_version` span tag, **on agent spans only** — never on their children. This matches the Python tag name and semantics exactly, so the backend rollups work identically across SDKs.

Implementation notes:

- Because span kind in Go is fixed at start by the typed constructors (unlike Python/Node, where kind can still change at finish), the tag is written directly at both entry points behind a kind check — no deferred materialization is needed.
- A version supplied on a non-agent span is dropped with a `log.Warn`, modeled exactly on the existing `AgentManifest` gate in `Annotate`.
- Public surface is two options (`WithAgentVersion` as a `StartSpanOption`, `WithAnnotatedAgentVersion` as an `AnnotateOption`); the internal plumbing is `StartSpanConfig.AgentVersion` / `SpanAnnotations.AgentVersion` and the new `TagKeyAgentVersion` constant.
- Go has no `annotationContext` equivalent, so that surface (present in the Python and Node PRs) has no counterpart here.

### Motivation

Part of the Agent Tracking work (M6). Users need to correlate agent behavior, cost, and evaluation results with the specific version of the agent that produced them. dd-trace-py shipped this in #19490; this brings Go to parity. A companion Node.js PR is open against dd-trace-js.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Four new subtests in `TestSpanAnnotate` cover the config path, the annotation path, annotation-overrides-config precedence, and the non-agent drop.

Claude session: `f18b59fb-588d-4ea7-a2bd-752e23d7b426`
Resume: `claude --resume f18b59fb-588d-4ea7-a2bd-752e23d7b426`
