### PR TITLE
fix(civisibility): report parallel test active and wait timing

### DIFF
--- a/internal/civisibility/constants/test_tags.go
+++ b/internal/civisibility/constants/test_tags.go
@@ -34,6 +34,24 @@ const (
 	// This constant is used to tag traces with the execution status of the test.
 	TestStatus = "test.status"
 
+	// TestActiveDuration is the observed test-body duration, excluding the
+	// duration-excluded interval around testing.T.Parallel.
+	TestActiveDuration = "test.active_duration"
+
+	// TestIsParallel indicates whether the test entered Go's parallel scheduler.
+	TestIsParallel = "test.is_parallel"
+
+	// TestParallelPauseStartOffset is the start of the duration-excluded
+	// testing.T.Parallel interval relative to the test event start.
+	TestParallelPauseStartOffset = "test.parallel.pause.start_offset"
+
+	// TestParallelPauseEndOffset is the end of the duration-excluded
+	// testing.T.Parallel interval relative to the test event start.
+	TestParallelPauseEndOffset = "test.parallel.pause.end_offset"
+
+	// TestParallelPauseDuration is the duration-excluded testing.T.Parallel interval.
+	TestParallelPauseDuration = "test.parallel.pause.duration"
+
 	// TestFinalStatus indicates the final adjusted status for a test after considering retries.
 	// This constant is used to tag the final execution span with the overall test result.
 	TestFinalStatus = "test.final_status"

--- a/internal/civisibility/constants/test_tags.go
+++ b/internal/civisibility/constants/test_tags.go
@@ -34,22 +34,23 @@ const (
 	// This constant is used to tag traces with the execution status of the test.
 	TestStatus = "test.status"
 
-	// TestActiveDuration is the observed test-body duration, excluding the
-	// duration-excluded interval around testing.T.Parallel.
+	// TestActiveDuration is the observed active test execution duration. For
+	// parallel tests, it excludes the native scheduler wait in testing.T.Parallel.
 	TestActiveDuration = "test.active_duration"
 
-	// TestIsParallel indicates whether the test entered Go's parallel scheduler.
+	// TestIsParallel indicates whether the test called testing.T.Parallel.
 	TestIsParallel = "test.is_parallel"
 
-	// TestParallelPauseStartOffset is the start of the duration-excluded
-	// testing.T.Parallel interval relative to the test event start.
+	// TestParallelPauseStartOffset is the projected start of the native parallel
+	// scheduler wait relative to the test event start.
 	TestParallelPauseStartOffset = "test.parallel.pause.start_offset"
 
-	// TestParallelPauseEndOffset is the end of the duration-excluded
-	// testing.T.Parallel interval relative to the test event start.
+	// TestParallelPauseEndOffset is the projected end of the native parallel
+	// scheduler wait relative to the test event start.
 	TestParallelPauseEndOffset = "test.parallel.pause.end_offset"
 
-	// TestParallelPauseDuration is the duration-excluded testing.T.Parallel interval.
+	// TestParallelPauseDuration is the native parallel scheduler wait excluded
+	// from TestActiveDuration.
 	TestParallelPauseDuration = "test.parallel.pause.duration"
 
 	// TestFinalStatus indicates the final adjusted status for a test after considering retries.

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -78,7 +78,7 @@ type (
 		isFreshRetryAttemptDescendant bool
 		suppressCoverageCollection    bool
 		suppressUserTestBody          bool
-		retryAttemptFinalizer         func(retryAttemptResult)
+		retryAttemptFinalizer         func(*retryAttemptResult, bool)
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState
@@ -87,6 +87,7 @@ type (
 		processRetryManagedDescendant bool
 		processRetryParallelPause     func() func()
 		processRetryParallelPaused    atomic.Bool
+		parallelTiming                *parallelTimingState
 	}
 
 	// runTestWithRetryOptions contains the options for calling runTestWithRetry function

--- a/internal/civisibility/integrations/gotesting/instrumentation.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation.go
@@ -78,7 +78,8 @@ type (
 		isFreshRetryAttemptDescendant bool
 		suppressCoverageCollection    bool
 		suppressUserTestBody          bool
-		retryAttemptFinalizer         func(*retryAttemptResult, bool)
+		retryAttemptTiming            testExecutionTiming
+		retryAttemptFinalizer         func(retryAttemptResult)
 		deferredRetryEvent            *deferredProcessRetryEvent
 		quarantinedRaceProcess        *quarantinedRaceProcessContext
 		quarantinedRaceChild          *quarantinedRaceChildState

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -125,10 +125,14 @@ func instrumentTestingBuiltWithOrchestrion() {
 //
 //go:linkname instrumentTestingTFunc
 func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
-	return instrumentTestingTFuncWithOptions(f, false)
+	return instrumentTestingTFuncWithParallelTiming(f, false)
 }
 
-func instrumentTestingTFuncWithOptions(f func(*testing.T), captureParallelBaseline bool) func(*testing.T) {
+func instrumentTestingTFuncWithParallelBaseline(f func(*testing.T)) func(*testing.T) {
+	return instrumentTestingTFuncWithParallelTiming(f, true)
+}
+
+func instrumentTestingTFuncWithParallelTiming(f func(*testing.T), captureParallelBaseline bool) func(*testing.T) {
 	release, ok := acquireOrchestrionTestingHook()
 	if !ok {
 		return f
@@ -415,11 +419,10 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 		return
 	}
 
-	// Record the skip once; the wrapper finalizer closes the event.
+	// Leave event closure to the finalizer so it can write timing tags.
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
 		log.Debug("instrumentCloseAndSkip: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), skipReason)
-		// Keep Close in the finalizer so it can write timing tags first.
 		ciTestItem.skipReason = skipReason
 		if !ciTestItem.hasAdditionalFeatureWrapper {
 			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
@@ -446,14 +449,13 @@ func instrumentSkipNow(tb testing.TB) {
 		return
 	}
 
-	// Record the skip once; the wrapper finalizer closes the event.
+	// Leave event closure to the finalizer so it can write timing tags.
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
 		if formatted := ciTestItem.processRetrySkipReason.Load(); formatted != nil {
 			ciTestItem.skipReason = *formatted
 		}
 		log.Debug("instrumentSkipNow: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), ciTestItem.skipReason)
-		// Keep Close in the finalizer so it can write timing tags first.
 		if !ciTestItem.hasAdditionalFeatureWrapper {
 			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
 		}

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -398,7 +398,8 @@ func instrumentSetErrorInfo(tb testing.TB, errType string, errMessage string, sk
 	}
 }
 
-// instrumentCloseAndSkip helper function to close and skip with a reason a `*testing.T, *testing.B, *testing.common` CI Visibility span
+// instrumentCloseAndSkip records a skip reason for the CI Visibility event
+// associated with a *testing.T, *testing.B, or *testing.common.
 //
 //go:linkname instrumentCloseAndSkip
 func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
@@ -420,11 +421,11 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 		return
 	}
 
-	// Get the CI Visibility span and check if we can mark it as skipped and close it
+	// Record the skip once; the wrapper finalizer closes the event.
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
 		log.Debug("instrumentCloseAndSkip: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), skipReason)
-		// The wrapper finalizer owns Close so timing tags can be written first.
+		// Keep Close in the finalizer so it can write timing tags first.
 		ciTestItem.skipReason = skipReason
 		if !ciTestItem.hasAdditionalFeatureWrapper {
 			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
@@ -432,7 +433,8 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	}
 }
 
-// instrumentSkipNow helper function to close and skip a `*testing.T, *testing.B, *testing.common` CI Visibility span
+// instrumentSkipNow records a skip when the hook receives no reason argument.
+// It preserves any reason captured earlier for the CI Visibility event.
 //
 //go:linkname instrumentSkipNow
 func instrumentSkipNow(tb testing.TB) {
@@ -450,14 +452,14 @@ func instrumentSkipNow(tb testing.TB) {
 		return
 	}
 
-	// Get the CI Visibility span and check if we can mark it as skipped and close it
+	// Record the skip once; the wrapper finalizer closes the event.
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
 		if formatted := ciTestItem.processRetrySkipReason.Load(); formatted != nil {
 			ciTestItem.skipReason = *formatted
 		}
 		log.Debug("instrumentSkipNow: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), ciTestItem.skipReason)
-		// The wrapper finalizer owns Close so timing tags can be written first.
+		// Keep Close in the finalizer so it can write timing tags first.
 		if !ciTestItem.hasAdditionalFeatureWrapper {
 			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
 		}
@@ -708,9 +710,10 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 	return nil
 }
 
-// instrumentTestingParallel reports whether CI Visibility has replaced the
-// native Parallel implementation. Only an isolated quarantined race subtree
-// takes ownership; every other call keeps the existing native fast path.
+// instrumentTestingParallel captures the timing baseline and reports whether CI
+// Visibility has replaced the native Parallel implementation. Only an isolated
+// quarantined race subtree takes ownership; every other call returns false so
+// the native implementation runs.
 //
 //go:linkname instrumentTestingParallel
 func instrumentTestingParallel(t *testing.T) bool {

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -286,15 +286,9 @@ func instrumentTestingTFuncWithOptions(f func(*testing.T), captureParallelBaseli
 					if bodyTerminal != nil {
 						bodyStack = utils.GetStacktrace(1)
 					}
-					execMeta.retryAttemptFinalizer = func(result *retryAttemptResult, finalize bool) {
-						if result == nil {
-							return
-						}
-						if !finalize {
-							result.timing = timing
-							return
-						}
-						applyTestExecutionTiming(test, timing)
+					execMeta.retryAttemptTiming = timing
+					execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
+						reportTestExecutionTiming(test, result.timing)
 						terminal := bodyTerminal
 						terminalStack := bodyStack
 						if result.panicData != nil {
@@ -305,7 +299,7 @@ func instrumentTestingTFuncWithOptions(f func(*testing.T), captureParallelBaseli
 							terminal = result.cleanupPanicData
 							terminalStack = string(result.cleanupPanicStack)
 						}
-						logFreshRetryAttemptState("finalize_orchestrion", currentT, *result)
+						logFreshRetryAttemptState("finalize_orchestrion", currentT, result)
 						finalizeInstrumentedTestExecution(currentT, execMeta, test, suite, module, result.duration, result.output, terminal, terminalStack, false)
 					}
 					if r != nil {
@@ -315,7 +309,7 @@ func instrumentTestingTFuncWithOptions(f func(*testing.T), captureParallelBaseli
 				}
 
 				unexpectedTermination := r == nil && processRetryUnexpectedTestTermination(currentT, bodyReturned)
-				applyTestExecutionTiming(test, timing)
+				reportTestExecutionTiming(test, timing)
 				policyBodyDuration := bodyDuration
 				if timing.activeDurationOK {
 					policyBodyDuration = timing.activeDuration

--- a/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
+++ b/internal/civisibility/integrations/gotesting/instrumentation_orchestrion.go
@@ -125,6 +125,10 @@ func instrumentTestingBuiltWithOrchestrion() {
 //
 //go:linkname instrumentTestingTFunc
 func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
+	return instrumentTestingTFuncWithOptions(f, false)
+}
+
+func instrumentTestingTFuncWithOptions(f func(*testing.T), captureParallelBaseline bool) func(*testing.T) {
 	release, ok := acquireOrchestrionTestingHook()
 	if !ok {
 		return f
@@ -224,6 +228,11 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 			module := session.GetOrCreateModule(moduleName)
 			suite := module.GetOrCreateSuite(suiteName)
 			test := suite.CreateTest(currentT.Name())
+			initializeTestExecutionTiming(test)
+			parallelBaseline := parallelTimingBaseline{}
+			if captureParallelBaseline {
+				parallelBaseline = captureParallelTimingBaseline(currentT)
+			}
 			startTime := time.Now()
 
 			if testifyData != nil {
@@ -262,7 +271,14 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 			bodyReturned := false
 			defer func() {
 				r := recover()
-				bodyDuration := time.Since(startTime)
+				bodyEnd := time.Now()
+				bodyDuration := bodyEnd.Sub(startTime)
+				var timing testExecutionTiming
+				if captureParallelBaseline {
+					timing = observeTestExecutionTiming(currentT, execMeta, parallelBaseline, bodyDuration, bodyEnd)
+				} else {
+					timing = observeHookedTestExecutionTiming(currentT, execMeta, bodyDuration, bodyEnd)
+				}
 
 				if execMeta.usesFreshRetryAttemptRuntime {
 					bodyTerminal := r
@@ -270,7 +286,15 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 					if bodyTerminal != nil {
 						bodyStack = utils.GetStacktrace(1)
 					}
-					execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
+					execMeta.retryAttemptFinalizer = func(result *retryAttemptResult, finalize bool) {
+						if result == nil {
+							return
+						}
+						if !finalize {
+							result.timing = timing
+							return
+						}
+						applyTestExecutionTiming(test, timing)
 						terminal := bodyTerminal
 						terminalStack := bodyStack
 						if result.panicData != nil {
@@ -281,7 +305,7 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 							terminal = result.cleanupPanicData
 							terminalStack = string(result.cleanupPanicStack)
 						}
-						logFreshRetryAttemptState("finalize_orchestrion", currentT, result)
+						logFreshRetryAttemptState("finalize_orchestrion", currentT, *result)
 						finalizeInstrumentedTestExecution(currentT, execMeta, test, suite, module, result.duration, result.output, terminal, terminalStack, false)
 					}
 					if r != nil {
@@ -291,7 +315,12 @@ func instrumentTestingTFunc(f func(*testing.T)) func(*testing.T) {
 				}
 
 				unexpectedTermination := r == nil && processRetryUnexpectedTestTermination(currentT, bodyReturned)
-				duration := runAndApplyTestCleanupWithDuration(currentT, execMeta, bodyDuration)
+				applyTestExecutionTiming(test, timing)
+				policyBodyDuration := bodyDuration
+				if timing.activeDurationOK {
+					policyBodyDuration = timing.activeDuration
+				}
+				duration := runAndApplyTestCleanupWithDuration(currentT, execMeta, policyBodyDuration)
 				if unexpectedTermination {
 					r = unexpectedTestTerminationMessage
 				}
@@ -395,16 +424,11 @@ func instrumentCloseAndSkip(tb testing.TB, skipReason string) {
 	ciTestItem := getTestMetadata(tb)
 	if ciTestItem != nil && ciTestItem.test != nil && ciTestItem.skipped.CompareAndSwap(0, 1) {
 		log.Debug("instrumentCloseAndSkip: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), skipReason)
-		// If there's an additional feature wrapper (retry/EFD), let the defer block handle closing
-		// so that test.final_status can be set properly. Store the skip reason for the defer block.
-		if ciTestItem.hasAdditionalFeatureWrapper {
-			ciTestItem.skipReason = skipReason
-			return
+		// The wrapper finalizer owns Close so timing tags can be written first.
+		ciTestItem.skipReason = skipReason
+		if !ciTestItem.hasAdditionalFeatureWrapper {
+			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
 		}
-		// For single-execution tests (no wrapper), this is the final execution.
-		// Set test.final_status before closing.
-		ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
-		ciTestItem.test.Close(integrations.ResultStatusSkip, integrations.WithTestSkipReason(skipReason))
 	}
 }
 
@@ -433,18 +457,9 @@ func instrumentSkipNow(tb testing.TB) {
 			ciTestItem.skipReason = *formatted
 		}
 		log.Debug("instrumentSkipNow: skipping test [name: %q, reason: %q]", ciTestItem.test.Name(), ciTestItem.skipReason)
-		// If there's an additional feature wrapper (retry/EFD), let the defer block handle closing
-		// so that test.final_status can be set properly.
-		if ciTestItem.hasAdditionalFeatureWrapper {
-			return
-		}
-		// For single-execution tests (no wrapper), this is the final execution.
-		// Set test.final_status before closing.
-		ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
-		if ciTestItem.skipReason != "" {
-			ciTestItem.test.Close(integrations.ResultStatusSkip, integrations.WithTestSkipReason(ciTestItem.skipReason))
-		} else {
-			ciTestItem.test.Close(integrations.ResultStatusSkip)
+		// The wrapper finalizer owns Close so timing tags can be written first.
+		if !ciTestItem.hasAdditionalFeatureWrapper {
+			ciTestItem.test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
 		}
 	}
 }
@@ -506,6 +521,7 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 		module := session.GetOrCreateModule(moduleName, integrations.WithTestModuleStartTime(startTime))
 		suite := module.GetOrCreateSuite(suiteName, integrations.WithTestSuiteStartTime(startTime))
 		test := suite.CreateTest(fmt.Sprintf("%s/%s", pb.Name(), name), integrations.WithTestStartTime(startTime))
+		initializeTestExecutionTiming(test)
 		test.SetTestFunc(originalFunc)
 
 		// Restore the original name without the sub-benchmark auto name.
@@ -516,6 +532,7 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 		// Run original benchmark.
 		var iPfOfB *benchmarkPrivateFields
 		var recoverFunc *func(r any)
+		var benchmarkSkipReason string
 		instrumentedFunc := func(b *testing.B) {
 			// Stop the timer to do the initialization and replacements.
 			b.StopTimer()
@@ -549,6 +566,7 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 				execMeta = createTestMetadata(b, nil)
 				defer deleteTestMetadata(b)
 			}
+			defer func() { benchmarkSkipReason = execMeta.skipReason }()
 
 			// Set the CI visibility test.
 			execMeta.test = test
@@ -565,6 +583,7 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 		b.Run(name, instrumentedFunc)
 
 		endTime := time.Now()
+		test.SetTag(constants.TestActiveDuration, max(endTime.Sub(startTime), 0).Nanoseconds())
 		results := iPfOfB.result
 
 		// Set benchmark data for CI visibility.
@@ -611,7 +630,12 @@ func instrumentTestingBFunc(pb *testing.B, name string, f func(*testing.B)) (str
 			module.SetTag(ext.Error, true)
 			test.Close(integrations.ResultStatusFail, integrations.WithTestFinishTime(endTime))
 		} else if iPfOfB.B.Skipped() {
-			test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
+			test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
+			if benchmarkSkipReason != "" {
+				test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime), integrations.WithTestSkipReason(benchmarkSkipReason))
+			} else {
+				test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
+			}
 		} else {
 			test.Close(integrations.ResultStatusPass, integrations.WithTestFinishTime(endTime))
 		}
@@ -690,6 +714,7 @@ func getTestOptimizationTest(tb testing.TB) integrations.Test {
 //
 //go:linkname instrumentTestingParallel
 func instrumentTestingParallel(t *testing.T) bool {
+	captureParallelTimingHook(t)
 	if !quarantinedRaceParallelHookActive {
 		return false
 	}

--- a/internal/civisibility/integrations/gotesting/parallel_timing.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing.go
@@ -22,17 +22,22 @@ const (
 	parallelWaitTag             = "test.parallel.wait"
 )
 
+// A non-nil parallelTimingState means the Parallel hook ran, even when the
+// runtime layout is unsupported and the baseline is invalid.
 type parallelTimingState struct {
 	baseline parallelTimingBaseline
 }
 
+// parallelTimingSample combines Go's native testing clock with the wrapper's
+// wall clock. T.Parallel records the pre-pause duration and resets the native
+// start time when the test resumes.
 type parallelTimingSample struct {
-	preDuration       time.Duration
-	baselineToResume  time.Duration
-	postResume        time.Duration
-	pauseClockValid   bool
-	wallProjectionEnd time.Time
-	wallProjectionOK  bool
+	durationBeforePause time.Duration
+	elapsedToResume     time.Duration
+	durationAfterResume time.Duration
+	pauseClockValid     bool
+	wallProjectionEnd   time.Time
+	wallProjectionOK    bool
 }
 
 type testExecutionTiming struct {
@@ -110,10 +115,10 @@ func observeTestExecutionTiming(
 
 func calculateTestExecutionTiming(bodyDuration time.Duration, sample parallelTimingSample) testExecutionTiming {
 	timing := testExecutionTiming{isParallel: true}
-	if !sample.pauseClockValid || sample.preDuration < 0 {
+	if !sample.pauseClockValid || sample.durationBeforePause < 0 {
 		return timing
 	}
-	pauseRaw := sample.baselineToResume - sample.preDuration
+	pauseRaw := sample.elapsedToResume - sample.durationBeforePause
 	if pauseRaw < -parallelTimingSkewTolerance {
 		return timing
 	}
@@ -124,16 +129,16 @@ func calculateTestExecutionTiming(bodyDuration time.Duration, sample parallelTim
 	timing.activeDuration = max(bodyDuration-pauseDuration, 0)
 	timing.activeDurationOK = true
 
-	if !sample.wallProjectionOK || sample.postResume < -parallelTimingSkewTolerance {
+	if !sample.wallProjectionOK || sample.durationAfterResume < -parallelTimingSkewTolerance {
 		return timing
 	}
-	timing.pauseEnd = sample.wallProjectionEnd.Add(-max(sample.postResume, 0))
+	timing.pauseEnd = sample.wallProjectionEnd.Add(-max(sample.durationAfterResume, 0))
 	timing.pauseStart = timing.pauseEnd.Add(-pauseDuration)
 	timing.pauseProjectionOK = !timing.pauseEnd.Before(timing.pauseStart)
 	return timing
 }
 
-func applyTestExecutionTiming(test integrations.Test, timing testExecutionTiming) {
+func reportTestExecutionTiming(test integrations.Test, timing testExecutionTiming) {
 	if test == nil {
 		return
 	}

--- a/internal/civisibility/integrations/gotesting/parallel_timing.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations"
+)
+
+const (
+	parallelTimingSkewTolerance = time.Millisecond
+	parallelWaitOperationName   = "testing.parallel.wait"
+	parallelWaitResourceName    = "testing.T.Parallel"
+	parallelWaitTag             = "test.parallel.wait"
+)
+
+type parallelTimingState struct {
+	baseline parallelTimingBaseline
+}
+
+type parallelTimingSample struct {
+	preDuration       time.Duration
+	baselineToResume  time.Duration
+	postResume        time.Duration
+	pauseClockValid   bool
+	wallProjectionEnd time.Time
+	wallProjectionOK  bool
+}
+
+type testExecutionTiming struct {
+	isParallel        bool
+	activeDuration    time.Duration
+	activeDurationOK  bool
+	pauseStart        time.Time
+	pauseEnd          time.Time
+	pauseProjectionOK bool
+}
+
+func initializeTestExecutionTiming(test integrations.Test) {
+	if test == nil {
+		return
+	}
+	test.SetTag(constants.TestActiveDuration, int64(0))
+	test.SetTag(constants.TestIsParallel, false)
+}
+
+func captureParallelTimingHook(t *testing.T) {
+	if t == nil {
+		return
+	}
+	execMeta := getTestMetadata(t)
+	if execMeta == nil || execMeta.parallelTiming != nil {
+		return
+	}
+	execMeta.parallelTiming = &parallelTimingState{baseline: captureParallelTimingBaseline(t)}
+}
+
+func observeHookedTestExecutionTiming(
+	t *testing.T,
+	execMeta *testExecutionMetadata,
+	bodyDuration time.Duration,
+	bodyEnd time.Time,
+) testExecutionTiming {
+	if execMeta == nil || execMeta.parallelTiming == nil {
+		return testExecutionTiming{activeDuration: max(bodyDuration, 0), activeDurationOK: true}
+	}
+	baseline := execMeta.parallelTiming.baseline
+	if !baseline.valid {
+		return testExecutionTiming{isParallel: true}
+	}
+	return calculateTestExecutionTiming(bodyDuration, sampleParallelTiming(t, baseline, bodyEnd))
+}
+
+func observeTestExecutionTiming(
+	t *testing.T,
+	execMeta *testExecutionMetadata,
+	fallback parallelTimingBaseline,
+	bodyDuration time.Duration,
+	bodyEnd time.Time,
+) testExecutionTiming {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || layout.disabled || !layout.parallelStateOK {
+		return testExecutionTiming{}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return testExecutionTiming{}
+	}
+	isParallel := *fieldPtr[bool](base, layout.common.isParallel)
+	if !isParallel {
+		return testExecutionTiming{activeDuration: max(bodyDuration, 0), activeDurationOK: true}
+	}
+	if !layout.parallelTimingOK {
+		return testExecutionTiming{isParallel: true}
+	}
+	baseline := fallback
+	if execMeta != nil && execMeta.parallelTiming != nil {
+		baseline = execMeta.parallelTiming.baseline
+	}
+	if !baseline.valid {
+		return testExecutionTiming{isParallel: true}
+	}
+	sample := sampleParallelTiming(t, baseline, bodyEnd)
+	return calculateTestExecutionTiming(bodyDuration, sample)
+}
+
+func calculateTestExecutionTiming(bodyDuration time.Duration, sample parallelTimingSample) testExecutionTiming {
+	timing := testExecutionTiming{isParallel: true}
+	if !sample.pauseClockValid || sample.preDuration < 0 {
+		return timing
+	}
+	pauseRaw := sample.baselineToResume - sample.preDuration
+	if pauseRaw < -parallelTimingSkewTolerance {
+		return timing
+	}
+	pauseDuration := max(pauseRaw, 0)
+	if pauseDuration > bodyDuration+parallelTimingSkewTolerance {
+		return timing
+	}
+	timing.activeDuration = max(bodyDuration-pauseDuration, 0)
+	timing.activeDurationOK = true
+
+	if !sample.wallProjectionOK || sample.postResume < -parallelTimingSkewTolerance {
+		return timing
+	}
+	timing.pauseEnd = sample.wallProjectionEnd.Add(-max(sample.postResume, 0))
+	timing.pauseStart = timing.pauseEnd.Add(-pauseDuration)
+	timing.pauseProjectionOK = !timing.pauseEnd.Before(timing.pauseStart)
+	return timing
+}
+
+func applyTestExecutionTiming(test integrations.Test, timing testExecutionTiming) {
+	if test == nil {
+		return
+	}
+	if timing.isParallel {
+		test.SetTag(constants.TestIsParallel, true)
+	}
+	if timing.activeDurationOK {
+		test.SetTag(constants.TestActiveDuration, timing.activeDuration.Nanoseconds())
+	}
+	if !timing.isParallel || !timing.pauseProjectionOK {
+		return
+	}
+
+	eventStart := test.StartTime()
+	startOffset := timing.pauseStart.Sub(eventStart)
+	endOffset := timing.pauseEnd.Sub(eventStart)
+	if eventStart.IsZero() || startOffset < -parallelTimingSkewTolerance || endOffset < startOffset {
+		return
+	}
+	startOffset = max(startOffset, 0)
+	endOffset = max(endOffset, startOffset)
+	test.SetTag(constants.TestParallelPauseStartOffset, startOffset.Nanoseconds())
+	test.SetTag(constants.TestParallelPauseEndOffset, endOffset.Nanoseconds())
+	test.SetTag(constants.TestParallelPauseDuration, (endOffset - startOffset).Nanoseconds())
+	emitParallelWaitSpan(test, eventStart.Add(startOffset), eventStart.Add(endOffset))
+}
+
+func emitParallelWaitSpan(test integrations.Test, start, finish time.Time) {
+	if test == nil || start.IsZero() || finish.Before(start) {
+		return
+	}
+	span, _ := tracer.StartSpanFromContext(
+		test.Context(),
+		parallelWaitOperationName,
+		tracer.ResourceName(parallelWaitResourceName),
+		tracer.StartTime(start),
+		tracer.Tag(ext.Component, "go-testing"),
+		tracer.Tag(parallelWaitTag, true),
+	)
+	if span != nil {
+		span.Finish(tracer.FinishTime(finish))
+	}
+}

--- a/internal/civisibility/integrations/gotesting/parallel_timing.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing.go
@@ -72,11 +72,7 @@ func observeHookedTestExecutionTiming(
 	if execMeta == nil || execMeta.parallelTiming == nil {
 		return testExecutionTiming{activeDuration: max(bodyDuration, 0), activeDurationOK: true}
 	}
-	baseline := execMeta.parallelTiming.baseline
-	if !baseline.valid {
-		return testExecutionTiming{isParallel: true}
-	}
-	return calculateTestExecutionTiming(bodyDuration, sampleParallelTiming(t, baseline, bodyEnd))
+	return observeTestExecutionTiming(t, execMeta, parallelTimingBaseline{}, bodyDuration, bodyEnd)
 }
 
 func observeTestExecutionTiming(

--- a/internal/civisibility/integrations/gotesting/parallel_timing.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing.go
@@ -22,8 +22,8 @@ const (
 	parallelWaitTag             = "test.parallel.wait"
 )
 
-// A non-nil parallelTimingState means the Parallel hook ran, even when the
-// runtime layout is unsupported and the baseline is invalid.
+// Keep the baseline out of testExecutionMetadata because only parallel tests
+// need it. A non-nil state also records that the hook ran with an invalid baseline.
 type parallelTimingState struct {
 	baseline parallelTimingBaseline
 }

--- a/internal/civisibility/integrations/gotesting/parallel_timing_other.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_other.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type parallelTimingBaseline struct {
+	now   time.Time
+	valid bool
+}
+
+func parallelTimeNowType() reflect.Type { return reflect.TypeFor[time.Time]() }
+
+func captureParallelTimingBaseline(t *testing.T) parallelTimingBaseline {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || !layout.parallelTimingOK {
+		return parallelTimingBaseline{}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return parallelTimingBaseline{}
+	}
+	return parallelTimingBaseline{
+		now:   *(*time.Time)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset)),
+		valid: true,
+	}
+}
+
+func sampleParallelTiming(t *testing.T, baseline parallelTimingBaseline, bodyEnd time.Time) parallelTimingSample {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || !layout.parallelTimingOK || !baseline.valid {
+		return parallelTimingSample{}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return parallelTimingSample{}
+	}
+	resumed := *(*time.Time)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset))
+	return parallelTimingSample{
+		preDuration:       *fieldPtr[time.Duration](base, layout.common.duration),
+		baselineToResume:  resumed.Sub(baseline.now),
+		postResume:        bodyEnd.Sub(resumed),
+		pauseClockValid:   true,
+		wallProjectionEnd: bodyEnd,
+		wallProjectionOK:  true,
+	}
+}

--- a/internal/civisibility/integrations/gotesting/parallel_timing_other.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_other.go
@@ -47,11 +47,11 @@ func sampleParallelTiming(t *testing.T, baseline parallelTimingBaseline, bodyEnd
 	}
 	resumed := *(*time.Time)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset))
 	return parallelTimingSample{
-		preDuration:       *fieldPtr[time.Duration](base, layout.common.duration),
-		baselineToResume:  resumed.Sub(baseline.now),
-		postResume:        bodyEnd.Sub(resumed),
-		pauseClockValid:   true,
-		wallProjectionEnd: bodyEnd,
-		wallProjectionOK:  true,
+		durationBeforePause: *fieldPtr[time.Duration](base, layout.common.duration),
+		elapsedToResume:     resumed.Sub(baseline.now),
+		durationAfterResume: bodyEnd.Sub(resumed),
+		pauseClockValid:     true,
+		wallProjectionEnd:   bodyEnd,
+		wallProjectionOK:    true,
 	}
 }

--- a/internal/civisibility/integrations/gotesting/parallel_timing_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_test.go
@@ -17,7 +17,14 @@ import (
 
 func exerciseParallelTiming(t *testing.T) {
 	t.Helper()
+	exerciseParallelTimingCalculation(t)
+	exerciseParallelTimingHookFallbacks(t)
+	exerciseParallelTimingReporting(t)
+	exerciseParallelTimingRetryPolicy(t)
+}
 
+func exerciseParallelTimingCalculation(t *testing.T) {
+	t.Helper()
 	wallEnd := time.Now()
 	timing := calculateTestExecutionTiming(20*time.Millisecond, parallelTimingSample{
 		durationBeforePause: 3 * time.Millisecond,
@@ -61,7 +68,48 @@ func exerciseParallelTiming(t *testing.T) {
 	require.True(t, invalidProjection.activeDurationOK)
 	require.Equal(t, 12*time.Millisecond, invalidProjection.activeDuration)
 	require.False(t, invalidProjection.pauseProjectionOK)
+}
 
+func exerciseParallelTimingHookFallbacks(t *testing.T) {
+	t.Helper()
+	hookedNonParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{}, 2*time.Millisecond, time.Time{})
+	require.False(t, hookedNonParallel.isParallel)
+	require.True(t, hookedNonParallel.activeDurationOK)
+	require.Equal(t, 2*time.Millisecond, hookedNonParallel.activeDuration)
+
+	var uncommitted testing.T
+	hookedUncommitted := observeHookedTestExecutionTiming(&uncommitted, &testExecutionMetadata{
+		parallelTiming: &parallelTimingState{},
+	}, 2*time.Millisecond, time.Time{})
+	require.False(t, hookedUncommitted.isParallel)
+	require.True(t, hookedUncommitted.activeDurationOK)
+	require.Equal(t, 2*time.Millisecond, hookedUncommitted.activeDuration)
+
+	hookedUnsupportedParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{
+		parallelTiming: &parallelTimingState{},
+	}, 2*time.Millisecond, time.Time{})
+	require.False(t, hookedUnsupportedParallel.isParallel)
+	require.False(t, hookedUnsupportedParallel.activeDurationOK)
+}
+
+func exerciseParallelTimingReporting(t *testing.T) {
+	t.Helper()
+	event := newProcessRetryRecordingTestForTesting("parallel-timing")
+	initializeTestExecutionTiming(event)
+	require.EqualValues(t, 0, event.tags[constants.TestActiveDuration])
+	require.Equal(t, false, event.tags[constants.TestIsParallel])
+	reportTestExecutionTiming(event, testExecutionTiming{
+		isParallel:       true,
+		activeDuration:   12 * time.Millisecond,
+		activeDurationOK: true,
+	})
+	require.EqualValues(t, (12 * time.Millisecond).Nanoseconds(), event.tags[constants.TestActiveDuration])
+	require.Equal(t, true, event.tags[constants.TestIsParallel])
+	require.NotContains(t, event.tags, constants.TestParallelPauseDuration)
+}
+
+func exerciseParallelTimingRetryPolicy(t *testing.T) {
+	t.Helper()
 	policyTiming := calculateTestExecutionTiming(6*time.Second, parallelTimingSample{
 		durationBeforePause: time.Second,
 		elapsedToResume:     3 * time.Second,
@@ -79,36 +127,6 @@ func exerciseParallelTiming(t *testing.T) {
 	require.EqualValues(t, 11, activeRetries)
 	require.EqualValues(t, 5, wallRetries)
 
-	hookedNonParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{}, 2*time.Millisecond, time.Time{})
-	require.False(t, hookedNonParallel.isParallel)
-	require.True(t, hookedNonParallel.activeDurationOK)
-	require.Equal(t, 2*time.Millisecond, hookedNonParallel.activeDuration)
-	var uncommitted testing.T
-	hookedUncommitted := observeHookedTestExecutionTiming(&uncommitted, &testExecutionMetadata{
-		parallelTiming: &parallelTimingState{},
-	}, 2*time.Millisecond, time.Time{})
-	require.False(t, hookedUncommitted.isParallel)
-	require.True(t, hookedUncommitted.activeDurationOK)
-	require.Equal(t, 2*time.Millisecond, hookedUncommitted.activeDuration)
-	hookedUnsupportedParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{
-		parallelTiming: &parallelTimingState{},
-	}, 2*time.Millisecond, time.Time{})
-	require.False(t, hookedUnsupportedParallel.isParallel)
-	require.False(t, hookedUnsupportedParallel.activeDurationOK)
-
-	event := newProcessRetryRecordingTestForTesting("parallel-timing")
-	initializeTestExecutionTiming(event)
-	require.EqualValues(t, 0, event.tags[constants.TestActiveDuration])
-	require.Equal(t, false, event.tags[constants.TestIsParallel])
-	reportTestExecutionTiming(event, testExecutionTiming{
-		isParallel:       true,
-		activeDuration:   12 * time.Millisecond,
-		activeDurationOK: true,
-	})
-	require.EqualValues(t, (12 * time.Millisecond).Nanoseconds(), event.tags[constants.TestActiveDuration])
-	require.Equal(t, true, event.tags[constants.TestIsParallel])
-	require.NotContains(t, event.tags, constants.TestParallelPauseDuration)
-
 	policyAttempt := processRetryAttemptResult{Result: processRetryResult{
 		DurationNanos: (7 * time.Second).Nanoseconds(),
 		DurationValid: true,
@@ -120,7 +138,6 @@ func exerciseParallelTiming(t *testing.T) {
 	policyDuration, ok = policyAttempt.Result.policyDuration()
 	require.False(t, ok)
 	require.Zero(t, policyDuration)
-
 }
 
 func BenchmarkParallelTimingBaselineCapture(b *testing.B) {
@@ -128,6 +145,18 @@ func BenchmarkParallelTimingBaselineCapture(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		_ = captureParallelTimingBaseline(&t)
+	}
+}
+
+func BenchmarkParallelTimingHookCapture(b *testing.B) {
+	var t testing.T
+	meta := createTestMetadata(&t, nil)
+	defer deleteTestMetadata(&t)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		meta.parallelTiming = nil
+		captureParallelTimingHook(&t)
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/parallel_timing_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_test.go
@@ -20,12 +20,12 @@ func exerciseParallelTiming(t *testing.T) {
 
 	wallEnd := time.Now()
 	timing := calculateTestExecutionTiming(20*time.Millisecond, parallelTimingSample{
-		preDuration:       3 * time.Millisecond,
-		baselineToResume:  11 * time.Millisecond,
-		postResume:        4 * time.Millisecond,
-		pauseClockValid:   true,
-		wallProjectionEnd: wallEnd,
-		wallProjectionOK:  true,
+		durationBeforePause: 3 * time.Millisecond,
+		elapsedToResume:     11 * time.Millisecond,
+		durationAfterResume: 4 * time.Millisecond,
+		pauseClockValid:     true,
+		wallProjectionEnd:   wallEnd,
+		wallProjectionOK:    true,
 	})
 	require.True(t, timing.isParallel)
 	require.True(t, timing.activeDurationOK)
@@ -36,36 +36,36 @@ func exerciseParallelTiming(t *testing.T) {
 	require.True(t, timing.pauseProjectionOK)
 
 	withinSkew := calculateTestExecutionTiming(time.Millisecond, parallelTimingSample{
-		preDuration:      time.Millisecond,
-		baselineToResume: time.Millisecond - parallelTimingSkewTolerance/2,
-		pauseClockValid:  true,
+		durationBeforePause: time.Millisecond,
+		elapsedToResume:     time.Millisecond - parallelTimingSkewTolerance/2,
+		pauseClockValid:     true,
 	})
 	require.True(t, withinSkew.activeDurationOK)
 	require.Equal(t, time.Millisecond, withinSkew.activeDuration)
 
 	invalidPause := calculateTestExecutionTiming(time.Millisecond, parallelTimingSample{
-		preDuration:      3 * time.Millisecond,
-		baselineToResume: time.Millisecond,
-		pauseClockValid:  true,
+		durationBeforePause: 3 * time.Millisecond,
+		elapsedToResume:     time.Millisecond,
+		pauseClockValid:     true,
 	})
 	require.False(t, invalidPause.activeDurationOK)
 	require.False(t, invalidPause.pauseProjectionOK)
 
 	invalidProjection := calculateTestExecutionTiming(20*time.Millisecond, parallelTimingSample{
-		preDuration:      3 * time.Millisecond,
-		baselineToResume: 11 * time.Millisecond,
-		postResume:       -2 * time.Millisecond,
-		pauseClockValid:  true,
-		wallProjectionOK: true,
+		durationBeforePause: 3 * time.Millisecond,
+		elapsedToResume:     11 * time.Millisecond,
+		durationAfterResume: -2 * time.Millisecond,
+		pauseClockValid:     true,
+		wallProjectionOK:    true,
 	})
 	require.True(t, invalidProjection.activeDurationOK)
 	require.Equal(t, 12*time.Millisecond, invalidProjection.activeDuration)
 	require.False(t, invalidProjection.pauseProjectionOK)
 
 	policyTiming := calculateTestExecutionTiming(6*time.Second, parallelTimingSample{
-		preDuration:      time.Second,
-		baselineToResume: 3 * time.Second,
-		pauseClockValid:  true,
+		durationBeforePause: time.Second,
+		elapsedToResume:     3 * time.Second,
+		pauseClockValid:     true,
 	})
 	require.True(t, policyTiming.activeDurationOK)
 	require.Equal(t, 4*time.Second, policyTiming.activeDuration)
@@ -100,7 +100,7 @@ func exerciseParallelTiming(t *testing.T) {
 	initializeTestExecutionTiming(event)
 	require.EqualValues(t, 0, event.tags[constants.TestActiveDuration])
 	require.Equal(t, false, event.tags[constants.TestIsParallel])
-	applyTestExecutionTiming(event, testExecutionTiming{
+	reportTestExecutionTiming(event, testExecutionTiming{
 		isParallel:       true,
 		activeDuration:   12 * time.Millisecond,
 		activeDurationOK: true,
@@ -113,11 +113,11 @@ func exerciseParallelTiming(t *testing.T) {
 		DurationNanos: (7 * time.Second).Nanoseconds(),
 		DurationValid: true,
 	}}
-	policyDuration, ok := processRetryPolicyDuration(policyAttempt)
+	policyDuration, ok := policyAttempt.Result.policyDuration()
 	require.True(t, ok)
 	require.Equal(t, 7*time.Second, policyDuration)
 	policyAttempt.Result.DurationValid = false
-	policyDuration, ok = processRetryPolicyDuration(policyAttempt)
+	policyDuration, ok = policyAttempt.Result.policyDuration()
 	require.False(t, ok)
 	require.Zero(t, policyDuration)
 

--- a/internal/civisibility/integrations/gotesting/parallel_timing_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	civisibilitynet "github.com/DataDog/dd-trace-go/v2/internal/civisibility/utils/net"
 )
 
 func exerciseParallelTiming(t *testing.T) {
@@ -59,6 +61,23 @@ func exerciseParallelTiming(t *testing.T) {
 	require.True(t, invalidProjection.activeDurationOK)
 	require.Equal(t, 12*time.Millisecond, invalidProjection.activeDuration)
 	require.False(t, invalidProjection.pauseProjectionOK)
+
+	policyTiming := calculateTestExecutionTiming(6*time.Second, parallelTimingSample{
+		preDuration:      time.Second,
+		baselineToResume: 3 * time.Second,
+		pauseClockValid:  true,
+	})
+	require.True(t, policyTiming.activeDurationOK)
+	require.Equal(t, 4*time.Second, policyTiming.activeDuration)
+	settings := &civisibilitynet.SettingsResponseData{}
+	settings.EarlyFlakeDetection.SlowTestRetries.FiveS = 11
+	settings.EarlyFlakeDetection.SlowTestRetries.TenS = 5
+	activeRetries, activeOK := efdRetryCountForDuration(settings, policyTiming.activeDuration)
+	wallRetries, wallOK := efdRetryCountForDuration(settings, 6*time.Second)
+	require.True(t, activeOK)
+	require.True(t, wallOK)
+	require.EqualValues(t, 11, activeRetries)
+	require.EqualValues(t, 5, wallRetries)
 
 	hookedNonParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{}, 2*time.Millisecond, time.Time{})
 	require.False(t, hookedNonParallel.isParallel)

--- a/internal/civisibility/integrations/gotesting/parallel_timing_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_test.go
@@ -83,10 +83,17 @@ func exerciseParallelTiming(t *testing.T) {
 	require.False(t, hookedNonParallel.isParallel)
 	require.True(t, hookedNonParallel.activeDurationOK)
 	require.Equal(t, 2*time.Millisecond, hookedNonParallel.activeDuration)
+	var uncommitted testing.T
+	hookedUncommitted := observeHookedTestExecutionTiming(&uncommitted, &testExecutionMetadata{
+		parallelTiming: &parallelTimingState{},
+	}, 2*time.Millisecond, time.Time{})
+	require.False(t, hookedUncommitted.isParallel)
+	require.True(t, hookedUncommitted.activeDurationOK)
+	require.Equal(t, 2*time.Millisecond, hookedUncommitted.activeDuration)
 	hookedUnsupportedParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{
 		parallelTiming: &parallelTimingState{},
 	}, 2*time.Millisecond, time.Time{})
-	require.True(t, hookedUnsupportedParallel.isParallel)
+	require.False(t, hookedUnsupportedParallel.isParallel)
 	require.False(t, hookedUnsupportedParallel.activeDurationOK)
 
 	event := newProcessRetryRecordingTestForTesting("parallel-timing")

--- a/internal/civisibility/integrations/gotesting/parallel_timing_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func exerciseParallelTiming(t *testing.T) {
+	t.Helper()
+
+	wallEnd := time.Now()
+	timing := calculateTestExecutionTiming(20*time.Millisecond, parallelTimingSample{
+		preDuration:       3 * time.Millisecond,
+		baselineToResume:  11 * time.Millisecond,
+		postResume:        4 * time.Millisecond,
+		pauseClockValid:   true,
+		wallProjectionEnd: wallEnd,
+		wallProjectionOK:  true,
+	})
+	require.True(t, timing.isParallel)
+	require.True(t, timing.activeDurationOK)
+	require.Equal(t, 12*time.Millisecond, timing.activeDuration)
+	require.Equal(t, wallEnd.Add(-4*time.Millisecond), timing.pauseEnd)
+	require.Equal(t, wallEnd.Add(-12*time.Millisecond), timing.pauseStart)
+	require.Equal(t, 8*time.Millisecond, timing.pauseEnd.Sub(timing.pauseStart))
+	require.True(t, timing.pauseProjectionOK)
+
+	withinSkew := calculateTestExecutionTiming(time.Millisecond, parallelTimingSample{
+		preDuration:      time.Millisecond,
+		baselineToResume: time.Millisecond - parallelTimingSkewTolerance/2,
+		pauseClockValid:  true,
+	})
+	require.True(t, withinSkew.activeDurationOK)
+	require.Equal(t, time.Millisecond, withinSkew.activeDuration)
+
+	invalidPause := calculateTestExecutionTiming(time.Millisecond, parallelTimingSample{
+		preDuration:      3 * time.Millisecond,
+		baselineToResume: time.Millisecond,
+		pauseClockValid:  true,
+	})
+	require.False(t, invalidPause.activeDurationOK)
+	require.False(t, invalidPause.pauseProjectionOK)
+
+	invalidProjection := calculateTestExecutionTiming(20*time.Millisecond, parallelTimingSample{
+		preDuration:      3 * time.Millisecond,
+		baselineToResume: 11 * time.Millisecond,
+		postResume:       -2 * time.Millisecond,
+		pauseClockValid:  true,
+		wallProjectionOK: true,
+	})
+	require.True(t, invalidProjection.activeDurationOK)
+	require.Equal(t, 12*time.Millisecond, invalidProjection.activeDuration)
+	require.False(t, invalidProjection.pauseProjectionOK)
+
+	hookedNonParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{}, 2*time.Millisecond, time.Time{})
+	require.False(t, hookedNonParallel.isParallel)
+	require.True(t, hookedNonParallel.activeDurationOK)
+	require.Equal(t, 2*time.Millisecond, hookedNonParallel.activeDuration)
+	hookedUnsupportedParallel := observeHookedTestExecutionTiming(nil, &testExecutionMetadata{
+		parallelTiming: &parallelTimingState{},
+	}, 2*time.Millisecond, time.Time{})
+	require.True(t, hookedUnsupportedParallel.isParallel)
+	require.False(t, hookedUnsupportedParallel.activeDurationOK)
+
+	event := newProcessRetryRecordingTestForTesting("parallel-timing")
+	initializeTestExecutionTiming(event)
+	require.EqualValues(t, 0, event.tags[constants.TestActiveDuration])
+	require.Equal(t, false, event.tags[constants.TestIsParallel])
+	applyTestExecutionTiming(event, testExecutionTiming{
+		isParallel:       true,
+		activeDuration:   12 * time.Millisecond,
+		activeDurationOK: true,
+	})
+	require.EqualValues(t, (12 * time.Millisecond).Nanoseconds(), event.tags[constants.TestActiveDuration])
+	require.Equal(t, true, event.tags[constants.TestIsParallel])
+	require.NotContains(t, event.tags, constants.TestParallelPauseDuration)
+
+	policyAttempt := processRetryAttemptResult{Result: processRetryResult{
+		DurationNanos: (7 * time.Second).Nanoseconds(),
+		DurationValid: true,
+	}}
+	policyDuration, ok := processRetryPolicyDuration(policyAttempt)
+	require.True(t, ok)
+	require.Equal(t, 7*time.Second, policyDuration)
+	policyAttempt.Result.DurationValid = false
+	policyDuration, ok = processRetryPolicyDuration(policyAttempt)
+	require.False(t, ok)
+	require.Zero(t, policyDuration)
+
+}
+
+func BenchmarkParallelTimingBaselineCapture(b *testing.B) {
+	var t testing.T
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = captureParallelTimingBaseline(&t)
+	}
+}
+
+func BenchmarkParallelTimingHookedNonParallel(b *testing.B) {
+	meta := &testExecutionMetadata{}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = observeHookedTestExecutionTiming(nil, meta, time.Nanosecond, time.Time{})
+	}
+}

--- a/internal/civisibility/integrations/gotesting/parallel_timing_windows.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_windows.go
@@ -1,0 +1,110 @@
+//go:build windows
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"math/bits"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type parallelTimingBaseline struct {
+	now   int64
+	valid bool
+}
+
+var (
+	parallelTimingFrequencyOnce sync.Once
+	parallelTimingFrequency     int64
+)
+
+func parallelTimeNowType() reflect.Type { return reflect.TypeFor[int64]() }
+
+func captureParallelTimingBaseline(t *testing.T) parallelTimingBaseline {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || !layout.parallelTimingOK {
+		return parallelTimingBaseline{}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return parallelTimingBaseline{}
+	}
+	return parallelTimingBaseline{
+		now:   *(*int64)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset)),
+		valid: true,
+	}
+}
+
+func sampleParallelTiming(t *testing.T, baseline parallelTimingBaseline, _ time.Time) parallelTimingSample {
+	layout := getTestingInternalsLayout()
+	if t == nil || layout == nil || !layout.parallelTimingOK || !baseline.valid {
+		return parallelTimingSample{}
+	}
+	base := commonBaseForTest(t, layout)
+	if base == nil {
+		return parallelTimingSample{}
+	}
+	resumed := *(*int64)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset))
+	frequency := getParallelTimingFrequency()
+	baselineToResume, baselineOK := parallelCounterDuration(resumed-baseline.now, frequency)
+	if !baselineOK {
+		return parallelTimingSample{}
+	}
+	sample := parallelTimingSample{
+		preDuration:      *fieldPtr[time.Duration](base, layout.common.duration),
+		baselineToResume: baselineToResume,
+		pauseClockValid:  true,
+	}
+	for range 2 {
+		before := time.Now()
+		counter, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
+		after := time.Now()
+		if !ok {
+			continue
+		}
+		postResume, ok := parallelCounterDuration(counter-resumed, frequency)
+		if !ok {
+			continue
+		}
+		sample.postResume = postResume
+		if after.Sub(before) <= parallelTimingSkewTolerance {
+			sample.wallProjectionEnd = before.Add(after.Sub(before) / 2)
+			sample.wallProjectionOK = true
+			break
+		}
+	}
+	return sample
+}
+
+func getParallelTimingFrequency() int64 {
+	parallelTimingFrequencyOnce.Do(func() {
+		frequency, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceFrequency)
+		if ok && frequency > 0 {
+			parallelTimingFrequency = frequency
+		}
+	})
+	return parallelTimingFrequency
+}
+
+func parallelCounterDuration(delta, frequency int64) (time.Duration, bool) {
+	if delta < 0 || frequency <= 0 {
+		return 0, false
+	}
+	hi, lo := bits.Mul64(uint64(delta), uint64(time.Second)/uint64(time.Nanosecond))
+	if hi >= uint64(frequency) {
+		return 0, false
+	}
+	nanos, _ := bits.Div64(hi, lo, uint64(frequency))
+	if nanos > uint64(^uint64(0)>>1) {
+		return 0, false
+	}
+	return time.Duration(nanos), true
+}

--- a/internal/civisibility/integrations/gotesting/parallel_timing_windows.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_windows.go
@@ -8,9 +8,7 @@
 package gotesting
 
 import (
-	"math/bits"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -20,11 +18,6 @@ type parallelTimingBaseline struct {
 	now   int64
 	valid bool
 }
-
-var (
-	parallelTimingFrequencyOnce sync.Once
-	parallelTimingFrequency     int64
-)
 
 func parallelTimeNowType() reflect.Type { return reflect.TypeFor[int64]() }
 
@@ -53,28 +46,30 @@ func sampleParallelTiming(t *testing.T, baseline parallelTimingBaseline, _ time.
 		return parallelTimingSample{}
 	}
 	resumed := *(*int64)(unsafe.Add(base, layout.common.start.offset+layout.parallelNow.offset))
-	frequency := getParallelTimingFrequency()
-	baselineToResume, baselineOK := parallelCounterDuration(resumed-baseline.now, frequency)
+	frequency := testingClockFrequency()
+	elapsedToResume, baselineOK := testingClockDuration(resumed-baseline.now, frequency)
 	if !baselineOK {
 		return parallelTimingSample{}
 	}
 	sample := parallelTimingSample{
-		preDuration:      *fieldPtr[time.Duration](base, layout.common.duration),
-		baselineToResume: baselineToResume,
-		pauseClockValid:  true,
+		durationBeforePause: *fieldPtr[time.Duration](base, layout.common.duration),
+		elapsedToResume:     elapsedToResume,
+		pauseClockValid:     true,
 	}
+	// QPC has no wall-clock epoch. Bracket the read with time.Now and use the
+	// midpoint when the bracket is tight; retry once if the goroutine was preempted.
 	for range 2 {
 		before := time.Now()
-		counter, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
+		counter, ok := testingClockNow()
 		after := time.Now()
 		if !ok {
 			continue
 		}
-		postResume, ok := parallelCounterDuration(counter-resumed, frequency)
+		durationAfterResume, ok := testingClockDuration(counter-resumed, frequency)
 		if !ok {
 			continue
 		}
-		sample.postResume = postResume
+		sample.durationAfterResume = durationAfterResume
 		if after.Sub(before) <= parallelTimingSkewTolerance {
 			sample.wallProjectionEnd = before.Add(after.Sub(before) / 2)
 			sample.wallProjectionOK = true
@@ -82,29 +77,4 @@ func sampleParallelTiming(t *testing.T, baseline parallelTimingBaseline, _ time.
 		}
 	}
 	return sample
-}
-
-func getParallelTimingFrequency() int64 {
-	parallelTimingFrequencyOnce.Do(func() {
-		frequency, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceFrequency)
-		if ok && frequency > 0 {
-			parallelTimingFrequency = frequency
-		}
-	})
-	return parallelTimingFrequency
-}
-
-func parallelCounterDuration(delta, frequency int64) (time.Duration, bool) {
-	if delta < 0 || frequency <= 0 {
-		return 0, false
-	}
-	hi, lo := bits.Mul64(uint64(delta), uint64(time.Second)/uint64(time.Nanosecond))
-	if hi >= uint64(frequency) {
-		return 0, false
-	}
-	nanos, _ := bits.Div64(hi, lo, uint64(frequency))
-	if nanos > uint64(^uint64(0)>>1) {
-		return 0, false
-	}
-	return time.Duration(nanos), true
 }

--- a/internal/civisibility/integrations/gotesting/parallel_timing_windows_test.go
+++ b/internal/civisibility/integrations/gotesting/parallel_timing_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestParallelCounterDuration(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		delta     int64
+		frequency int64
+		want      time.Duration
+		ok        bool
+	}{
+		{name: "exact", delta: 10, frequency: 10, want: time.Second, ok: true},
+		{name: "fractional", delta: 1, frequency: 3, want: 333333333 * time.Nanosecond, ok: true},
+		{name: "negative delta", delta: -1, frequency: 1},
+		{name: "zero frequency", delta: 1, frequency: 0},
+		{name: "overflow", delta: math.MaxInt64, frequency: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parallelCounterDuration(tc.delta, tc.frequency)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("parallelCounterDuration(%d, %d) = (%v, %t), want (%v, %t)", tc.delta, tc.frequency, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/civisibility/integrations/gotesting/quarantine_process.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process.go
@@ -1160,8 +1160,7 @@ func validateProcessRetrySubtreeResultEnvelope(result processRetryResult, expect
 		!processRetryJSONStringFits(result.SuiteName, processRetryErrorMessageMaxBytes) {
 		return fmt.Errorf("%w: invalid subtree root identity", errProcessRetryResultInvalid)
 	}
-	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano ||
-		result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
+	if result.StartUnixNano == 0 || result.FinishUnixNano < result.StartUnixNano {
 		return fmt.Errorf("%w: invalid subtree root timing (%d,%d,%d)", errProcessRetryResultInvalid, result.StartUnixNano, result.FinishUnixNano, result.DurationNanos)
 	}
 	if result.OutputTruncated && result.OutputTail == "" {

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -668,6 +668,9 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 		MRunEpoch: 1, InvocationOrdinal: 1, Subtree: cfg,
 	}
 	require.NoError(t, validateProcessRetryResult(valid, expected))
+	independentPolicyDuration := valid
+	independentPolicyDuration.DurationNanos = 3
+	require.NoError(t, validateProcessRetryResult(independentPolicyDuration, expected))
 
 	missingIdentity := valid
 	missingIdentity.ModuleName = ""

--- a/internal/civisibility/integrations/gotesting/quarantine_process_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_test.go
@@ -520,8 +520,8 @@ func TestQuarantinedRaceAggregatePayloadFitsWireLimit(t *testing.T) {
 				},
 			}
 			result := processRetryResult{
-				Version: 1, TestName: root, ModuleName: "module", SuiteName: "suite", Attempt: 1, RetryReason: processRetrySubtreeReason,
-				Status: processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, Failed: true,
+				Version: processRetryResultVersion, TestName: root, ModuleName: "module", SuiteName: "suite", Attempt: 1, RetryReason: processRetrySubtreeReason,
+				Status: processRetryStatusFail, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, DurationValid: true, Failed: true,
 				Subtests: make([]processRetrySubtreeResult, tt.count),
 			}
 			for idx := range result.Subtests {
@@ -552,8 +552,8 @@ func TestQuarantinedRaceAggregatePayloadFitsWireLimit(t *testing.T) {
 func TestQuarantinedRaceSmallPayloadSerializationIsUnchanged(t *testing.T) {
 	resultPath := filepath.Join(t.TempDir(), "result.json")
 	result := processRetryResult{
-		Version: 1, TestName: "TestSmall/root", Attempt: 1, RetryReason: processRetrySubtreeReason,
-		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		Version: processRetryResultVersion, TestName: "TestSmall/root", Attempt: 1, RetryReason: processRetrySubtreeReason,
+		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, DurationValid: true,
 		Subtests: []processRetrySubtreeResult{{
 			TestName: "TestSmall/root/child", Status: processRetryStatusPass,
 			StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
@@ -579,8 +579,8 @@ func TestQuarantinedRaceUnrepresentableCoreWritesExplicitResult(t *testing.T) {
 		},
 	}
 	result := processRetryResult{
-		Version: 1, TestName: root, Attempt: 1, RetryReason: processRetrySubtreeReason,
-		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
+		Version: processRetryResultVersion, TestName: root, Attempt: 1, RetryReason: processRetrySubtreeReason,
+		Status: processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1, DurationValid: true,
 		Subtests: []processRetrySubtreeResult{{
 			TestName: root + "/" + strings.Repeat("x", processRetrySubtreeWireMaxBytes),
 			Status:   processRetryStatusPass, StartUnixNano: 1, FinishUnixNano: 2, DurationNanos: 1,
@@ -639,7 +639,7 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 	}
 	now := time.Now().UnixNano()
 	valid := processRetryResult{
-		Version:           1,
+		Version:           processRetryResultVersion,
 		TestName:          cfg.SelectedRoot,
 		ModuleName:        "module",
 		SuiteName:         "suite",
@@ -651,6 +651,7 @@ func TestQuarantinedRaceSubtreeResultValidationIsFailClosed(t *testing.T) {
 		StartUnixNano:     now,
 		FinishUnixNano:    now + 10,
 		DurationNanos:     10,
+		DurationValid:     true,
 		Subtests: []processRetrySubtreeResult{{
 			TestName:       "TestCheckout/card/visa",
 			ModuleName:     "module",

--- a/internal/civisibility/integrations/gotesting/reflection_offsets.go
+++ b/internal/civisibility/integrations/gotesting/reflection_offsets.go
@@ -146,6 +146,7 @@ type testingInternalsLayout struct {
 	outputWriter   outputWriterLayout
 	testState      testStateLayout
 	benchmark      benchmarkFieldsLayout
+	parallelNow    unsafeField
 
 	testFieldsOK      bool
 	parentFieldsOK    bool
@@ -157,6 +158,8 @@ type testingInternalsLayout struct {
 	testStateOK       bool
 	benchmarkFieldsOK bool
 	retryAttemptOK    bool
+	parallelStateOK   bool
+	parallelTimingOK  bool
 }
 
 var (
@@ -260,8 +263,20 @@ func buildTestingInternalsLayout(tType, bType reflect.Type) (layout *testingInte
 	l.buildContextMatcherLayout()
 	l.buildChattyPrinterLayout()
 	l.buildTestStateLayout()
+	l.buildParallelTimingLayout()
 	l.computeSectionFlags()
 	return l
+}
+
+func (l *testingInternalsLayout) buildParallelTimingLayout() {
+	start := l.common.start.unsafeField
+	if !start.available || start.typ.Kind() != reflect.Struct {
+		return
+	}
+	now, ok := exactField(start.typ, "now", parallelTimeNowType(), false)
+	if ok {
+		l.parallelNow = now
+	}
 }
 
 func (l *testingInternalsLayout) buildTestStateLayout() {
@@ -361,6 +376,10 @@ func (l *testingInternalsLayout) buildChattyPrinterLayout() {
 // helper wrappers read these flags directly instead of repeating compatibility
 // decisions in hot paths.
 func (l *testingInternalsLayout) computeSectionFlags() {
+	l.parallelStateOK = l.common.isParallel.available
+	l.parallelTimingOK = l.parallelStateOK && allAvailable(
+		l.common.start.unsafeField, l.common.duration, l.parallelNow,
+	)
 	l.testFieldsOK = allAvailable(
 		l.common.mu, l.common.output, l.common.level, l.common.name,
 		l.common.failed, l.common.skipped, l.common.parent.unsafeField, l.common.barrier,
@@ -399,7 +418,7 @@ func (l *testingInternalsLayout) computeSectionFlags() {
 		l.common.lastRaceErrors, l.common.raceErrorLogged,
 		l.common.tempDir, l.common.tempDirErr, l.common.tempDirSeq,
 		l.common.ctx, l.common.cancelCtx, l.tstate.unsafeField, l.denyParallel,
-	) && l.testStateOK
+	) && l.testStateOK && l.parallelTimingOK
 }
 
 func denyParallelField(owner reflect.Type) (unsafeField, bool) {

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -63,6 +63,8 @@ func TestGetFieldPointerFrom(t *testing.T) {
 		t.Fatal("Expected an error for non-existent field, got nil")
 	}
 
+	// These pure instrumentation assertions share an existing top-level test so
+	// the subprocess span-count scenarios do not gain extra test spans.
 	exerciseTestingInternalsOffsetLayout(t)
 	exerciseTestingInternalsCopyEquivalence(t)
 	exerciseTestingInternalsHelperMapIsolation(t)
@@ -70,8 +72,6 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	exerciseParallelTiming(t)
 	exerciseDenyParallelFieldCompatibility(t)
 	exerciseBenchmarkFuncInstrumentationConcurrentWrites(t)
-	// These pure instrumentation assertions run under this existing top-level test
-	// so the subprocess span-count scenarios do not gain extra test spans.
 	exerciseAdditionalFeaturePathSelection(t)
 	exerciseParallelEFDSelection(t)
 	exerciseMetadataOnlyPropagationSuppression(t)

--- a/internal/civisibility/integrations/gotesting/reflections_test.go
+++ b/internal/civisibility/integrations/gotesting/reflections_test.go
@@ -67,6 +67,7 @@ func TestGetFieldPointerFrom(t *testing.T) {
 	exerciseTestingInternalsCopyEquivalence(t)
 	exerciseTestingInternalsHelperMapIsolation(t)
 	exerciseTestingInternalsPrivatePointerAssignment(t)
+	exerciseParallelTiming(t)
 	exerciseDenyParallelFieldCompatibility(t)
 	exerciseBenchmarkFuncInstrumentationConcurrentWrites(t)
 	// These pure instrumentation assertions run under this existing top-level test
@@ -250,6 +251,15 @@ func exerciseTestingInternalsOffsetLayout(t *testing.T) {
 	if !layout.testFieldsOK || !layout.parentFieldsOK || !layout.copyTestOK || !layout.createTestOK || !layout.benchmarkFieldsOK {
 		testutils.SkipIfGoTip(t, "some fast-path sections unavailable (expected forward-compat drift): %+v", layout)
 		t.Fatalf("expected core layout sections to be enabled: %+v", layout)
+	}
+	if !layout.parallelStateOK || !layout.parallelTimingOK {
+		t.Fatalf("expected parallel timing layout to be enabled: %+v", layout)
+	}
+	parallelTimingDrift := buildTestingInternalsLayout(reflect.TypeFor[testing.T](), reflect.TypeFor[testing.B]())
+	parallelTimingDrift.parallelNow.available = false
+	parallelTimingDrift.computeSectionFlags()
+	if !parallelTimingDrift.parallelStateOK || parallelTimingDrift.parallelTimingOK || parallelTimingDrift.retryAttemptOK {
+		t.Fatal("nested clock drift must preserve parallel-state detection and disable timing-dependent paths")
 	}
 	if !layout.common.finished.available || !processRetryChildCleanupLayoutSupported(layout) {
 		t.Fatal("expected process retry child cleanup layout to include testing.common.finished")

--- a/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
@@ -133,17 +133,18 @@ func executeFreshRetryAttemptIteration(execOpts *executionOptions) bool {
 
 	complete := func(attempt *retryAttemptRoot, result retryAttemptResult) {
 		localT := attempt.test
+		if finalize := execMeta.retryAttemptFinalizer; finalize != nil {
+			finalize(&result, false)
+			defer func() {
+				execMeta.retryAttemptFinalizer = nil
+				defer completeDeferredProcessRetryEvent(execMeta)
+				finalize(&result, true)
+			}()
+		}
 		observation := observeFreshRetryAttempt(currentIndex, result)
 		observation.rootParallel = attempt.group.rootParallelWasObserved()
 		execOpts.lastObservation = observation
 		logFreshRetryAttemptState("complete", localT, result)
-		if finalize := execMeta.retryAttemptFinalizer; finalize != nil {
-			defer func() {
-				execMeta.retryAttemptFinalizer = nil
-				defer completeDeferredProcessRetryEvent(execMeta)
-				finalize(result)
-			}()
-		}
 		if execOpts.originalExecutionMetadata != nil {
 			execOpts.originalExecutionMetadata.test = execMeta.test
 		}

--- a/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_integration.go
@@ -134,11 +134,11 @@ func executeFreshRetryAttemptIteration(execOpts *executionOptions) bool {
 	complete := func(attempt *retryAttemptRoot, result retryAttemptResult) {
 		localT := attempt.test
 		if finalize := execMeta.retryAttemptFinalizer; finalize != nil {
-			finalize(&result, false)
+			result.timing = execMeta.retryAttemptTiming
 			defer func() {
 				execMeta.retryAttemptFinalizer = nil
 				defer completeDeferredProcessRetryEvent(execMeta)
-				finalize(&result, true)
+				finalize(result)
 			}()
 		}
 		observation := observeFreshRetryAttempt(currentIndex, result)

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner.go
@@ -91,6 +91,7 @@ type retryAttemptResult struct {
 	terminalTrace          []retryAttemptTerminal
 	output                 []byte
 	nativeOutput           []byte
+	timing                 testExecutionTiming
 }
 
 var errRetryAttemptNilPanicOrGoexit = errors.New("test executed panic(nil) or runtime.Goexit")

--- a/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_runner_test.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
@@ -31,10 +32,12 @@ func requireRetryAttemptParallelConflict(t *testing.T, panicData any) {
 }
 
 func TestProcessRetryParityFreshRunnerNormalLifecycle(t *testing.T) {
+	const cleanupDuration = 25 * time.Millisecond
 	var events []string
 	attempt, result, reason := runFreshRetryAttempt(t, func(local *testing.T) {
 		local.Cleanup(func() {
 			require.ErrorIs(t, local.Context().Err(), context.Canceled)
+			time.Sleep(cleanupDuration)
 			events = append(events, "cleanup-1")
 		})
 		local.Cleanup(func() { events = append(events, "cleanup-2") })
@@ -55,7 +58,7 @@ func TestProcessRetryParityFreshRunnerNormalLifecycle(t *testing.T) {
 	require.True(t, result.nativeSignalExecuted)
 	require.Equal(t, retryAttemptCompletionNormal, result.completionPhase)
 	require.Equal(t, retryAttemptNotFailed, result.failureCheckpointPhase)
-	require.Positive(t, result.duration)
+	require.GreaterOrEqual(t, result.duration, cleanupDuration)
 	require.Contains(t, string(result.output), "partial\n")
 }
 

--- a/internal/civisibility/integrations/gotesting/retry_attempt_time_other.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_time_other.go
@@ -8,32 +8,23 @@
 package gotesting
 
 import (
-	"reflect"
 	"time"
 	"unsafe"
 )
 
 func initializeRetryAttemptStart(base unsafe.Pointer, field unsafeField) {
-	if base == nil || !field.available {
+	layout := getTestingInternalsLayout()
+	if base == nil || !field.available || layout == nil || !layout.parallelTimingOK {
 		return
 	}
-	value := reflect.NewAt(field.typ, fieldRawPtr(base, field)).Elem()
-	now := value.FieldByName("now")
-	if now.IsValid() && now.CanAddr() && now.Type() == reflect.TypeFor[time.Time]() {
-		reflect.NewAt(now.Type(), unsafe.Pointer(now.UnsafeAddr())).Elem().Set(reflect.ValueOf(time.Now()))
-	}
+	*(*time.Time)(unsafe.Add(base, field.offset+layout.parallelNow.offset)) = time.Now()
 }
 
 func addRetryAttemptElapsed(base unsafe.Pointer, layout *testingInternalsLayout) {
 	field := layout.common.start.unsafeField
-	if base == nil || !field.available {
+	if base == nil || !field.available || !layout.parallelTimingOK {
 		return
 	}
-	value := reflect.NewAt(field.typ, fieldRawPtr(base, field)).Elem()
-	now := value.FieldByName("now")
-	if !now.IsValid() || !now.CanAddr() || now.Type() != reflect.TypeFor[time.Time]() {
-		return
-	}
-	started := reflect.NewAt(now.Type(), unsafe.Pointer(now.UnsafeAddr())).Elem().Interface().(time.Time)
+	started := *(*time.Time)(unsafe.Add(base, field.offset+layout.parallelNow.offset))
 	*fieldPtr[time.Duration](base, layout.common.duration) += time.Since(started)
 }

--- a/internal/civisibility/integrations/gotesting/retry_attempt_time_windows.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_time_windows.go
@@ -10,28 +10,14 @@ package gotesting
 import (
 	"time"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
-
-var (
-	retryAttemptKernel32                  = windows.NewLazySystemDLL("kernel32.dll")
-	retryAttemptQueryPerformanceCounter   = retryAttemptKernel32.NewProc("QueryPerformanceCounter")
-	retryAttemptQueryPerformanceFrequency = retryAttemptKernel32.NewProc("QueryPerformanceFrequency")
-)
-
-func retryAttemptPerformanceValue(proc *windows.LazyProc) (int64, bool) {
-	var value int64
-	ok, _, _ := proc.Call(uintptr(unsafe.Pointer(&value)))
-	return value, ok != 0
-}
 
 func initializeRetryAttemptStart(base unsafe.Pointer, field unsafeField) {
 	layout := getTestingInternalsLayout()
 	if base == nil || !field.available || layout == nil || !layout.parallelTimingOK {
 		return
 	}
-	counter, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
+	counter, ok := testingClockNow()
 	if !ok {
 		return
 	}
@@ -43,8 +29,8 @@ func addRetryAttemptElapsed(base unsafe.Pointer, layout *testingInternalsLayout)
 	if base == nil || !field.available || !layout.parallelTimingOK {
 		return
 	}
-	now, counterOK := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
-	frequency := getParallelTimingFrequency()
+	now, counterOK := testingClockNow()
+	frequency := testingClockFrequency()
 	if !counterOK || frequency <= 0 {
 		return
 	}
@@ -52,7 +38,7 @@ func addRetryAttemptElapsed(base unsafe.Pointer, layout *testingInternalsLayout)
 	if now <= started {
 		return
 	}
-	elapsed, ok := parallelCounterDuration(now-started, frequency)
+	elapsed, ok := testingClockDuration(now-started, frequency)
 	if !ok {
 		return
 	}

--- a/internal/civisibility/integrations/gotesting/retry_attempt_time_windows.go
+++ b/internal/civisibility/integrations/gotesting/retry_attempt_time_windows.go
@@ -8,8 +8,6 @@
 package gotesting
 
 import (
-	"math/bits"
-	"reflect"
 	"time"
 	"unsafe"
 
@@ -29,41 +27,34 @@ func retryAttemptPerformanceValue(proc *windows.LazyProc) (int64, bool) {
 }
 
 func initializeRetryAttemptStart(base unsafe.Pointer, field unsafeField) {
-	if base == nil || !field.available {
+	layout := getTestingInternalsLayout()
+	if base == nil || !field.available || layout == nil || !layout.parallelTimingOK {
 		return
 	}
 	counter, ok := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
 	if !ok {
 		return
 	}
-	value := reflect.NewAt(field.typ, fieldRawPtr(base, field)).Elem()
-	now := value.FieldByName("now")
-	if now.IsValid() && now.CanAddr() && now.Kind() == reflect.Int64 {
-		reflect.NewAt(now.Type(), unsafe.Pointer(now.UnsafeAddr())).Elem().SetInt(counter)
-	}
+	*(*int64)(unsafe.Add(base, field.offset+layout.parallelNow.offset)) = counter
 }
 
 func addRetryAttemptElapsed(base unsafe.Pointer, layout *testingInternalsLayout) {
 	field := layout.common.start.unsafeField
-	if base == nil || !field.available {
+	if base == nil || !field.available || !layout.parallelTimingOK {
 		return
 	}
 	now, counterOK := retryAttemptPerformanceValue(retryAttemptQueryPerformanceCounter)
-	frequency, frequencyOK := retryAttemptPerformanceValue(retryAttemptQueryPerformanceFrequency)
-	if !counterOK || !frequencyOK || frequency <= 0 {
+	frequency := getParallelTimingFrequency()
+	if !counterOK || frequency <= 0 {
 		return
 	}
-	value := reflect.NewAt(field.typ, fieldRawPtr(base, field)).Elem()
-	startedField := value.FieldByName("now")
-	if !startedField.IsValid() || !startedField.CanAddr() || startedField.Kind() != reflect.Int64 {
-		return
-	}
-	started := reflect.NewAt(startedField.Type(), unsafe.Pointer(startedField.UnsafeAddr())).Elem().Int()
+	started := *(*int64)(unsafe.Add(base, field.offset+layout.parallelNow.offset))
 	if now <= started {
 		return
 	}
-	hi, lo := bits.Mul64(uint64(now-started), uint64(time.Second)/uint64(time.Nanosecond))
-	elapsedNanoseconds, _ := bits.Div64(hi, lo, uint64(frequency))
-	elapsed := time.Duration(elapsedNanoseconds)
+	elapsed, ok := parallelCounterDuration(now-started, frequency)
+	if !ok {
+		return
+	}
 	*fieldPtr[time.Duration](base, layout.common.duration) += elapsed
 }

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -151,6 +151,10 @@ const (
 	processRetryDefaultTimeout             = 10 * time.Minute
 )
 
+// processRetryResult preserves three distinct clocks across the child-process
+// boundary: Start/Finish form the event's wall envelope; Duration is Go's
+// policy duration including cleanup; ObservedActiveDuration is the test body.
+// Both duration values exclude the T.Parallel scheduler wait.
 type processRetryResult struct {
 	Version                       int                                `json:"version"`
 	TestName                      string                             `json:"test_name"`
@@ -187,6 +191,71 @@ type processRetryResult struct {
 	SkippedByITR                  bool                               `json:"skipped_by_itr,omitempty"`
 	ITRForcedRun                  bool                               `json:"itr_forced_run,omitempty"`
 	Modified                      bool                               `json:"modified,omitempty"`
+}
+
+func (r *processRetryResult) policyDuration() (time.Duration, bool) {
+	if !r.DurationValid || r.DurationNanos < 0 {
+		return 0, false
+	}
+	return time.Duration(r.DurationNanos), true
+}
+
+func (r *processRetryResult) executionTiming(wallTimingValid bool, start, finish time.Time) testExecutionTiming {
+	timing := testExecutionTiming{isParallel: r.RootParallel}
+	if r.ObservedActiveDurationValid && r.ObservedActiveDurationNanos >= 0 {
+		timing.activeDuration = time.Duration(r.ObservedActiveDurationNanos)
+		timing.activeDurationOK = true
+	}
+	if !wallTimingValid || r.ParallelPauseStartOffsetNanos == nil || r.ParallelPauseEndOffsetNanos == nil {
+		return timing
+	}
+	startOffset := time.Duration(*r.ParallelPauseStartOffsetNanos)
+	endOffset := time.Duration(*r.ParallelPauseEndOffsetNanos)
+	if startOffset >= 0 && endOffset >= startOffset && endOffset <= finish.Sub(start) {
+		timing.pauseStart = start.Add(startOffset)
+		timing.pauseEnd = start.Add(endOffset)
+		timing.pauseProjectionOK = true
+	}
+	return timing
+}
+
+func (r *processRetryResult) setExecutionTiming(timing testExecutionTiming) {
+	r.ObservedActiveDurationNanos = timing.activeDuration.Nanoseconds()
+	r.ObservedActiveDurationValid = timing.activeDurationOK
+	if !timing.pauseProjectionOK {
+		return
+	}
+	startOffset := timing.pauseStart.UnixNano() - r.StartUnixNano
+	endOffset := timing.pauseEnd.UnixNano() - r.StartUnixNano
+	wallDuration := r.FinishUnixNano - r.StartUnixNano
+	if startOffset < 0 || endOffset < startOffset || endOffset > wallDuration {
+		return
+	}
+	r.ParallelPauseStartOffsetNanos = &startOffset
+	r.ParallelPauseEndOffsetNanos = &endOffset
+}
+
+func (r *processRetryResult) validateTiming() error {
+	if r.DurationNanos < 0 || (!r.DurationValid && r.DurationNanos != 0) ||
+		r.ObservedActiveDurationNanos < 0 || (!r.ObservedActiveDurationValid && r.ObservedActiveDurationNanos != 0) {
+		return fmt.Errorf("%w: invalid duration", errProcessRetryResultInvalid)
+	}
+	if (r.ParallelPauseStartOffsetNanos == nil) != (r.ParallelPauseEndOffsetNanos == nil) {
+		return fmt.Errorf("%w: incomplete parallel pause", errProcessRetryResultInvalid)
+	}
+	if r.ParallelPauseStartOffsetNanos == nil {
+		return nil
+	}
+	if !r.RootParallel {
+		return fmt.Errorf("%w: pause on non-parallel test", errProcessRetryResultInvalid)
+	}
+	startOffset := *r.ParallelPauseStartOffsetNanos
+	endOffset := *r.ParallelPauseEndOffsetNanos
+	wallDuration := r.FinishUnixNano - r.StartUnixNano
+	if r.StartUnixNano == 0 || r.FinishUnixNano == 0 || startOffset < 0 || endOffset < startOffset || wallDuration < 0 || endOffset > wallDuration {
+		return fmt.Errorf("%w: invalid parallel pause", errProcessRetryResultInvalid)
+	}
+	return nil
 }
 
 type processRetryErrorInfo struct {
@@ -872,7 +941,7 @@ type processRetryAttemptResult struct {
 	SetupFailure                bool
 	BodyAdmitted                bool
 	ControlledTerminalCommitted bool
-	ResultWallTimingValid       bool
+	WallTimingValid             bool
 	Cleanup                     func()
 	quarantinedRaceInvocations  []quarantinedRaceInvocation
 }
@@ -2059,7 +2128,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		attempt.Err = errors.Join(attempt.Err, resultErr)
 	} else {
 		attempt.Result = result
-		attempt.ResultWallTimingValid = timingOK
+		attempt.WallTimingValid = timingOK
 		if isProcessRetryControlledTerminalStatus(result.Status) && control != nil {
 			terminal, terminalTimedOut, terminalErr := control.controlledTerminalState(ctx, shutdown, attemptTimer.C())
 			applyProcessRetryControlledTerminalState(&attempt, terminal, terminalTimedOut, terminalErr)
@@ -2480,29 +2549,8 @@ func deferProcessRetryTestEventWithAdmission(
 	return effective, tail
 }
 
-func processRetryPolicyDuration(attempt processRetryAttemptResult) (time.Duration, bool) {
-	if !attempt.Result.DurationValid || attempt.Result.DurationNanos < 0 {
-		return 0, false
-	}
-	return time.Duration(attempt.Result.DurationNanos), true
-}
-
-func applyProcessRetryExecutionTiming(test integrations.Test, attempt processRetryAttemptResult) {
-	timing := testExecutionTiming{isParallel: attempt.Result.RootParallel}
-	if attempt.Result.ObservedActiveDurationValid && attempt.Result.ObservedActiveDurationNanos >= 0 {
-		timing.activeDuration = time.Duration(attempt.Result.ObservedActiveDurationNanos)
-		timing.activeDurationOK = true
-	}
-	if attempt.ResultWallTimingValid && attempt.Result.ParallelPauseStartOffsetNanos != nil && attempt.Result.ParallelPauseEndOffsetNanos != nil {
-		startOffset := time.Duration(*attempt.Result.ParallelPauseStartOffsetNanos)
-		endOffset := time.Duration(*attempt.Result.ParallelPauseEndOffsetNanos)
-		if startOffset >= 0 && endOffset >= startOffset && endOffset <= attempt.FinishTime.Sub(attempt.StartTime) {
-			timing.pauseStart = attempt.StartTime.Add(startOffset)
-			timing.pauseEnd = attempt.StartTime.Add(endOffset)
-			timing.pauseProjectionOK = true
-		}
-	}
-	applyTestExecutionTiming(test, timing)
+func reportProcessRetryExecutionTiming(test integrations.Test, attempt *processRetryAttemptResult) {
+	reportTestExecutionTiming(test, attempt.Result.executionTiming(attempt.WallTimingValid, attempt.StartTime, attempt.FinishTime))
 }
 
 func finishProcessRetryTestEvent(
@@ -2545,7 +2593,7 @@ func finishProcessRetryTestEvent(
 		}
 	}
 	execMeta.test = test
-	applyProcessRetryExecutionTiming(test, attempt)
+	reportProcessRetryExecutionTiming(test, &attempt)
 	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
 	// A validated process skip is already the outcome of the execution. In
@@ -2569,7 +2617,7 @@ func finishProcessRetryTestEvent(
 	if admitContinuation != nil {
 		admitContinuation(effective)
 	}
-	policyDuration, policyDurationOK := processRetryPolicyDuration(attempt)
+	policyDuration, policyDurationOK := attempt.Result.policyDuration()
 	if policyDurationOK && isAnEfdExecution(execMeta) && policyDuration >= 5*time.Minute {
 		test.SetTag(constants.TestEarlyFlakeDetectionRetryAborted, "slow")
 	}
@@ -3483,37 +3531,25 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 	}
 	rootParallel = rootParallel || o.result.timing.isParallel
 	result := processRetryResult{
-		Version:                     processRetryResultVersion,
-		TestName:                    o.cfg.TestName,
-		ModuleName:                  o.execMeta.identity.ModuleName,
-		SuiteName:                   o.execMeta.identity.SuiteName,
-		Attempt:                     o.cfg.Attempt,
-		RetryReason:                 o.cfg.RetryReason,
-		MRunEpoch:                   o.cfg.MRunEpoch,
-		InvocationOrdinal:           o.cfg.InvocationOrdinal,
-		StartUnixNano:               startUnixNano,
-		FinishUnixNano:              finishUnixNano,
-		DurationNanos:               o.result.duration.Nanoseconds(),
-		DurationValid:               o.result.duration >= 0,
-		ObservedActiveDurationNanos: o.result.timing.activeDuration.Nanoseconds(),
-		ObservedActiveDurationValid: o.result.timing.activeDurationOK,
-		Failed:                      failed,
-		Skipped:                     o.result.skipped,
-		Panic:                       panicData != nil,
-		RaceDetected:                o.result.raceDetected,
-		RootParallel:                rootParallel,
+		Version:           processRetryResultVersion,
+		TestName:          o.cfg.TestName,
+		ModuleName:        o.execMeta.identity.ModuleName,
+		SuiteName:         o.execMeta.identity.SuiteName,
+		Attempt:           o.cfg.Attempt,
+		RetryReason:       o.cfg.RetryReason,
+		MRunEpoch:         o.cfg.MRunEpoch,
+		InvocationOrdinal: o.cfg.InvocationOrdinal,
+		StartUnixNano:     startUnixNano,
+		FinishUnixNano:    finishUnixNano,
+		DurationNanos:     o.result.duration.Nanoseconds(),
+		DurationValid:     o.result.duration >= 0,
+		Failed:            failed,
+		Skipped:           o.result.skipped,
+		Panic:             panicData != nil,
+		RaceDetected:      o.result.raceDetected,
+		RootParallel:      rootParallel,
 	}
-	if o.result.timing.pauseProjectionOK {
-		startOffsetNanos := o.result.timing.pauseStart.UnixNano() - startUnixNano
-		endOffsetNanos := o.result.timing.pauseEnd.UnixNano() - startUnixNano
-		wallDurationNanos := finishUnixNano - startUnixNano
-		if startOffsetNanos >= 0 && endOffsetNanos >= startOffsetNanos && endOffsetNanos <= wallDurationNanos {
-			startNanos := startOffsetNanos
-			endNanos := endOffsetNanos
-			result.ParallelPauseStartOffsetNanos = &startNanos
-			result.ParallelPauseEndOffsetNanos = &endNanos
-		}
-	}
+	result.setExecutionTiming(o.result.timing)
 	if result.Failed {
 		if panicInfo := o.execMeta.processRetryPanic.Load(); result.Panic && panicInfo != nil {
 			result.ErrorType = panicInfo.Type
@@ -3966,23 +4002,8 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 	if (result.MRunEpoch == 0) != (result.InvocationOrdinal == 0) {
 		return fmt.Errorf("%w: invalid invocation identity", errProcessRetryResultInvalid)
 	}
-	if result.DurationNanos < 0 || (!result.DurationValid && result.DurationNanos != 0) ||
-		result.ObservedActiveDurationNanos < 0 || (!result.ObservedActiveDurationValid && result.ObservedActiveDurationNanos != 0) {
-		return fmt.Errorf("%w: invalid duration", errProcessRetryResultInvalid)
-	}
-	if (result.ParallelPauseStartOffsetNanos == nil) != (result.ParallelPauseEndOffsetNanos == nil) {
-		return fmt.Errorf("%w: incomplete parallel pause", errProcessRetryResultInvalid)
-	}
-	if result.ParallelPauseStartOffsetNanos != nil {
-		if !result.RootParallel {
-			return fmt.Errorf("%w: pause on non-parallel test", errProcessRetryResultInvalid)
-		}
-		startOffset := *result.ParallelPauseStartOffsetNanos
-		endOffset := *result.ParallelPauseEndOffsetNanos
-		wallDuration := result.FinishUnixNano - result.StartUnixNano
-		if result.StartUnixNano == 0 || result.FinishUnixNano == 0 || startOffset < 0 || endOffset < startOffset || wallDuration < 0 || endOffset > wallDuration {
-			return fmt.Errorf("%w: invalid parallel pause", errProcessRetryResultInvalid)
-		}
+	if err := result.validateTiming(); err != nil {
+		return err
 	}
 	if result.ResultError == processRetryResultErrorSubtreeTooLarge && expected.Subtree == nil {
 		return fmt.Errorf("%w: unexpected subtree result error", errProcessRetryResultInvalid)

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -119,6 +119,7 @@ type processRetryChildConfig struct {
 type processRetryStatus string
 
 const (
+	processRetryResultVersion                                            = 2
 	processRetryStatusPass                            processRetryStatus = "pass"
 	processRetryStatusFail                            processRetryStatus = "fail"
 	processRetryStatusSkip                            processRetryStatus = "skip"
@@ -151,36 +152,41 @@ const (
 )
 
 type processRetryResult struct {
-	Version           int                                `json:"version"`
-	TestName          string                             `json:"test_name"`
-	ModuleName        string                             `json:"module_name,omitempty"`
-	SuiteName         string                             `json:"suite_name,omitempty"`
-	Attempt           int                                `json:"attempt"`
-	RetryReason       string                             `json:"retry_reason"`
-	MRunEpoch         uint64                             `json:"m_run_epoch,omitempty"`
-	InvocationOrdinal uint64                             `json:"invocation_ordinal,omitempty"`
-	Status            processRetryStatus                 `json:"status"`
-	StartUnixNano     int64                              `json:"start_unix_nano"`
-	FinishUnixNano    int64                              `json:"finish_unix_nano"`
-	DurationNanos     int64                              `json:"duration_nanos"`
-	Failed            bool                               `json:"failed"`
-	Skipped           bool                               `json:"skipped"`
-	Panic             bool                               `json:"panic"`
-	RaceDetected      bool                               `json:"race_detected,omitempty"`
-	RootParallel      bool                               `json:"root_parallel,omitempty"`
-	ErrorType         string                             `json:"error_type,omitempty"`
-	ErrorMessage      string                             `json:"error_message,omitempty"`
-	ErrorStack        string                             `json:"error_stack,omitempty"`
-	SkipReason        string                             `json:"skip_reason,omitempty"`
-	ResultError       string                             `json:"result_error,omitempty"`
-	OutputTail        string                             `json:"output_tail,omitempty"`
-	OutputTruncated   bool                               `json:"output_truncated,omitempty"`
-	Source            *processRetryTestSource            `json:"source,omitempty"`
-	Coverage          []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
-	Subtests          []processRetrySubtreeResult        `json:"subtests,omitempty"`
-	SkippedByITR      bool                               `json:"skipped_by_itr,omitempty"`
-	ITRForcedRun      bool                               `json:"itr_forced_run,omitempty"`
-	Modified          bool                               `json:"modified,omitempty"`
+	Version                       int                                `json:"version"`
+	TestName                      string                             `json:"test_name"`
+	ModuleName                    string                             `json:"module_name,omitempty"`
+	SuiteName                     string                             `json:"suite_name,omitempty"`
+	Attempt                       int                                `json:"attempt"`
+	RetryReason                   string                             `json:"retry_reason"`
+	MRunEpoch                     uint64                             `json:"m_run_epoch,omitempty"`
+	InvocationOrdinal             uint64                             `json:"invocation_ordinal,omitempty"`
+	Status                        processRetryStatus                 `json:"status"`
+	StartUnixNano                 int64                              `json:"start_unix_nano"`
+	FinishUnixNano                int64                              `json:"finish_unix_nano"`
+	DurationNanos                 int64                              `json:"duration_nanos"`
+	DurationValid                 bool                               `json:"duration_valid"`
+	ObservedActiveDurationNanos   int64                              `json:"observed_active_duration_nanos"`
+	ObservedActiveDurationValid   bool                               `json:"observed_active_duration_valid"`
+	ParallelPauseStartOffsetNanos *int64                             `json:"parallel_pause_start_offset_nanos,omitempty"`
+	ParallelPauseEndOffsetNanos   *int64                             `json:"parallel_pause_end_offset_nanos,omitempty"`
+	Failed                        bool                               `json:"failed"`
+	Skipped                       bool                               `json:"skipped"`
+	Panic                         bool                               `json:"panic"`
+	RaceDetected                  bool                               `json:"race_detected,omitempty"`
+	RootParallel                  bool                               `json:"root_parallel,omitempty"`
+	ErrorType                     string                             `json:"error_type,omitempty"`
+	ErrorMessage                  string                             `json:"error_message,omitempty"`
+	ErrorStack                    string                             `json:"error_stack,omitempty"`
+	SkipReason                    string                             `json:"skip_reason,omitempty"`
+	ResultError                   string                             `json:"result_error,omitempty"`
+	OutputTail                    string                             `json:"output_tail,omitempty"`
+	OutputTruncated               bool                               `json:"output_truncated,omitempty"`
+	Source                        *processRetryTestSource            `json:"source,omitempty"`
+	Coverage                      []coverage.ProcessTestCoverageFile `json:"coverage,omitempty"`
+	Subtests                      []processRetrySubtreeResult        `json:"subtests,omitempty"`
+	SkippedByITR                  bool                               `json:"skipped_by_itr,omitempty"`
+	ITRForcedRun                  bool                               `json:"itr_forced_run,omitempty"`
+	Modified                      bool                               `json:"modified,omitempty"`
 }
 
 type processRetryErrorInfo struct {
@@ -866,6 +872,7 @@ type processRetryAttemptResult struct {
 	SetupFailure                bool
 	BodyAdmitted                bool
 	ControlledTerminalCommitted bool
+	ResultWallTimingValid       bool
 	Cleanup                     func()
 	quarantinedRaceInvocations  []quarantinedRaceInvocation
 }
@@ -2052,6 +2059,7 @@ func runProcessRetryAttemptWithBaselineAndShutdown(
 		attempt.Err = errors.Join(attempt.Err, resultErr)
 	} else {
 		attempt.Result = result
+		attempt.ResultWallTimingValid = timingOK
 		if isProcessRetryControlledTerminalStatus(result.Status) && control != nil {
 			terminal, terminalTimedOut, terminalErr := control.controlledTerminalState(ctx, shutdown, attemptTimer.C())
 			applyProcessRetryControlledTerminalState(&attempt, terminal, terminalTimedOut, terminalErr)
@@ -2472,6 +2480,31 @@ func deferProcessRetryTestEventWithAdmission(
 	return effective, tail
 }
 
+func processRetryPolicyDuration(attempt processRetryAttemptResult) (time.Duration, bool) {
+	if !attempt.Result.DurationValid || attempt.Result.DurationNanos < 0 {
+		return 0, false
+	}
+	return time.Duration(attempt.Result.DurationNanos), true
+}
+
+func applyProcessRetryExecutionTiming(test integrations.Test, attempt processRetryAttemptResult) {
+	timing := testExecutionTiming{isParallel: attempt.Result.RootParallel}
+	if attempt.Result.ObservedActiveDurationValid && attempt.Result.ObservedActiveDurationNanos >= 0 {
+		timing.activeDuration = time.Duration(attempt.Result.ObservedActiveDurationNanos)
+		timing.activeDurationOK = true
+	}
+	if attempt.ResultWallTimingValid && attempt.Result.ParallelPauseStartOffsetNanos != nil && attempt.Result.ParallelPauseEndOffsetNanos != nil {
+		startOffset := time.Duration(*attempt.Result.ParallelPauseStartOffsetNanos)
+		endOffset := time.Duration(*attempt.Result.ParallelPauseEndOffsetNanos)
+		if startOffset >= 0 && endOffset >= startOffset && endOffset <= attempt.FinishTime.Sub(attempt.StartTime) {
+			timing.pauseStart = attempt.StartTime.Add(startOffset)
+			timing.pauseEnd = attempt.StartTime.Add(endOffset)
+			timing.pauseProjectionOK = true
+		}
+	}
+	applyTestExecutionTiming(test, timing)
+}
+
 func finishProcessRetryTestEvent(
 	testInfo *commonInfo,
 	execMeta *testExecutionMetadata,
@@ -2489,6 +2522,7 @@ func finishProcessRetryTestEvent(
 	module := session.GetOrCreateModule(testInfo.moduleName)
 	suite := module.GetOrCreateSuite(testInfo.suiteName)
 	test := suite.CreateTest(testInfo.testName, integrations.WithTestStartTime(attempt.StartTime))
+	initializeTestExecutionTiming(test)
 	if testInfo.sourceFunc != nil {
 		test.SetTestFunc(testInfo.sourceFunc)
 	} else if source := attempt.Result.Source; source != nil {
@@ -2511,6 +2545,7 @@ func finishProcessRetryTestEvent(
 		}
 	}
 	execMeta.test = test
+	applyProcessRetryExecutionTiming(test, attempt)
 	coverage.SubmitProcessTestCoverage(session.SessionID(), suite.SuiteID(), test.TestID(), attempt.Result.Coverage)
 	cancelExecution := setTestTagsFromExecutionMetadataNoClose(test, execMeta)
 	// A validated process skip is already the outcome of the execution. In
@@ -2534,8 +2569,11 @@ func finishProcessRetryTestEvent(
 	if admitContinuation != nil {
 		admitContinuation(effective)
 	}
-	duration := max(attempt.FinishTime.Sub(attempt.StartTime), 0)
-	finalExec := isFinalExecution(effective.Failed, effective.Skipped, execMeta, duration)
+	policyDuration, policyDurationOK := processRetryPolicyDuration(attempt)
+	if policyDurationOK && isAnEfdExecution(execMeta) && policyDuration >= 5*time.Minute {
+		test.SetTag(constants.TestEarlyFlakeDetectionRetryAborted, "slow")
+	}
+	finalExec := isFinalExecution(effective.Failed, effective.Skipped, execMeta, policyDuration)
 	if finalExec && deferred == nil {
 		if effective.FailureKind == "metadata_cancelled" {
 			test.SetTag(constants.TestFinalStatus, constants.TestStatusFail)
@@ -3156,7 +3194,7 @@ func writeInvalidProcessRetryChildConfigResult(cfg processRetryChildConfig, reas
 		}
 	}
 	result := processRetryResult{
-		Version:     1,
+		Version:     processRetryResultVersion,
 		Status:      processRetryStatusNotRun,
 		ResultError: reason,
 	}
@@ -3197,7 +3235,7 @@ func (w *processRetryResultWriter) Write(result processRetryResult) bool {
 
 func processRetryNotRunResult(cfg processRetryChildConfig, resultError string) processRetryResult {
 	return processRetryResult{
-		Version:           1,
+		Version:           processRetryResultVersion,
 		TestName:          cfg.TestName,
 		Attempt:           cfg.Attempt,
 		RetryReason:       cfg.RetryReason,
@@ -3295,7 +3333,17 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			observation.execMeta = execMeta
 			return ""
 		}
-		childBody := original
+		var timing testExecutionTiming
+		timedOriginal := func(t *testing.T) {
+			parallelBaseline := captureParallelTimingBaseline(t)
+			bodyStart := time.Now()
+			defer func() {
+				bodyEnd := time.Now()
+				timing = observeTestExecutionTiming(t, observation.execMeta, parallelBaseline, bodyEnd.Sub(bodyStart), bodyEnd)
+			}()
+			original(t)
+		}
+		childBody := timedOriginal
 		if cfg.Subtree != nil && cfg.Subtree.SelectedRoot == topLevelName {
 			childBody = func(t *testing.T) {
 				rootDirective := cfg.Subtree.Root
@@ -3323,7 +3371,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 				} else {
 					observation.execMeta.isItrForcedRun = forced
 				}
-				original(t)
+				timedOriginal(t)
 			}
 		}
 		attempt, result, reason := runFreshRetryAttemptInGroupWithCallbacks(group, prepare, childBody, nil)
@@ -3332,6 +3380,7 @@ func wrapProcessRetryChildTest(original func(*testing.T), cfg processRetryChildC
 			t.Fail()
 			return
 		}
+		result.timing = timing
 		observation.result = result
 		status := processRetryControlledTerminalStatus(result)
 		if status != "" {
@@ -3416,7 +3465,7 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 			return processRetryNotRunResult(o.cfg, "parallel_control_failed")
 		}
 	}
-	finish := o.startTime.Add(o.result.duration)
+	finish := time.Now()
 	panicData := o.result.panicData
 	panicStack := o.result.panicStack
 	if panicData == nil && o.result.cleanupPanicData != nil {
@@ -3430,23 +3479,37 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		rootParallel = o.group.rootParallelObserved
 		o.group.mu.Unlock()
 	}
+	rootParallel = rootParallel || o.result.timing.isParallel
 	result := processRetryResult{
-		Version:           1,
-		TestName:          o.cfg.TestName,
-		ModuleName:        o.execMeta.identity.ModuleName,
-		SuiteName:         o.execMeta.identity.SuiteName,
-		Attempt:           o.cfg.Attempt,
-		RetryReason:       o.cfg.RetryReason,
-		MRunEpoch:         o.cfg.MRunEpoch,
-		InvocationOrdinal: o.cfg.InvocationOrdinal,
-		StartUnixNano:     o.startTime.UnixNano(),
-		FinishUnixNano:    finish.UnixNano(),
-		DurationNanos:     o.result.duration.Nanoseconds(),
-		Failed:            failed,
-		Skipped:           o.result.skipped,
-		Panic:             panicData != nil,
-		RaceDetected:      o.result.raceDetected,
-		RootParallel:      rootParallel,
+		Version:                     processRetryResultVersion,
+		TestName:                    o.cfg.TestName,
+		ModuleName:                  o.execMeta.identity.ModuleName,
+		SuiteName:                   o.execMeta.identity.SuiteName,
+		Attempt:                     o.cfg.Attempt,
+		RetryReason:                 o.cfg.RetryReason,
+		MRunEpoch:                   o.cfg.MRunEpoch,
+		InvocationOrdinal:           o.cfg.InvocationOrdinal,
+		StartUnixNano:               o.startTime.UnixNano(),
+		FinishUnixNano:              finish.UnixNano(),
+		DurationNanos:               o.result.duration.Nanoseconds(),
+		DurationValid:               o.result.duration >= 0,
+		ObservedActiveDurationNanos: o.result.timing.activeDuration.Nanoseconds(),
+		ObservedActiveDurationValid: o.result.timing.activeDurationOK,
+		Failed:                      failed,
+		Skipped:                     o.result.skipped,
+		Panic:                       panicData != nil,
+		RaceDetected:                o.result.raceDetected,
+		RootParallel:                rootParallel,
+	}
+	if o.result.timing.pauseProjectionOK {
+		startOffset := o.result.timing.pauseStart.Sub(o.startTime)
+		endOffset := o.result.timing.pauseEnd.Sub(o.startTime)
+		if startOffset >= 0 && endOffset >= startOffset && endOffset <= finish.Sub(o.startTime)+parallelTimingSkewTolerance {
+			startNanos := startOffset.Nanoseconds()
+			endNanos := endOffset.Nanoseconds()
+			result.ParallelPauseStartOffsetNanos = &startNanos
+			result.ParallelPauseEndOffsetNanos = &endNanos
+		}
 	}
 	if result.Failed {
 		if panicInfo := o.execMeta.processRetryPanic.Load(); result.Panic && panicInfo != nil {
@@ -3883,15 +3946,11 @@ func readProcessRetryResult(resultPath string, expected processRetryChildConfig)
 		return processRetryResult{}, false, err
 	}
 	timingOK := result.StartUnixNano != 0 && result.FinishUnixNano != 0 && result.FinishUnixNano >= result.StartUnixNano
-	if timingOK && result.DurationNanos != 0 && result.DurationNanos != result.FinishUnixNano-result.StartUnixNano {
-		log.Debug("civisibility: process retry result timing duration mismatch")
-		timingOK = false
-	}
 	return result, timingOK, nil
 }
 
 func validateProcessRetryResult(result processRetryResult, expected processRetryChildConfig) error {
-	if result.Version != 1 {
+	if result.Version != processRetryResultVersion {
 		return fmt.Errorf("%w: unsupported version", errProcessRetryResultInvalid)
 	}
 	if result.TestName != expected.TestName ||
@@ -3903,6 +3962,24 @@ func validateProcessRetryResult(result processRetryResult, expected processRetry
 	}
 	if (result.MRunEpoch == 0) != (result.InvocationOrdinal == 0) {
 		return fmt.Errorf("%w: invalid invocation identity", errProcessRetryResultInvalid)
+	}
+	if result.DurationNanos < 0 || (!result.DurationValid && result.DurationNanos != 0) ||
+		result.ObservedActiveDurationNanos < 0 || (!result.ObservedActiveDurationValid && result.ObservedActiveDurationNanos != 0) {
+		return fmt.Errorf("%w: invalid duration", errProcessRetryResultInvalid)
+	}
+	if (result.ParallelPauseStartOffsetNanos == nil) != (result.ParallelPauseEndOffsetNanos == nil) {
+		return fmt.Errorf("%w: incomplete parallel pause", errProcessRetryResultInvalid)
+	}
+	if result.ParallelPauseStartOffsetNanos != nil {
+		if !result.RootParallel {
+			return fmt.Errorf("%w: pause on non-parallel test", errProcessRetryResultInvalid)
+		}
+		startOffset := *result.ParallelPauseStartOffsetNanos
+		endOffset := *result.ParallelPauseEndOffsetNanos
+		wallDuration := result.FinishUnixNano - result.StartUnixNano
+		if result.StartUnixNano == 0 || result.FinishUnixNano == 0 || startOffset < 0 || endOffset < startOffset || wallDuration < 0 || endOffset > wallDuration {
+			return fmt.Errorf("%w: invalid parallel pause", errProcessRetryResultInvalid)
+		}
 	}
 	if result.ResultError == processRetryResultErrorSubtreeTooLarge && expected.Subtree == nil {
 		return fmt.Errorf("%w: unexpected subtree result error", errProcessRetryResultInvalid)
@@ -3946,7 +4023,7 @@ func validateProcessRetryResultStatus(result processRetryResult) error {
 			return fmt.Errorf("%w: invalid controlled terminal mirrors", errProcessRetryResultInvalid)
 		}
 	case processRetryStatusNotRun:
-		if result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 || result.SkippedByITR || result.ITRForcedRun || result.Modified || !validProcessRetryResultError(result.ResultError) {
+		if result.DurationValid || result.ObservedActiveDurationValid || result.Failed || result.Skipped || result.Panic || result.RaceDetected || result.RootParallel || result.ErrorType != "" || result.ErrorMessage != "" || result.ErrorStack != "" || result.SkipReason != "" || result.OutputTail != "" || result.OutputTruncated || result.Source != nil || len(result.Coverage) > 0 || len(result.Subtests) > 0 || result.SkippedByITR || result.ITRForcedRun || result.Modified || !validProcessRetryResultError(result.ResultError) {
 			return fmt.Errorf("%w: invalid not_run mirrors", errProcessRetryResultInvalid)
 		}
 	default:
@@ -3996,7 +4073,7 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 	}
 	finish := time.Now()
 	result := processRetryResult{
-		Version:           1,
+		Version:           processRetryResultVersion,
 		TestName:          t.cfg.TestName,
 		Attempt:           t.cfg.Attempt,
 		RetryReason:       t.cfg.RetryReason,
@@ -4012,7 +4089,6 @@ func (t *processRetryNoopTest) writePanicResult(info *processRetryErrorInfo) {
 		ErrorStack:        info.Stack,
 		StartUnixNano:     t.startTime.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
-		DurationNanos:     finish.Sub(t.startTime).Nanoseconds(),
 	}
 	if t.identity != nil {
 		result.ModuleName = t.identity.ModuleName

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -3466,6 +3466,8 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		}
 	}
 	finish := time.Now()
+	startUnixNano := o.startTime.UnixNano()
+	finishUnixNano := finish.UnixNano()
 	panicData := o.result.panicData
 	panicStack := o.result.panicStack
 	if panicData == nil && o.result.cleanupPanicData != nil {
@@ -3489,8 +3491,8 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		RetryReason:                 o.cfg.RetryReason,
 		MRunEpoch:                   o.cfg.MRunEpoch,
 		InvocationOrdinal:           o.cfg.InvocationOrdinal,
-		StartUnixNano:               o.startTime.UnixNano(),
-		FinishUnixNano:              finish.UnixNano(),
+		StartUnixNano:               startUnixNano,
+		FinishUnixNano:              finishUnixNano,
 		DurationNanos:               o.result.duration.Nanoseconds(),
 		DurationValid:               o.result.duration >= 0,
 		ObservedActiveDurationNanos: o.result.timing.activeDuration.Nanoseconds(),
@@ -3502,11 +3504,12 @@ func (o *processRetryChildObservation) buildResult(status processRetryStatus) pr
 		RootParallel:                rootParallel,
 	}
 	if o.result.timing.pauseProjectionOK {
-		startOffset := o.result.timing.pauseStart.Sub(o.startTime)
-		endOffset := o.result.timing.pauseEnd.Sub(o.startTime)
-		if startOffset >= 0 && endOffset >= startOffset && endOffset <= finish.Sub(o.startTime)+parallelTimingSkewTolerance {
-			startNanos := startOffset.Nanoseconds()
-			endNanos := endOffset.Nanoseconds()
+		startOffsetNanos := o.result.timing.pauseStart.UnixNano() - startUnixNano
+		endOffsetNanos := o.result.timing.pauseEnd.UnixNano() - startUnixNano
+		wallDurationNanos := finishUnixNano - startUnixNano
+		if startOffsetNanos >= 0 && endOffsetNanos >= startOffsetNanos && endOffsetNanos <= wallDurationNanos {
+			startNanos := startOffsetNanos
+			endNanos := endOffsetNanos
 			result.ParallelPauseStartOffsetNanos = &startNanos
 			result.ParallelPauseEndOffsetNanos = &endNanos
 		}

--- a/internal/civisibility/integrations/gotesting/retry_process.go
+++ b/internal/civisibility/integrations/gotesting/retry_process.go
@@ -151,7 +151,7 @@ const (
 	processRetryDefaultTimeout             = 10 * time.Minute
 )
 
-// processRetryResult preserves three distinct clocks across the child-process
+// processRetryResult preserves three timing contracts across the child-process
 // boundary: Start/Finish form the event's wall envelope; Duration is Go's
 // policy duration including cleanup; ObservedActiveDuration is the test body.
 // Both duration values exclude the T.Parallel scheduler wait.

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1141,7 +1141,7 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 	if len(raceInvocations) > 0 {
 		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, raceInvocations, false, g.raceReplay)
 	}
-	policyDuration, _ := processRetryPolicyDuration(attempt)
+	policyDuration, _ := attempt.Result.policyDuration()
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,
 		failed:         effective.Failed,

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred.go
@@ -1141,11 +1141,12 @@ func (g *deferredProcessRetryGroup) applyCompletedAttempt(completed deferredProc
 	if len(raceInvocations) > 0 {
 		replayQuarantinedRaceResults(&g.testInfo, g.raceProcess, raceInvocations, false, g.raceReplay)
 	}
+	policyDuration, _ := processRetryPolicyDuration(attempt)
 	g.latest = retryAttemptObservation{
 		executionIndex: completed.prepared.index,
 		failed:         effective.Failed,
 		skipped:        effective.Skipped,
-		duration:       max(attempt.FinishTime.Sub(attempt.StartTime), 0),
+		duration:       policyDuration,
 		raceDetected:   attempt.Result.RaceDetected,
 		rootParallel:   attempt.Result.RootParallel,
 	}

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -760,7 +760,7 @@ func TestDeferredProcessRetryLeaseFailureAbortsAdmission(t *testing.T) {
 		identity:                  identity,
 		isFlakyTestRetriesEnabled: true,
 		test:                      newProcessRetryRecordingTestForTesting(identity.FullName),
-		retryAttemptFinalizer:     func(retryAttemptResult) {},
+		retryAttemptFinalizer:     func(*retryAttemptResult, bool) {},
 	}
 	coordinator := newProcessRetryCoordinatorForTesting(false)
 	execOpts := &executionOptions{
@@ -1258,7 +1258,7 @@ func newDeferredProcessRetryPendingGroupForTesting(
 		isFlakyTestRetriesEnabled: true,
 		test:                      event,
 	}
-	execMeta.retryAttemptFinalizer = func(retryAttemptResult) {}
+	execMeta.retryAttemptFinalizer = func(*retryAttemptResult, bool) {}
 	coordinator := newProcessRetryCoordinatorForTesting(false, runners...)
 	options := &runTestWithRetryOptions{
 		t:                       t,

--- a/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_deferred_test.go
@@ -760,7 +760,7 @@ func TestDeferredProcessRetryLeaseFailureAbortsAdmission(t *testing.T) {
 		identity:                  identity,
 		isFlakyTestRetriesEnabled: true,
 		test:                      newProcessRetryRecordingTestForTesting(identity.FullName),
-		retryAttemptFinalizer:     func(*retryAttemptResult, bool) {},
+		retryAttemptFinalizer:     func(retryAttemptResult) {},
 	}
 	coordinator := newProcessRetryCoordinatorForTesting(false)
 	execOpts := &executionOptions{
@@ -1258,7 +1258,7 @@ func newDeferredProcessRetryPendingGroupForTesting(
 		isFlakyTestRetriesEnabled: true,
 		test:                      event,
 	}
-	execMeta.retryAttemptFinalizer = func(*retryAttemptResult, bool) {}
+	execMeta.retryAttemptFinalizer = func(retryAttemptResult) {}
 	coordinator := newProcessRetryCoordinatorForTesting(false, runners...)
 	options := &runTestWithRetryOptions{
 		t:                       t,

--- a/internal/civisibility/integrations/gotesting/retry_process_test.go
+++ b/internal/civisibility/integrations/gotesting/retry_process_test.go
@@ -1184,7 +1184,7 @@ func TestProcessRetryChildInvalidConfig(t *testing.T) {
 	require.Equal(t, 1, runProcessRetryChild(nil))
 
 	result := readProcessRetryResultForTesting(t, resultPath)
-	require.Equal(t, 1, result.Version)
+	require.Equal(t, processRetryResultVersion, result.Version)
 	require.Equal(t, processRetryStatusNotRun, result.Status)
 	require.Equal(t, "missing_test_name", result.ResultError)
 	require.Empty(t, result.TestName)
@@ -1461,7 +1461,7 @@ func TestProcessRetryChildWritesResult(t *testing.T) {
 	require.True(t, ran)
 	require.Empty(t, *tests)
 	result := readProcessRetryResultForTesting(t, resultPath)
-	require.Equal(t, 1, result.Version)
+	require.Equal(t, processRetryResultVersion, result.Version)
 	require.Equal(t, "TestSelected", result.TestName)
 	require.Equal(t, 1, result.Attempt)
 	require.Equal(t, constants.AutoTestRetriesRetryReason, result.RetryReason)
@@ -1470,6 +1470,11 @@ func TestProcessRetryChildWritesResult(t *testing.T) {
 	require.False(t, result.Skipped)
 	require.Positive(t, result.StartUnixNano)
 	require.GreaterOrEqual(t, result.FinishUnixNano, result.StartUnixNano)
+	require.True(t, result.DurationValid)
+	require.True(t, result.ObservedActiveDurationValid)
+	require.False(t, result.RootParallel)
+	require.Nil(t, result.ParallelPauseStartOffsetNanos)
+	require.Nil(t, result.ParallelPauseEndOffsetNanos)
 }
 
 func TestProcessRetryChildRejectsDuplicateMRunBeforeCompletion(t *testing.T) {
@@ -1711,6 +1716,12 @@ func TestProcessRetryChildPublicHelpersPreserveNativeState(t *testing.T) {
 			require.Equal(t, tt.errorMessage, result.ErrorMessage)
 			require.Equal(t, tt.skipReason, result.SkipReason)
 			require.Equal(t, tt.rootParallel, result.RootParallel)
+			if tt.rootParallel {
+				require.True(t, result.DurationValid)
+				require.True(t, result.ObservedActiveDurationValid)
+				require.NotNil(t, result.ParallelPauseStartOffsetNanos)
+				require.NotNil(t, result.ParallelPauseEndOffsetNanos)
+			}
 		})
 	}
 }
@@ -1772,7 +1783,7 @@ func TestProcessRetryStructuredMetadataFitsEncodedResultLimit(t *testing.T) {
 	}
 	encodedExpansion := strings.Repeat("\x00<>&\xff", processRetryErrorStackMaxBytes)
 	result := processRetryResult{
-		Version:        1,
+		Version:        processRetryResultVersion,
 		TestName:       cfg.TestName,
 		Attempt:        cfg.Attempt,
 		RetryReason:    cfg.RetryReason,
@@ -1780,6 +1791,7 @@ func TestProcessRetryStructuredMetadataFitsEncodedResultLimit(t *testing.T) {
 		StartUnixNano:  1,
 		FinishUnixNano: 2,
 		DurationNanos:  1,
+		DurationValid:  true,
 		Failed:         true,
 		ErrorType:      truncateProcessRetryErrorType(encodedExpansion),
 		ErrorMessage:   truncateProcessRetryStructuredErrorMessage(encodedExpansion),
@@ -1804,7 +1816,7 @@ func TestProcessRetryStructuredMetadataFitsEncodedResultLimit(t *testing.T) {
 		RetryReason: constants.AutoTestRetriesRetryReason,
 	}
 	skipResult := processRetryResult{
-		Version:        1,
+		Version:        processRetryResultVersion,
 		TestName:       skipCfg.TestName,
 		Attempt:        skipCfg.Attempt,
 		RetryReason:    skipCfg.RetryReason,
@@ -1812,6 +1824,7 @@ func TestProcessRetryStructuredMetadataFitsEncodedResultLimit(t *testing.T) {
 		StartUnixNano:  1,
 		FinishUnixNano: 2,
 		DurationNanos:  1,
+		DurationValid:  true,
 		Skipped:        true,
 		SkipReason:     truncateProcessRetrySkipReason(encodedExpansion),
 	}
@@ -1910,7 +1923,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		RetryReason: constants.AutoTestRetriesRetryReason,
 	}
 	result := processRetryResult{
-		Version:        1,
+		Version:        processRetryResultVersion,
 		TestName:       cfg.TestName,
 		Attempt:        cfg.Attempt,
 		RetryReason:    cfg.RetryReason,
@@ -1918,13 +1931,20 @@ func TestReadProcessRetryResult(t *testing.T) {
 		StartUnixNano:  10,
 		FinishUnixNano: 20,
 		DurationNanos:  10,
+		DurationValid:  true,
 	}
+	pauseStart, pauseEnd := int64(2), int64(5)
+	result.ObservedActiveDurationNanos = 7
+	result.ObservedActiveDurationValid = true
+	result.RootParallel = true
+	result.ParallelPauseStartOffsetNanos = &pauseStart
+	result.ParallelPauseEndOffsetNanos = &pauseEnd
 	writeProcessRetryResultForTesting(t, cfg.ResultPath, result)
 
 	got, timingOK, err := readProcessRetryResult(cfg.ResultPath, cfg)
 	require.NoError(t, err)
 	require.True(t, timingOK)
-	require.Equal(t, processRetryStatusPass, got.Status)
+	require.Equal(t, result, got)
 
 	payload, err := json.Marshal(result)
 	require.NoError(t, err)
@@ -1954,7 +1974,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 	require.ErrorIs(t, err, errProcessRetryResultMissing)
 
 	result = processRetryResult{
-		Version:     1,
+		Version:     processRetryResultVersion,
 		TestName:    cfg.TestName,
 		Attempt:     cfg.Attempt,
 		RetryReason: cfg.RetryReason,
@@ -1968,15 +1988,15 @@ func TestReadProcessRetryResult(t *testing.T) {
 
 	for _, valid := range []processRetryResult{
 		{
-			Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+			Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 			Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorMessage: "message", ErrorStack: "stack",
 		},
 		{
-			Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+			Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 			Status: processRetryStatusFail, Failed: true, RaceDetected: true,
 		},
 		{
-			Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+			Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 			Status: processRetryStatusSkip, Skipped: true, SkipReason: "skip reason",
 		},
 	} {
@@ -1991,9 +2011,46 @@ func TestReadProcessRetryResult(t *testing.T) {
 		result processRetryResult
 	}{
 		{
+			name: "nonzero invalid policy duration",
+			result: processRetryResult{
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Status: processRetryStatusPass, DurationNanos: 1,
+			},
+		},
+		{
+			name: "nonzero invalid observed duration",
+			result: processRetryResult{
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Status: processRetryStatusPass, ObservedActiveDurationNanos: 1,
+			},
+		},
+		{
+			name: "incomplete parallel pause",
+			result: processRetryResult{
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Status: processRetryStatusPass, RootParallel: true, ParallelPauseStartOffsetNanos: &pauseStart,
+			},
+		},
+		{
+			name: "pause on non-parallel test",
+			result: processRetryResult{
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Status: processRetryStatusPass, StartUnixNano: 10, FinishUnixNano: 20,
+				ParallelPauseStartOffsetNanos: &pauseStart, ParallelPauseEndOffsetNanos: &pauseEnd,
+			},
+		},
+		{
+			name: "parallel pause outside wall timing",
+			result: processRetryResult{
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Status: processRetryStatusPass, StartUnixNano: 10, FinishUnixNano: 12, RootParallel: true,
+				ParallelPauseStartOffsetNanos: &pauseStart, ParallelPauseEndOffsetNanos: &pauseEnd,
+			},
+		},
+		{
 			name: "unknown version",
 			result: processRetryResult{
-				Version:     2,
+				Version:     processRetryResultVersion + 1,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2003,7 +2060,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "unknown status",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2013,7 +2070,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "pass failed mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2024,7 +2081,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "pass skipped mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2035,14 +2092,14 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "pass skip reason",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusPass, SkipReason: "invalid",
 			},
 		},
 		{
 			name: "pass panic metadata",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2054,7 +2111,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "pass race mirror",
 			result: processRetryResult{
-				Version:      1,
+				Version:      processRetryResultVersion,
 				TestName:     cfg.TestName,
 				Attempt:      cfg.Attempt,
 				RetryReason:  cfg.RetryReason,
@@ -2065,7 +2122,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "skip missing mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2075,7 +2132,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "skip failed mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2087,7 +2144,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "fail missing mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2097,7 +2154,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "race missing failed mirror",
 			result: processRetryResult{
-				Version:      1,
+				Version:      processRetryResultVersion,
 				TestName:     cfg.TestName,
 				Attempt:      cfg.Attempt,
 				RetryReason:  cfg.RetryReason,
@@ -2108,63 +2165,63 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "fail message without type",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ErrorMessage: "invalid",
 			},
 		},
 		{
 			name: "fail skip reason",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, SkipReason: "invalid",
 			},
 		},
 		{
 			name: "fail result error",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ResultError: "invalid",
 			},
 		},
 		{
 			name: "oversized error type",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ErrorType: strings.Repeat("x", processRetryErrorTypeMaxBytes+1),
 			},
 		},
 		{
 			name: "encoded oversized error type",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ErrorType: strings.Repeat("\n", processRetryErrorTypeMaxBytes),
 			},
 		},
 		{
 			name: "oversized error message",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorMessage: strings.Repeat("x", processRetryErrorMessageMaxBytes+1),
 			},
 		},
 		{
 			name: "oversized error stack",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusFail, Failed: true, ErrorType: "Error", ErrorStack: strings.Repeat("x", processRetryErrorStackMaxBytes+1),
 			},
 		},
 		{
 			name: "oversized skip reason",
 			result: processRetryResult{
-				Version: 1, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
+				Version: processRetryResultVersion, TestName: cfg.TestName, Attempt: cfg.Attempt, RetryReason: cfg.RetryReason,
 				Status: processRetryStatusSkip, Skipped: true, SkipReason: strings.Repeat("x", processRetrySkipReasonMaxBytes+1),
 			},
 		},
 		{
 			name: "panic missing error type",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
@@ -2176,12 +2233,23 @@ func TestReadProcessRetryResult(t *testing.T) {
 		{
 			name: "not run failed mirror",
 			result: processRetryResult{
-				Version:     1,
+				Version:     processRetryResultVersion,
 				TestName:    cfg.TestName,
 				Attempt:     cfg.Attempt,
 				RetryReason: cfg.RetryReason,
 				Status:      processRetryStatusNotRun,
 				Failed:      true,
+			},
+		},
+		{
+			name: "not run timing mirror",
+			result: processRetryResult{
+				Version:       processRetryResultVersion,
+				TestName:      cfg.TestName,
+				Attempt:       cfg.Attempt,
+				RetryReason:   cfg.RetryReason,
+				Status:        processRetryStatusNotRun,
+				DurationValid: true,
 			},
 		},
 	}
@@ -2195,7 +2263,7 @@ func TestReadProcessRetryResult(t *testing.T) {
 
 	t.Run("invalid timing keeps result", func(t *testing.T) {
 		result := processRetryResult{
-			Version:        1,
+			Version:        processRetryResultVersion,
 			TestName:       cfg.TestName,
 			Attempt:        cfg.Attempt,
 			RetryReason:    cfg.RetryReason,
@@ -3564,7 +3632,7 @@ func TestRunProcessRetryAttemptHonorsConcurrencyCap(t *testing.T) {
 			}
 			now := time.Now()
 			result := processRetryResult{
-				Version:        1,
+				Version:        processRetryResultVersion,
 				TestName:       cfg.TestName,
 				Attempt:        cfg.Attempt,
 				RetryReason:    cfg.RetryReason,
@@ -3572,6 +3640,7 @@ func TestRunProcessRetryAttemptHonorsConcurrencyCap(t *testing.T) {
 				StartUnixNano:  now.UnixNano(),
 				FinishUnixNano: now.Add(time.Millisecond).UnixNano(),
 				DurationNanos:  int64(time.Millisecond),
+				DurationValid:  true,
 			}
 			data, err := json.Marshal(result)
 			if err != nil {
@@ -4358,7 +4427,7 @@ func TestRunProcessRetryAttemptAttachesBeforeResumeAndReleasesLast(t *testing.T)
 			cfg := processRetryChildConfigFromCommandEnv(t, cmd.Env)
 			now := time.Now()
 			writeProcessRetryResultForTesting(t, cfg.ResultPath, processRetryResult{
-				Version:        1,
+				Version:        processRetryResultVersion,
 				TestName:       cfg.TestName,
 				Attempt:        cfg.Attempt,
 				RetryReason:    cfg.RetryReason,
@@ -4366,6 +4435,7 @@ func TestRunProcessRetryAttemptAttachesBeforeResumeAndReleasesLast(t *testing.T)
 				StartUnixNano:  now.UnixNano(),
 				FinishUnixNano: now.Add(time.Millisecond).UnixNano(),
 				DurationNanos:  int64(time.Millisecond),
+				DurationValid:  true,
 			})
 			closeProcessRetryCommandWriters(cmd)
 			waitCh := make(chan error, 1)
@@ -4784,7 +4854,7 @@ func TestRunProcessRetryAttemptStartsProcessTimeoutAfterLimiterAcquire(t *testin
 				return nil, err
 			}
 			data, err := json.Marshal(processRetryResult{
-				Version:        1,
+				Version:        processRetryResultVersion,
 				TestName:       cfg.TestName,
 				Attempt:        cfg.Attempt,
 				RetryReason:    cfg.RetryReason,
@@ -4792,6 +4862,7 @@ func TestRunProcessRetryAttemptStartsProcessTimeoutAfterLimiterAcquire(t *testin
 				StartUnixNano:  now.UnixNano(),
 				FinishUnixNano: now.Add(time.Millisecond).UnixNano(),
 				DurationNanos:  int64(time.Millisecond),
+				DurationValid:  true,
 			})
 			if err != nil {
 				return nil, err
@@ -5108,6 +5179,9 @@ func TestFinishProcessRetryTestEventDoesNotChangeAggregateCounters(t *testing.T)
 	require.Zero(t, modulesCounters[identity.ModuleName])
 	require.Zero(t, suitesCounters[identity.SuiteName])
 	require.Equal(t, true, recorder.tests[0].tags[ext.Error])
+	require.EqualValues(t, 0, recorder.tests[0].tags[constants.TestActiveDuration])
+	require.Equal(t, false, recorder.tests[0].tags[constants.TestIsParallel])
+	require.NotContains(t, recorder.tests[0].tags, constants.TestParallelPauseDuration)
 	require.Empty(t, recorder.tests[0].errorType)
 	require.Empty(t, recorder.tests[0].errorMessage)
 	require.Empty(t, recorder.tests[0].errorStack)
@@ -5116,6 +5190,54 @@ func TestFinishProcessRetryTestEventDoesNotChangeAggregateCounters(t *testing.T)
 }
 
 func TestFinishProcessRetryTestEventForwardsStructuredResultMetadata(t *testing.T) {
+	t.Run("timing", func(t *testing.T) {
+		for _, tt := range []struct {
+			name          string
+			durationValid bool
+			wantSlow      bool
+		}{
+			{name: "valid policy duration", durationValid: true, wantSlow: true},
+			{name: "invalid policy duration"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
+				defer restoreSession()
+
+				identity := newTestIdentity("module", "suite", "TestProcessRetryTiming")
+				now := time.Now()
+				finishProcessRetryTestEventForTesting(&commonInfo{
+					moduleName: identity.ModuleName,
+					suiteName:  identity.SuiteName,
+					testName:   identity.FullName,
+					identity:   identity,
+				}, &testExecutionMetadata{
+					identity:                     identity,
+					isARetry:                     true,
+					isEarlyFlakeDetectionEnabled: true,
+					isANewTest:                   true,
+					retryContinuationDecided:     true,
+				}, processRetryAttemptResult{
+					Result: processRetryResult{
+						Status:                      processRetryStatusPass,
+						DurationNanos:               (5 * time.Minute).Nanoseconds(),
+						DurationValid:               tt.durationValid,
+						ObservedActiveDurationNanos: (2 * time.Second).Nanoseconds(),
+						ObservedActiveDurationValid: true,
+						RootParallel:                true,
+					},
+					StartTime:  now,
+					FinishTime: now.Add(5 * time.Minute),
+				})
+
+				require.Len(t, recorder.tests, 1)
+				require.EqualValues(t, (2 * time.Second).Nanoseconds(), recorder.tests[0].tags[constants.TestActiveDuration])
+				require.Equal(t, true, recorder.tests[0].tags[constants.TestIsParallel])
+				_, slow := recorder.tests[0].tags[constants.TestEarlyFlakeDetectionRetryAborted]
+				require.Equal(t, tt.wantSlow, slow)
+			})
+		}
+	})
+
 	t.Run("failure", func(t *testing.T) {
 		recorder, restoreSession := setProcessRetryRecordingSessionForTesting(t)
 		defer restoreSession()
@@ -5463,7 +5585,7 @@ func TestProcessRetryDiagnosticsKeepSecretPathSentinelsOutOfSpanMetadata(t *test
 		RetryReason: constants.AutoTestRetriesRetryReason,
 	}
 	writeProcessRetryResultForTesting(t, cfg.ResultPath, processRetryResult{
-		Version:     1,
+		Version:     processRetryResultVersion,
 		TestName:    secretSentinel,
 		Attempt:     cfg.Attempt,
 		RetryReason: workspacePathSentinel,
@@ -6097,7 +6219,7 @@ func TestWriteProcessRetryResultAtomically(t *testing.T) {
 	start := time.Now()
 	finish := start.Add(time.Millisecond)
 	want := processRetryResult{
-		Version:           1,
+		Version:           processRetryResultVersion,
 		TestName:          cfg.TestName,
 		Attempt:           cfg.Attempt,
 		RetryReason:       cfg.RetryReason,
@@ -6107,6 +6229,7 @@ func TestWriteProcessRetryResultAtomically(t *testing.T) {
 		StartUnixNano:     start.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
 		DurationNanos:     finish.Sub(start).Nanoseconds(),
+		DurationValid:     true,
 	}
 
 	require.NoError(t, writeProcessRetryResultAtomically(resultPath, want))
@@ -6181,7 +6304,7 @@ func TestProcessRetryControlAdmissionParallelAndTerminalCommit(t *testing.T) {
 	start := time.Now()
 	finish := start.Add(time.Millisecond)
 	require.NoError(t, writeProcessRetryResultAtomically(cfg.ResultPath, processRetryResult{
-		Version:           1,
+		Version:           processRetryResultVersion,
 		TestName:          cfg.TestName,
 		Attempt:           cfg.Attempt,
 		RetryReason:       cfg.RetryReason,
@@ -6191,6 +6314,7 @@ func TestProcessRetryControlAdmissionParallelAndTerminalCommit(t *testing.T) {
 		StartUnixNano:     start.UnixNano(),
 		FinishUnixNano:    finish.UnixNano(),
 		DurationNanos:     finish.Sub(start).Nanoseconds(),
+		DurationValid:     true,
 		Failed:            true,
 		Panic:             true,
 		ErrorType:         "panic",
@@ -6858,7 +6982,7 @@ func processRetrySuccessfulAttemptHooks(t testing.TB, killTree func(*exec.Cmd) e
 				return nil, err
 			}
 			if err := writeProcessRetryResultAtomically(cfg.ResultPath, processRetryResult{
-				Version:        1,
+				Version:        processRetryResultVersion,
 				TestName:       cfg.TestName,
 				Attempt:        cfg.Attempt,
 				RetryReason:    cfg.RetryReason,
@@ -6866,6 +6990,7 @@ func processRetrySuccessfulAttemptHooks(t testing.TB, killTree func(*exec.Cmd) e
 				StartUnixNano:  now.UnixNano(),
 				FinishUnixNano: now.Add(time.Millisecond).UnixNano(),
 				DurationNanos:  int64(time.Millisecond),
+				DurationValid:  true,
 			}); err != nil {
 				return nil, err
 			}

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
@@ -303,6 +304,7 @@ func runFlakyTestRetriesTests(m *testing.M) {
 	if st02EndTime.Before(st03.StartTime()) {
 		panic("parallel testing does not work as expected, span 'testing_test.go.TestParallelSubTests/parallel_subtest_2' ends before span 'testing_test.go.TestParallelSubTests/parallel_subtest_3' starts")
 	}
+	checkParallelTimingSpans(finishedSpans, []*mocktracer.Span{st01, st02, st03})
 
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestSkip", 1)
 	checkSpansByResourceName(finishedSpans, "testing_test.go.TestRetryWithPanic", 4)
@@ -1511,6 +1513,12 @@ func checkSpansByTagValue(finishedSpans []*mocktracer.Span, tagName, tagValue st
 func checkCapabilitiesTags(finishedSpans []*mocktracer.Span) {
 	tests := getSpansWithType(finishedSpans, constants.SpanTypeTest)
 	numOfTests := len(tests)
+	if len(getSpansWithTagName(tests, constants.TestActiveDuration)) != numOfTests {
+		panic(fmt.Sprintf("expected all test spans to have the %s tag", constants.TestActiveDuration))
+	}
+	if len(getSpansWithTagName(tests, constants.TestIsParallel)) != numOfTests {
+		panic(fmt.Sprintf("expected all test spans to have the %s tag", constants.TestIsParallel))
+	}
 	if len(getSpansWithTagName(tests, constants.LibraryCapabilitiesTestImpactAnalysis)) != numOfTests {
 		panic(fmt.Sprintf("expected all test spans to have the %s tag", constants.LibraryCapabilitiesTestImpactAnalysis))
 	}
@@ -1531,6 +1539,62 @@ func checkCapabilitiesTags(finishedSpans []*mocktracer.Span) {
 	}
 	if len(getSpansWithTagName(tests, constants.LibraryCapabilitiesTestManagementAttemptToFix)) != numOfTests {
 		panic(fmt.Sprintf("expected all test spans to have the %s tag", constants.LibraryCapabilitiesTestManagementAttemptToFix))
+	}
+}
+
+func checkParallelTimingSpans(finishedSpans, parallelTests []*mocktracer.Span) {
+	tests := getSpansWithType(finishedSpans, constants.SpanTypeTest)
+	if got := len(getSpansWithTagNameAndValue(tests, constants.TestIsParallel, "true")); got != len(parallelTests) {
+		panic(fmt.Sprintf("expected exactly %d parallel test spans, got %d", len(parallelTests), got))
+	}
+	for _, tag := range []string{
+		constants.TestParallelPauseStartOffset,
+		constants.TestParallelPauseEndOffset,
+		constants.TestParallelPauseDuration,
+	} {
+		if got := len(getSpansWithTagName(tests, tag)); got != len(parallelTests) {
+			panic(fmt.Sprintf("expected exactly %d test spans with %s, got %d", len(parallelTests), tag, got))
+		}
+	}
+
+	waits := getSpansWithResourceName(finishedSpans, parallelWaitResourceName)
+	if len(waits) != len(parallelTests) {
+		panic(fmt.Sprintf("expected exactly %d parallel wait spans, got %d", len(parallelTests), len(waits)))
+	}
+	waitsByParent := make(map[uint64]*mocktracer.Span, len(waits))
+	for _, wait := range waits {
+		if wait.OperationName() != parallelWaitOperationName || wait.Tag(ext.Component) != "go-testing" || wait.Tag(parallelWaitTag) != "true" || wait.Tag(ext.SpanType) != "" {
+			panic(fmt.Sprintf("unexpected parallel wait span: %s", wait))
+		}
+		waitsByParent[wait.ParentID()] = wait
+	}
+
+	for _, test := range parallelTests {
+		wait := waitsByParent[test.SpanID()]
+		if wait == nil || wait.TraceID() != test.TraceID() {
+			panic(fmt.Sprintf("parallel test %d has no wait child in trace %d", test.SpanID(), test.TraceID()))
+		}
+		startOffset := durationTag(test, constants.TestParallelPauseStartOffset)
+		endOffset := durationTag(test, constants.TestParallelPauseEndOffset)
+		pauseDuration := durationTag(test, constants.TestParallelPauseDuration)
+		activeDuration := durationTag(test, constants.TestActiveDuration)
+		if startOffset < 0 || endOffset < startOffset || pauseDuration != endOffset-startOffset || activeDuration < 0 || activeDuration > test.Duration() {
+			panic(fmt.Sprintf("invalid timing tags on parallel test span: %s", test))
+		}
+		if wait.StartTime() != test.StartTime().Add(startOffset) || wait.Duration() != pauseDuration {
+			panic(fmt.Sprintf("parallel wait span does not match its parent timing tags: %s", wait))
+		}
+	}
+}
+
+func durationTag(span *mocktracer.Span, tag string) time.Duration {
+	switch value := span.Tag(tag).(type) {
+	case float64:
+		return time.Duration(value)
+	case int64:
+		return time.Duration(value)
+	default:
+		panic(fmt.Sprintf("expected numeric %s tag, got %T", tag, value))
 	}
 }
 

--- a/internal/civisibility/integrations/gotesting/testcontroller_test.go
+++ b/internal/civisibility/integrations/gotesting/testcontroller_test.go
@@ -70,6 +70,11 @@ var mTracer mocktracer.Tracer
 var logsEntries []*mockedLogEntry
 var parallelEfd bool
 
+const (
+	benchmarkTimingScenario        = "TestBenchmarkTiming"
+	parallelSubtestBlockerDuration = 75 * time.Millisecond
+)
+
 // TestMain is the entry point for testing and runs before any test.
 func TestMain(m *testing.M) {
 	// Enable logs collection for all test scenarios (propagates to spawned child processes).
@@ -114,6 +119,8 @@ func TestMain(m *testing.M) {
 	} else if internal.BoolEnv(processRetryNativeLifecycleFixtureEnv, false) &&
 		os.Getenv(processRetryChildResultScenarioEnv) != processRetryOrdinaryDescendantHelperScenario {
 		os.Exit(runProcessRetryChild(m))
+	} else if internal.BoolEnv(benchmarkTimingScenario, false) {
+		runBenchmarkTimingTests(m)
 	} else if testControllerBenchmarkSelected(os.Args[1:]) {
 		os.Exit(m.Run())
 	} else if internal.BoolEnv("Bypass", false) {
@@ -131,10 +138,65 @@ func TestMain(m *testing.M) {
 		runTestControllerSubprocess("ProcessRetryUnitTests", buildProcessRetryUnitRunFilter(*tests, layoutAvailable), "Bypass=true")
 		if layoutAvailable {
 			runTestControllerSubprocess("RetryNativeParallelUnitTest", "^TestRetryAttemptNativeMaxParallelMatchesTestingFlag$", "Bypass=true", "-test.parallel=3")
+			runTestControllerSubprocess("BenchmarkTiming", "^$", benchmarkTimingScenario+"=true", "-test.bench=^BenchmarkFirst$", "-test.benchtime=1x")
 			for _, v := range scenarios {
 				runTestControllerSubprocess(v, legacyScenarioRunFilter, v+"=true")
 			}
 		}
+	}
+
+	os.Exit(0)
+}
+
+func runBenchmarkTimingTests(m *testing.M) {
+	currentM = m
+	mTracer = integrations.InitializeCIVisibilityMock()
+
+	if exitCode := RunM(m); exitCode != 0 {
+		panic("expected benchmark timing scenario to pass, got exit code: " + strconv.Itoa(exitCode))
+	}
+
+	finishedSpans := mTracer.FinishedSpans()
+	tests := getSpansWithType(finishedSpans, constants.SpanTypeTest)
+	expectedResources := []string{
+		"testing_test.go.BenchmarkFirst",
+		"testing_test.go.BenchmarkFirst/child01",
+		"testing_test.go.BenchmarkFirst/child02",
+		"testing_test.go.BenchmarkFirst/child03",
+	}
+	if len(tests) != len(expectedResources) {
+		panic(fmt.Sprintf("expected %d benchmark spans, got %d", len(expectedResources), len(tests)))
+	}
+	for _, resource := range expectedResources {
+		checkSpansByResourceName(finishedSpans, resource, 1)
+	}
+	for _, test := range tests {
+		if activeDuration := durationTag(test, constants.TestActiveDuration); activeDuration < 0 {
+			panic(fmt.Sprintf("benchmark has negative %s: %s", constants.TestActiveDuration, test))
+		}
+		if got := test.Tag(constants.TestType); got != constants.TestTypeBenchmark {
+			panic(fmt.Sprintf("expected benchmark %s=%s, got %v: %s", constants.TestType, constants.TestTypeBenchmark, got, test))
+		}
+		if got := test.Tag(constants.TestIsParallel); got != "false" {
+			panic(fmt.Sprintf("expected benchmark %s=false, got %v: %s", constants.TestIsParallel, got, test))
+		}
+		for _, tag := range []string{
+			constants.TestParallelPauseStartOffset,
+			constants.TestParallelPauseEndOffset,
+			constants.TestParallelPauseDuration,
+		} {
+			if got := test.Tag(tag); got != nil {
+				panic(fmt.Sprintf("benchmark unexpectedly has %s=%v: %s", tag, got, test))
+			}
+		}
+	}
+
+	skipped := checkSpansByResourceName(finishedSpans, "testing_test.go.BenchmarkFirst/child03", 1)[0]
+	if got := skipped.Tag(constants.TestStatus); got != constants.TestStatusSkip {
+		panic(fmt.Sprintf("expected skipped sub-benchmark status, got %v", got))
+	}
+	if got := skipped.Tag(constants.TestSkipReason); got != "The reason..." {
+		panic(fmt.Sprintf("expected skipped sub-benchmark reason, got %v", got))
 	}
 
 	os.Exit(0)
@@ -1566,6 +1628,9 @@ func checkParallelTimingSpans(finishedSpans, parallelTests []*mocktracer.Span) {
 		if wait.OperationName() != parallelWaitOperationName || wait.Tag(ext.Component) != "go-testing" || wait.Tag(parallelWaitTag) != "true" || wait.Tag(ext.SpanType) != "" {
 			panic(fmt.Sprintf("unexpected parallel wait span: %s", wait))
 		}
+		if waitsByParent[wait.ParentID()] != nil {
+			panic(fmt.Sprintf("parallel test %d has multiple wait children", wait.ParentID()))
+		}
 		waitsByParent[wait.ParentID()] = wait
 	}
 
@@ -1583,6 +1648,23 @@ func checkParallelTimingSpans(finishedSpans, parallelTests []*mocktracer.Span) {
 		}
 		if wait.StartTime() != test.StartTime().Add(startOffset) || wait.Duration() != pauseDuration {
 			panic(fmt.Sprintf("parallel wait span does not match its parent timing tags: %s", wait))
+		}
+		if pauseDuration < parallelSubtestBlockerDuration-25*time.Millisecond {
+			panic(fmt.Sprintf("parallel pause did not include the serial blocker: pause=%s blocker=%s span=%s", pauseDuration, parallelSubtestBlockerDuration, test))
+		}
+		expectedActive := map[string]time.Duration{
+			"testing_test.go.TestParallelSubTests/parallel_subtest_1": 300 * time.Millisecond,
+			"testing_test.go.TestParallelSubTests/parallel_subtest_2": 200 * time.Millisecond,
+			"testing_test.go.TestParallelSubTests/parallel_subtest_3": 100 * time.Millisecond,
+		}[test.Tag(ext.ResourceName).(string)]
+		if activeDuration+parallelTimingSkewTolerance < expectedActive {
+			panic(fmt.Sprintf("parallel active duration is shorter than the test work: active=%s work=%s span=%s", activeDuration, expectedActive, test))
+		}
+		if activeDuration+pauseDuration > test.Duration()+parallelTimingSkewTolerance {
+			panic(fmt.Sprintf("parallel active and pause durations exceed wall time: active=%s pause=%s wall=%s span=%s", activeDuration, pauseDuration, test.Duration(), test))
+		}
+		if test.Duration()-activeDuration < parallelSubtestBlockerDuration-25*time.Millisecond {
+			panic(fmt.Sprintf("parallel active duration still includes the serial blocker: active=%s wall=%s span=%s", activeDuration, test.Duration(), test))
 		}
 	}
 }

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -791,15 +791,9 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 				if bodyTerminal != nil {
 					bodyStack = utils.GetStacktrace(1)
 				}
-				execMeta.retryAttemptFinalizer = func(result *retryAttemptResult, finalize bool) {
-					if result == nil {
-						return
-					}
-					if !finalize {
-						result.timing = timing
-						return
-					}
-					applyTestExecutionTiming(test, timing)
+				execMeta.retryAttemptTiming = timing
+				execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
+					reportTestExecutionTiming(test, result.timing)
 					terminal := bodyTerminal
 					terminalStack := bodyStack
 					if result.panicData != nil {
@@ -810,7 +804,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 						terminal = result.cleanupPanicData
 						terminalStack = string(result.cleanupPanicStack)
 					}
-					logFreshRetryAttemptState("finalize_runm", t, *result)
+					logFreshRetryAttemptState("finalize_runm", t, result)
 					finalizeInstrumentedTestExecution(t, execMeta, test, suite, module, result.duration, result.output, terminal, terminalStack, true)
 				}
 				if r != nil {
@@ -820,7 +814,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 			}
 
 			unexpectedTermination := r == nil && processRetryUnexpectedTestTermination(t, bodyReturned)
-			applyTestExecutionTiming(test, timing)
+			reportTestExecutionTiming(test, timing)
 			policyBodyDuration := bodyDuration
 			if timing.activeDurationOK {
 				policyBodyDuration = timing.activeDuration

--- a/internal/civisibility/integrations/gotesting/testing.go
+++ b/internal/civisibility/integrations/gotesting/testing.go
@@ -701,6 +701,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 		module := session.GetOrCreateModule(testInfo.moduleName)
 		suite := module.GetOrCreateSuite(testInfo.suiteName)
 		test := suite.CreateTest(testInfo.testName)
+		initializeTestExecutionTiming(test)
 		test.SetTestFunc(originalFunc)
 
 		// If the execution is for a new test we tag the test event as new
@@ -764,11 +765,14 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 		// Initialize the chatty printer if not already done.
 		instrumentChattyPrinter(t)
 
+		parallelBaseline := captureParallelTimingBaseline(t)
 		startTime := time.Now()
 		bodyReturned := false
 		defer func() {
 			r := recover()
-			bodyDuration := time.Since(startTime)
+			bodyEnd := time.Now()
+			bodyDuration := bodyEnd.Sub(startTime)
+			timing := observeTestExecutionTiming(t, execMeta, parallelBaseline, bodyDuration, bodyEnd)
 
 			if tCoverage != nil {
 				// Collect coverage after test execution so we can calculate the diff comparing to the baseline.
@@ -787,7 +791,15 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 				if bodyTerminal != nil {
 					bodyStack = utils.GetStacktrace(1)
 				}
-				execMeta.retryAttemptFinalizer = func(result retryAttemptResult) {
+				execMeta.retryAttemptFinalizer = func(result *retryAttemptResult, finalize bool) {
+					if result == nil {
+						return
+					}
+					if !finalize {
+						result.timing = timing
+						return
+					}
+					applyTestExecutionTiming(test, timing)
 					terminal := bodyTerminal
 					terminalStack := bodyStack
 					if result.panicData != nil {
@@ -798,7 +810,7 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 						terminal = result.cleanupPanicData
 						terminalStack = string(result.cleanupPanicStack)
 					}
-					logFreshRetryAttemptState("finalize_runm", t, result)
+					logFreshRetryAttemptState("finalize_runm", t, *result)
 					finalizeInstrumentedTestExecution(t, execMeta, test, suite, module, result.duration, result.output, terminal, terminalStack, true)
 				}
 				if r != nil {
@@ -808,7 +820,12 @@ func (ddm *M) executeInternalTest(testInfo *testingTInfo, wrapperOpts additional
 			}
 
 			unexpectedTermination := r == nil && processRetryUnexpectedTestTermination(t, bodyReturned)
-			duration := runAndApplyTestCleanupWithDuration(t, execMeta, bodyDuration)
+			applyTestExecutionTiming(test, timing)
+			policyBodyDuration := bodyDuration
+			if timing.activeDurationOK {
+				policyBodyDuration = timing.activeDuration
+			}
+			duration := runAndApplyTestCleanupWithDuration(t, execMeta, policyBodyDuration)
 			if unexpectedTermination {
 				r = unexpectedTestTerminationMessage
 			}
@@ -977,6 +994,7 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 		module := session.GetOrCreateModule(benchmarkInfo.moduleName, integrations.WithTestModuleStartTime(startTime))
 		suite := module.GetOrCreateSuite(benchmarkInfo.suiteName, integrations.WithTestSuiteStartTime(startTime))
 		test := suite.CreateTest(benchmarkInfo.testName, integrations.WithTestStartTime(startTime))
+		initializeTestExecutionTiming(test)
 		test.SetTestFunc(originalFunc)
 
 		// If the execution is for a new test we tag the test event as new
@@ -988,6 +1006,7 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 		// Run the original benchmark function.
 		var iPfOfB *benchmarkPrivateFields
 		var recoverFunc *func(r any)
+		var benchmarkSkipReason string
 		instrumentedFunc := func(b *testing.B) {
 			// Stop the timer to perform initialization and replacements.
 			b.StopTimer()
@@ -1025,6 +1044,7 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 				execMeta = createTestMetadata(b, nil)
 				defer deleteTestMetadata(b)
 			}
+			defer func() { benchmarkSkipReason = execMeta.skipReason }()
 
 			// Sets the CI Visibility test
 			execMeta.test = test
@@ -1039,6 +1059,7 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 		b.Run(b.Name(), instrumentedFunc)
 
 		endTime := time.Now()
+		test.SetTag(constants.TestActiveDuration, max(endTime.Sub(startTime), 0).Nanoseconds())
 		results := iPfOfB.result
 
 		// Set benchmark data for CI visibility.
@@ -1085,7 +1106,12 @@ func (ddm *M) executeInternalBenchmark(benchmarkInfo *testingBInfo) func(*testin
 			module.SetTag(ext.Error, true)
 			test.Close(integrations.ResultStatusFail, integrations.WithTestFinishTime(endTime))
 		} else if iPfOfB.B.Skipped() {
-			test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
+			test.SetTag(constants.TestFinalStatus, constants.TestStatusSkip)
+			if benchmarkSkipReason != "" {
+				test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime), integrations.WithTestSkipReason(benchmarkSkipReason))
+			} else {
+				test.Close(integrations.ResultStatusSkip, integrations.WithTestFinishTime(endTime))
+			}
 		} else {
 			test.Close(integrations.ResultStatusPass, integrations.WithTestFinishTime(endTime))
 		}

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -55,7 +55,7 @@ func GetTest(t *testing.T) *T {
 // Run may be called simultaneously from multiple goroutines, but all such calls
 // must return before the outer test function for t returns.
 func (ddt *T) Run(name string, f func(*testing.T)) bool {
-	f = instrumentTestingTFuncWithOptions(f, true)
+	f = instrumentTestingTFuncWithParallelBaseline(f)
 	t := (*testing.T)(ddt)
 	return t.Run(name, f)
 }

--- a/internal/civisibility/integrations/gotesting/testingT.go
+++ b/internal/civisibility/integrations/gotesting/testingT.go
@@ -55,7 +55,7 @@ func GetTest(t *testing.T) *T {
 // Run may be called simultaneously from multiple goroutines, but all such calls
 // must return before the outer test function for t returns.
 func (ddt *T) Run(name string, f func(*testing.T)) bool {
-	f = instrumentTestingTFunc(f)
+	f = instrumentTestingTFuncWithOptions(f, true)
 	t := (*testing.T)(ddt)
 	return t.Run(name, f)
 }

--- a/internal/civisibility/integrations/gotesting/testing_clock_windows.go
+++ b/internal/civisibility/integrations/gotesting/testing_clock_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package gotesting
+
+import (
+	"math/bits"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	testingKernel32                  = windows.NewLazySystemDLL("kernel32.dll")
+	testingQueryPerformanceCounter   = testingKernel32.NewProc("QueryPerformanceCounter")
+	testingQueryPerformanceFrequency = testingKernel32.NewProc("QueryPerformanceFrequency")
+	testingClockFrequencyOnce        sync.Once
+	testingClockFrequencyValue       int64
+)
+
+func testingClockNow() (int64, bool) {
+	return testingPerformanceValue(testingQueryPerformanceCounter)
+}
+
+func testingClockFrequency() int64 {
+	testingClockFrequencyOnce.Do(func() {
+		frequency, ok := testingPerformanceValue(testingQueryPerformanceFrequency)
+		if ok && frequency > 0 {
+			testingClockFrequencyValue = frequency
+		}
+	})
+	return testingClockFrequencyValue
+}
+
+func testingPerformanceValue(proc *windows.LazyProc) (int64, bool) {
+	var value int64
+	ok, _, _ := proc.Call(uintptr(unsafe.Pointer(&value)))
+	return value, ok != 0
+}
+
+func testingClockDuration(delta, frequency int64) (time.Duration, bool) {
+	if delta < 0 || frequency <= 0 {
+		return 0, false
+	}
+	hi, lo := bits.Mul64(uint64(delta), uint64(time.Second)/uint64(time.Nanosecond))
+	if hi >= uint64(frequency) {
+		return 0, false
+	}
+	nanos, _ := bits.Div64(hi, lo, uint64(frequency))
+	if nanos > uint64(^uint64(0)>>1) {
+		return 0, false
+	}
+	return time.Duration(nanos), true
+}

--- a/internal/civisibility/integrations/gotesting/testing_clock_windows_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_clock_windows_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-func TestParallelCounterDuration(t *testing.T) {
+func TestTestingClockDuration(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		delta     int64
@@ -28,9 +28,9 @@ func TestParallelCounterDuration(t *testing.T) {
 		{name: "overflow", delta: math.MaxInt64, frequency: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := parallelCounterDuration(tc.delta, tc.frequency)
+			got, ok := testingClockDuration(tc.delta, tc.frequency)
 			if got != tc.want || ok != tc.ok {
-				t.Fatalf("parallelCounterDuration(%d, %d) = (%v, %t), want (%v, %t)", tc.delta, tc.frequency, got, ok, tc.want, tc.ok)
+				t.Fatalf("testingClockDuration(%d, %d) = (%v, %t), want (%v, %t)", tc.delta, tc.frequency, got, ok, tc.want, tc.ok)
 			}
 		})
 	}

--- a/internal/civisibility/integrations/gotesting/testing_test.go
+++ b/internal/civisibility/integrations/gotesting/testing_test.go
@@ -100,18 +100,18 @@ func TestParallelSubTests(gt *testing.T) {
 		<-time.After(300 * time.Millisecond) // Simulate some work
 		fmt.Println("Running parallel subtest 1")
 	})
-
 	t.Run("parallel_subtest_2", func(t *testing.T) {
 		t.Parallel()
 		<-time.After(200 * time.Millisecond) // Simulate some work
 		fmt.Println("Running parallel subtest 2")
 	})
-
 	t.Run("parallel_subtest_3", func(t *testing.T) {
 		t.Parallel()
 		<-time.After(100 * time.Millisecond) // Simulate some work
 		fmt.Println("Running parallel subtest 3")
 	})
+
+	time.Sleep(parallelSubtestBlockerDuration)
 }
 
 // Tests for test retries feature

--- a/internal/orchestrion/_integration/civisibility/civisibility_payload_mocks.go
+++ b/internal/orchestrion/_integration/civisibility/civisibility_payload_mocks.go
@@ -42,6 +42,7 @@ type (
 		TestModuleID  uint64             `json:"test_module_id"`
 		TestSuiteID   uint64             `json:"test_suite_id"`
 		SpanID        uint64             `json:"span_id"`
+		ParentID      uint64             `json:"parent_id"`
 		TraceID       uint64             `json:"trace_id"`
 		Name          string             `json:"name"`
 		Service       string             `json:"service"`

--- a/internal/orchestrion/_integration/civisibility/main_test.go
+++ b/internal/orchestrion/_integration/civisibility/main_test.go
@@ -15,9 +15,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DataDog/orchestrion/runtime/built"
 	"github.com/tinylib/msgp/msgp"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/civisibility/constants"
 )
 
 var ciVisibilityPayloads mockPayloads
@@ -54,7 +57,7 @@ func TestMain(m *testing.M) {
 		CheckEventsByResourceName("testing_test.go", 1)
 
 	// test events
-	testEvents := events.CheckEventsByType("test", 14)
+	testEvents := events.CheckEventsByType("test", 15)
 	normalTests := testEvents.
 		CheckEventsByResourceName("testing_test.go.TestNormal", 1).
 		CheckEventsByTagAndValue("test.status", "pass", 1)
@@ -105,6 +108,12 @@ func TestMain(m *testing.M) {
 	testWithParallelSubtestsChild3 := testEvents.
 		CheckEventsByResourceName("testing_test.go.TestWithParallelSubTests/Sub3", 1).
 		CheckEventsByTagAndValue("test.status", "pass", 1)
+	parallelSkip := testEvents.
+		CheckEventsByResourceName("testing_test.go.TestParallelSkip", 1).
+		CheckEventsByTagAndValue("test.status", "skip", 1).
+		CheckEventsByTagAndValue("test.skip_reason", "parallel skip", 1)
+
+	validateParallelTimingPayload(events, testEvents)
 
 	// remaining must be 0
 	testEvents.
@@ -122,11 +131,83 @@ func TestMain(m *testing.M) {
 			testWithParallelSubtests,
 			testWithParallelSubtestsChild1,
 			testWithParallelSubtestsChild2,
-			testWithParallelSubtestsChild3).
+			testWithParallelSubtestsChild3,
+			parallelSkip).
 		HasCount(0)
 
 	// All previous checks will cause panic if they fail so we can safely exit with 0 here
 	os.Exit(0)
+}
+
+func validateParallelTimingPayload(events, testEvents mockEvents) {
+	parallelTests := make(map[uint64]mockEvent, 5)
+	for _, event := range testEvents {
+		active, ok := event.Content.Metrics[constants.TestActiveDuration]
+		if !ok || active < 0 {
+			panic(fmt.Sprintf("test event is missing a valid %s metric: %+v", constants.TestActiveDuration, event))
+		}
+		isParallel, ok := event.Content.Meta[constants.TestIsParallel]
+		if !ok || (isParallel != "true" && isParallel != "false") {
+			panic(fmt.Sprintf("test event is missing a valid %s tag: %+v", constants.TestIsParallel, event))
+		}
+
+		_, hasStart := event.Content.Metrics[constants.TestParallelPauseStartOffset]
+		_, hasEnd := event.Content.Metrics[constants.TestParallelPauseEndOffset]
+		_, hasDuration := event.Content.Metrics[constants.TestParallelPauseDuration]
+		if isParallel == "false" {
+			if hasStart || hasEnd || hasDuration {
+				panic(fmt.Sprintf("non-parallel test event has parallel pause metrics: %+v", event))
+			}
+			continue
+		}
+		if !hasStart || !hasEnd || !hasDuration {
+			panic(fmt.Sprintf("parallel test event is missing pause metrics: %+v", event))
+		}
+		parallelTests[event.Content.SpanID] = event
+	}
+	if len(parallelTests) != 5 {
+		panic(fmt.Sprintf("expected exactly 5 parallel test events, got %d", len(parallelTests)))
+	}
+
+	waits := events.GetEventsByResourceName("testing.T.Parallel").CheckEventsByType("span", len(parallelTests))
+	for _, wait := range waits {
+		if wait.Content.Name != "testing.parallel.wait" || wait.Content.Type != "" ||
+			wait.Content.Meta["component"] != "go-testing" || wait.Content.Meta["test.parallel.wait"] != "true" {
+			panic(fmt.Sprintf("unexpected parallel wait event: %+v", wait))
+		}
+		parent, ok := parallelTests[wait.Content.ParentID]
+		if !ok || wait.Content.TraceID != parent.Content.TraceID {
+			panic(fmt.Sprintf("parallel wait event has no test parent in its trace: %+v", wait))
+		}
+		delete(parallelTests, wait.Content.ParentID)
+
+		startOffset := parent.Content.Metrics[constants.TestParallelPauseStartOffset]
+		endOffset := parent.Content.Metrics[constants.TestParallelPauseEndOffset]
+		pauseDuration := parent.Content.Metrics[constants.TestParallelPauseDuration]
+		activeDuration := parent.Content.Metrics[constants.TestActiveDuration]
+		if startOffset < 0 || endOffset < startOffset || pauseDuration != endOffset-startOffset {
+			panic(fmt.Sprintf("invalid parallel timing metrics: %+v", parent))
+		}
+		if wait.Content.Start != parent.Content.Start+uint64(startOffset) || float64(wait.Content.Duration) != pauseDuration {
+			panic(fmt.Sprintf("parallel wait event does not match its parent metrics: wait=%+v parent=%+v", wait, parent))
+		}
+		if activeDuration+pauseDuration > float64(parent.Content.Duration)+float64(time.Millisecond) {
+			panic(fmt.Sprintf("parallel active and pause durations exceed wall time: %+v", parent))
+		}
+
+		switch parent.Content.Resource {
+		case "testing_test.go.TestWithParallelSubTests/Sub1",
+			"testing_test.go.TestWithParallelSubTests/Sub2",
+			"testing_test.go.TestWithParallelSubTests/Sub3":
+			minimumPause := float64(parallelPayloadBlockerDuration - 25*time.Millisecond)
+			if pauseDuration < minimumPause || float64(parent.Content.Duration)-activeDuration < minimumPause {
+				panic(fmt.Sprintf("parallel child timing includes the serial blocker: %+v", parent))
+			}
+		}
+	}
+	if len(parallelTests) != 0 {
+		panic(fmt.Sprintf("parallel test events are missing wait children: %+v", parallelTests))
+	}
 }
 
 func enableCiVisibilityEndpointMock() *httptest.Server {

--- a/internal/orchestrion/_integration/civisibility/testing_test.go
+++ b/internal/orchestrion/_integration/civisibility/testing_test.go
@@ -5,7 +5,12 @@
 
 package civisibility
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+const parallelPayloadBlockerDuration = 75 * time.Millisecond
 
 func TestNormal(t *testing.T) {
 	t.Log("Normal test")
@@ -30,6 +35,15 @@ func TestWithParallelSubTests(t *testing.T) {
 			t.Logf("Parallel sub test %s", localName)
 		})
 	}
+
+	// Keep the children paused long enough for the payload assertions to prove
+	// that active duration excludes the native parallel wait.
+	time.Sleep(parallelPayloadBlockerDuration)
+}
+
+func TestParallelSkip(t *testing.T) {
+	t.Parallel()
+	t.Skip("parallel skip")
 }
 
 func TestFail(t *testing.T) {

--- a/internal/orchestrion/_integration/civisibilitytest/payloads.go
+++ b/internal/orchestrion/_integration/civisibilitytest/payloads.go
@@ -439,6 +439,20 @@ func (e Events) CheckEventsByMetricAndValue(metricName string, metricValue float
 	return result
 }
 
+// CheckEventsByMetricName returns events containing the given metric and panics if the count does not match.
+func (e Events) CheckEventsByMetricName(metricName string, count int) Events {
+	var result Events
+	for _, event := range e {
+		if _, ok := event.Content.Metrics[metricName]; ok {
+			result = append(result, event)
+		}
+	}
+	if len(result) != count {
+		panic(fmt.Sprintf("expected exactly %d event(s) with metric %s, got %d", count, metricName, len(result)))
+	}
+	return result
+}
+
 // Except returns events whose resource does not appear in any provided event collection.
 func (e Events) Except(groups ...Events) Events {
 	var filtered Events

--- a/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
+++ b/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
@@ -60,6 +60,9 @@ type scenarioConfig struct {
 	expectedTotalEvents int
 	// expectedRetryEvents is the exact number of test events marked as retries.
 	expectedRetryEvents int
+	// expectedParallelEvents is the exact number of test events that completed a
+	// native t.Parallel transition and must publish pause timing.
+	expectedParallelEvents int
 	// expectedFailureOutput is required in subprocess output when a scenario is
 	// expected to fail for a specific reason.
 	expectedFailureOutput string
@@ -316,6 +319,22 @@ func validateScenarioPayloads(payloads *civisibilitytest.Payloads, cfg scenarioC
 	payloads.CheckPayloadCountAtLeast(1)
 	events := testCycleEvents(payloads.Events()).HasCount(cfg.expectedTotalEvents)
 	testEvents := events.CheckEventsByType(constants.SpanTypeTest, cfg.expectedTestEvents)
+	testEvents.CheckEventsByMetricName(constants.TestActiveDuration, cfg.expectedTestEvents)
+	testEvents.CheckEventsByTagAndValue(constants.TestIsParallel, "true", cfg.expectedParallelEvents)
+	testEvents.CheckEventsByTagAndValue(constants.TestIsParallel, "false", cfg.expectedTestEvents-cfg.expectedParallelEvents)
+	for _, metric := range []string{
+		constants.TestParallelPauseStartOffset,
+		constants.TestParallelPauseEndOffset,
+		constants.TestParallelPauseDuration,
+	} {
+		testEvents.CheckEventsByMetricName(metric, cfg.expectedParallelEvents)
+	}
+	if cfg.expectedParallelEvents > 0 {
+		payloads.Events().
+			CheckEventsByResourceName("testing.T.Parallel", cfg.expectedParallelEvents).
+			CheckEventsByType("span", cfg.expectedParallelEvents).
+			CheckEventsByTagAndValue("test.parallel.wait", "true", cfg.expectedParallelEvents)
+	}
 	expectedResourceEvents := cfg.expectedResourceEvents
 	if expectedResourceEvents == 0 {
 		expectedResourceEvents = cfg.expectedTestEvents
@@ -348,6 +367,7 @@ func scenarioOrder() []string {
 		"TestFailNowSingleExecution",
 		"TestManualFailNowSingleExecution",
 		"BenchmarkManualFailNow",
+		"BenchmarkManualSkip",
 		"TestDuplicateParallel",
 		"TestConcurrentDuplicateParallel",
 		"TestSubtestDuplicateParallel",
@@ -357,15 +377,16 @@ func scenarioOrder() []string {
 func scenariosByName() map[string]scenarioConfig {
 	return map[string]scenarioConfig{
 		"TestParallelWrapperNoRetry": {
-			testName:              "TestParallelWrapperNoRetry",
-			settings:              efdSettings(1),
-			knownTests:            knownTests("TestParallelWrapperNoRetry"),
-			expectedTestEvents:    1,
-			expectedSuiteEvents:   1,
-			expectedModuleEvents:  1,
-			expectedSessionEvents: 1,
-			expectedTotalEvents:   4,
-			expectedRetryEvents:   0,
+			testName:               "TestParallelWrapperNoRetry",
+			settings:               efdSettings(1),
+			knownTests:             knownTests("TestParallelWrapperNoRetry"),
+			expectedTestEvents:     1,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    4,
+			expectedRetryEvents:    0,
+			expectedParallelEvents: 1,
 			validate: func(events civisibilitytest.Events, _ string) {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 1)
 				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
@@ -373,16 +394,17 @@ func scenariosByName() map[string]scenarioConfig {
 			},
 		},
 		"TestParallelEFDSequential": {
-			testName:              "TestParallelEFDSequential",
-			settings:              efdSettings(1),
-			knownTests:            knownTests("TestKnownBaseline"),
-			expectedTestEvents:    2,
-			expectedSuiteEvents:   1,
-			expectedModuleEvents:  1,
-			expectedSessionEvents: 1,
-			expectedTotalEvents:   5,
-			expectedRetryEvents:   1,
-			retryReason:           constants.EarlyFlakeDetectionRetryReason,
+			testName:               "TestParallelEFDSequential",
+			settings:               efdSettings(1),
+			knownTests:             knownTests("TestKnownBaseline"),
+			expectedTestEvents:     2,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    5,
+			expectedRetryEvents:    1,
+			expectedParallelEvents: 2,
+			retryReason:            constants.EarlyFlakeDetectionRetryReason,
 			validate: func(events civisibilitytest.Events, _ string) {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
 				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
@@ -390,17 +412,18 @@ func scenariosByName() map[string]scenarioConfig {
 			},
 		},
 		"TestParallelEFDParallel": {
-			testName:              "TestParallelEFDParallel",
-			settings:              efdSettings(2),
-			env:                   map[string]string{constants.CIVisibilityInternalParallelEarlyFlakeDetectionEnabled: "true"},
-			knownTests:            knownTests("TestKnownBaseline"),
-			expectedTestEvents:    3,
-			expectedSuiteEvents:   1,
-			expectedModuleEvents:  1,
-			expectedSessionEvents: 1,
-			expectedTotalEvents:   6,
-			expectedRetryEvents:   2,
-			retryReason:           constants.EarlyFlakeDetectionRetryReason,
+			testName:               "TestParallelEFDParallel",
+			settings:               efdSettings(2),
+			env:                    map[string]string{constants.CIVisibilityInternalParallelEarlyFlakeDetectionEnabled: "true"},
+			knownTests:             knownTests("TestKnownBaseline"),
+			expectedTestEvents:     3,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    6,
+			expectedRetryEvents:    2,
+			expectedParallelEvents: 3,
+			retryReason:            constants.EarlyFlakeDetectionRetryReason,
 			validate: func(events civisibilitytest.Events, _ string) {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 3)
 				events.CheckEventsWithoutTag(constants.TestFinalStatus, 3)
@@ -415,13 +438,14 @@ func scenariosByName() map[string]scenarioConfig {
 				constants.CIVisibilityFlakyRetryCountEnvironmentVariable:      "1",
 				constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable: "1",
 			},
-			expectedTestEvents:    2,
-			expectedSuiteEvents:   1,
-			expectedModuleEvents:  1,
-			expectedSessionEvents: 1,
-			expectedTotalEvents:   5,
-			expectedRetryEvents:   1,
-			retryReason:           constants.AutoTestRetriesRetryReason,
+			expectedTestEvents:     2,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    5,
+			expectedRetryEvents:    1,
+			expectedParallelEvents: 2,
+			retryReason:            constants.AutoTestRetriesRetryReason,
 			validate: func(events civisibilitytest.Events, _ string) {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 1)
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 1)
@@ -435,14 +459,15 @@ func scenariosByName() map[string]scenarioConfig {
 				constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable: "2",
 				constants.CIVisibilityTestManagementEnabledEnvironmentVariable:             "true",
 			},
-			testManagement:        attemptToFixTests(),
-			expectedTestEvents:    2,
-			expectedSuiteEvents:   1,
-			expectedModuleEvents:  1,
-			expectedSessionEvents: 1,
-			expectedTotalEvents:   5,
-			expectedRetryEvents:   1,
-			retryReason:           constants.AttemptToFixRetryReason,
+			testManagement:         attemptToFixTests(),
+			expectedTestEvents:     2,
+			expectedSuiteEvents:    1,
+			expectedModuleEvents:   1,
+			expectedSessionEvents:  1,
+			expectedTotalEvents:    5,
+			expectedRetryEvents:    1,
+			expectedParallelEvents: 2,
+			retryReason:            constants.AttemptToFixRetryReason,
 			validate: func(events civisibilitytest.Events, _ string) {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
 				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
@@ -517,6 +542,20 @@ func scenariosByName() map[string]scenarioConfig {
 				events.CheckEventsByTagAndValue(constants.TestType, constants.TestTypeBenchmark, 1)
 			},
 		},
+		"BenchmarkManualSkip": {
+			testName:              "BenchmarkManualSkip",
+			expectedTestEvents:    1,
+			expectedSuiteEvents:   1,
+			expectedModuleEvents:  1,
+			expectedSessionEvents: 1,
+			expectedTotalEvents:   4,
+			runBenchmark:          true,
+			validate: func(events civisibilitytest.Events, _ string) {
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusSkip, 1)
+				events.CheckEventsByTagAndValue(constants.TestSkipReason, "manual benchmark skip", 1)
+				events.CheckEventsByTagAndValue(constants.TestType, constants.TestTypeBenchmark, 1)
+			},
+		},
 		"TestDuplicateParallel": {
 			testName: "TestDuplicateParallel",
 			settings: flakyRetrySettings(),
@@ -553,6 +592,7 @@ func scenariosByName() map[string]scenarioConfig {
 			expectedSessionEvents:   1,
 			expectedTotalEvents:     7,
 			expectedRetryEvents:     2,
+			expectedParallelEvents:  2,
 			retryReason:             constants.AutoTestRetriesRetryReason,
 			expectedResourceEvents:  2,
 			resourceName:            suiteName + ".TestSubtestDuplicateParallel/child",
@@ -720,4 +760,11 @@ func BenchmarkManualFailNow(b *testing.B) {
 		b.Skip("scenario not selected")
 	}
 	gotesting.GetBenchmark(b).FailNow()
+}
+
+func BenchmarkManualSkip(b *testing.B) {
+	if os.Getenv(scenarioEnv) != "BenchmarkManualSkip" {
+		b.Skip("scenario not selected")
+	}
+	gotesting.GetBenchmark(b).Skip("manual benchmark skip")
 }

--- a/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
+++ b/internal/orchestrion/_integration/parallel_testing_retries/parallel_testing_retries_test.go
@@ -32,7 +32,8 @@ const (
 	moduleName = "github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/parallel_testing_retries"
 	suiteName  = "parallel_testing_retries_test.go"
 
-	parallelPanic = "testing: t.Parallel called multiple times"
+	parallelPanic           = "testing: t.Parallel called multiple times"
+	parallelCleanupDuration = 25 * time.Millisecond
 )
 
 // scenarioConfig describes one subprocess scenario and the exact CI Visibility
@@ -63,6 +64,9 @@ type scenarioConfig struct {
 	// expectedParallelEvents is the exact number of test events that completed a
 	// native t.Parallel transition and must publish pause timing.
 	expectedParallelEvents int
+	// suppressParallelWaitEvents expects the noop tracer to omit the generic wait
+	// span while retaining the test event's parallel timing metrics.
+	suppressParallelWaitEvents bool
 	// expectedFailureOutput is required in subprocess output when a scenario is
 	// expected to fail for a specific reason.
 	expectedFailureOutput string
@@ -218,6 +222,7 @@ func scenarioEnvForChild(environ []string, cfg scenarioConfig) []string {
 		constants.CIVisibilityTestManagementEnabledEnvironmentVariable:             {},
 		constants.CIVisibilityTestManagementAttemptToFixRetriesEnvironmentVariable: {},
 		constants.CIVisibilityInternalParallelEarlyFlakeDetectionEnabled:           {},
+		constants.CIVisibilityUseNoopTracer:                                        {},
 	}
 	for _, entry := range environ {
 		key, _, _ := strings.Cut(entry, "=")
@@ -329,12 +334,14 @@ func validateScenarioPayloads(payloads *civisibilitytest.Payloads, cfg scenarioC
 	} {
 		testEvents.CheckEventsByMetricName(metric, cfg.expectedParallelEvents)
 	}
-	if cfg.expectedParallelEvents > 0 {
-		payloads.Events().
-			CheckEventsByResourceName("testing.T.Parallel", cfg.expectedParallelEvents).
-			CheckEventsByType("span", cfg.expectedParallelEvents).
-			CheckEventsByTagAndValue("test.parallel.wait", "true", cfg.expectedParallelEvents)
+	expectedParallelWaitEvents := cfg.expectedParallelEvents
+	if cfg.suppressParallelWaitEvents {
+		expectedParallelWaitEvents = 0
 	}
+	payloads.Events().
+		CheckEventsByResourceName("testing.T.Parallel", expectedParallelWaitEvents).
+		CheckEventsByType("span", expectedParallelWaitEvents).
+		CheckEventsByTagAndValue("test.parallel.wait", "true", expectedParallelWaitEvents)
 	expectedResourceEvents := cfg.expectedResourceEvents
 	if expectedResourceEvents == 0 {
 		expectedResourceEvents = cfg.expectedTestEvents
@@ -359,6 +366,8 @@ func validateScenarioPayloads(payloads *civisibilitytest.Payloads, cfg scenarioC
 func scenarioOrder() []string {
 	return []string{
 		"TestParallelWrapperNoRetry",
+		"TestDeniedParallel",
+		"TestParallelNoopTracer",
 		"TestParallelEFDSequential",
 		"TestParallelEFDParallel",
 		"TestParallelFlakyRetry",
@@ -393,6 +402,36 @@ func scenariosByName() map[string]scenarioConfig {
 				events.CheckEventsWithoutTag(constants.TestIsNew, 1)
 			},
 		},
+		"TestDeniedParallel": {
+			testName:                "TestDeniedParallel",
+			expectedTestEvents:      1,
+			expectedSuiteEvents:     1,
+			expectedModuleEvents:    1,
+			expectedSessionEvents:   1,
+			expectedTotalEvents:     4,
+			expectedFailureOutput:   "can not use t.Parallel",
+			expectFailure:           true,
+			validateFailureInParent: true,
+			validate: func(events civisibilitytest.Events, _ string) {
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusFail, 1)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusFail, 1)
+			},
+		},
+		"TestParallelNoopTracer": {
+			testName:                   "TestParallelNoopTracer",
+			env:                        map[string]string{constants.CIVisibilityUseNoopTracer: "true"},
+			expectedTestEvents:         1,
+			expectedSuiteEvents:        1,
+			expectedModuleEvents:       1,
+			expectedSessionEvents:      1,
+			expectedTotalEvents:        4,
+			expectedParallelEvents:     1,
+			suppressParallelWaitEvents: true,
+			validate: func(events civisibilitytest.Events, _ string) {
+				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 1)
+				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
+			},
+		},
 		"TestParallelEFDSequential": {
 			testName:               "TestParallelEFDSequential",
 			settings:               efdSettings(1),
@@ -409,6 +448,15 @@ func scenariosByName() map[string]scenarioConfig {
 				events.CheckEventsByTagAndValue(constants.TestStatus, constants.TestStatusPass, 2)
 				events.CheckEventsByTagAndValue(constants.TestFinalStatus, constants.TestStatusPass, 1)
 				events.CheckEventsByTagAndValue(constants.TestIsNew, "true", 2)
+				for _, event := range events {
+					unaccountedDuration := float64(event.Content.Duration) -
+						event.Content.Metrics[constants.TestActiveDuration] -
+						event.Content.Metrics[constants.TestParallelPauseDuration]
+					minimumCleanupDuration := float64((parallelCleanupDuration - 5*time.Millisecond).Nanoseconds())
+					if unaccountedDuration < minimumCleanupDuration {
+						panic(fmt.Sprintf("expected cleanup outside active duration, got %vns", unaccountedDuration))
+					}
+				}
 			},
 		},
 		"TestParallelEFDParallel": {
@@ -669,6 +717,18 @@ func skipUnlessScenario(t *testing.T, name string) {
 
 func TestParallelEFDSequential(t *testing.T) {
 	skipUnlessScenario(t, "TestParallelEFDSequential")
+	t.Cleanup(func() { time.Sleep(parallelCleanupDuration) })
+	t.Parallel()
+}
+
+func TestDeniedParallel(t *testing.T) {
+	skipUnlessScenario(t, "TestDeniedParallel")
+	t.Setenv("PARALLEL_TESTING_RETRIES_DENY_PARALLEL", "true")
+	t.Parallel()
+}
+
+func TestParallelNoopTracer(t *testing.T) {
+	skipUnlessScenario(t, "TestParallelNoopTracer")
 	t.Parallel()
 }
 

--- a/internal/orchestrion/_integration/retryprocess/main_test.go
+++ b/internal/orchestrion/_integration/retryprocess/main_test.go
@@ -97,19 +97,26 @@ func runOrchestrionRetryProcessController(t *testing.T, runFilter string, extraE
 }
 
 type retryProcessChildResult struct {
-	Version      int    `json:"version"`
-	TestName     string `json:"test_name"`
-	Attempt      int    `json:"attempt"`
-	RetryReason  string `json:"retry_reason"`
-	Status       string `json:"status"`
-	Failed       bool   `json:"failed"`
-	Skipped      bool   `json:"skipped"`
-	Panic        bool   `json:"panic"`
-	ErrorType    string `json:"error_type"`
-	ErrorMessage string `json:"error_message"`
-	ErrorStack   string `json:"error_stack"`
-	SkipReason   string `json:"skip_reason"`
-	ResultError  string `json:"result_error"`
+	Version                       int    `json:"version"`
+	TestName                      string `json:"test_name"`
+	Attempt                       int    `json:"attempt"`
+	RetryReason                   string `json:"retry_reason"`
+	Status                        string `json:"status"`
+	DurationNanos                 int64  `json:"duration_nanos"`
+	DurationValid                 bool   `json:"duration_valid"`
+	ObservedActiveDurationNanos   int64  `json:"observed_active_duration_nanos"`
+	ObservedActiveDurationValid   bool   `json:"observed_active_duration_valid"`
+	RootParallel                  bool   `json:"root_parallel"`
+	ParallelPauseStartOffsetNanos *int64 `json:"parallel_pause_start_offset_nanos,omitempty"`
+	ParallelPauseEndOffsetNanos   *int64 `json:"parallel_pause_end_offset_nanos,omitempty"`
+	Failed                        bool   `json:"failed"`
+	Skipped                       bool   `json:"skipped"`
+	Panic                         bool   `json:"panic"`
+	ErrorType                     string `json:"error_type"`
+	ErrorMessage                  string `json:"error_message"`
+	ErrorStack                    string `json:"error_stack"`
+	SkipReason                    string `json:"skip_reason"`
+	ResultError                   string `json:"result_error"`
 }
 
 type orchestrionCountingStringer struct {
@@ -842,11 +849,18 @@ func TestOrchestrionRetryProcessChildModeController(t *testing.T) {
 		t.Fatalf("orchestrion child process failed: %v\n%s", err, output)
 	}
 
-	if result.Version != 1 ||
+	if result.Version != 2 ||
 		result.TestName != "TestOrchestrionRetryProcessSelectedChild" ||
 		result.Attempt != 1 ||
 		result.RetryReason != constants.AutoTestRetriesRetryReason ||
 		result.Status != "pass" ||
+		!result.DurationValid ||
+		result.DurationNanos < 0 ||
+		!result.ObservedActiveDurationValid ||
+		result.ObservedActiveDurationNanos < 0 ||
+		result.RootParallel ||
+		result.ParallelPauseStartOffsetNanos != nil ||
+		result.ParallelPauseEndOffsetNanos != nil ||
 		result.Failed ||
 		result.Skipped {
 		t.Fatalf("unexpected child result: %+v\n%s", result, output)
@@ -1018,11 +1032,18 @@ func TestOrchestrionRetryProcessNoMatchingChildModeController(t *testing.T) {
 		t.Fatalf("orchestrion no-matching child process failed: %v\n%s", err, output)
 	}
 
-	if result.Version != 1 ||
+	if result.Version != 2 ||
 		result.TestName != "TestOrchestrionRetryProcessMissingChild" ||
 		result.Attempt != 1 ||
 		result.RetryReason != constants.AutoTestRetriesRetryReason ||
 		result.Status != "not_run" ||
+		result.DurationValid ||
+		result.DurationNanos != 0 ||
+		result.ObservedActiveDurationValid ||
+		result.ObservedActiveDurationNanos != 0 ||
+		result.RootParallel ||
+		result.ParallelPauseStartOffsetNanos != nil ||
+		result.ParallelPauseEndOffsetNanos != nil ||
 		result.Failed ||
 		result.Skipped {
 		t.Fatalf("unexpected no-matching child result: %+v\n%s", result, output)


### PR DESCRIPTION
### What does this PR do?

Keeps the Go test event's existing wall-clock start and duration, and reports the time excluded by `testing.T.Parallel` separately:

- every Go test and benchmark event gets `test.active_duration` (nanoseconds) and `test.is_parallel`;
- confirmed parallel tests also get `test.parallel.pause.start_offset`, `test.parallel.pause.end_offset`, and `test.parallel.pause.duration`;
- the pause is represented as a `testing.parallel.wait` child span so it is visible in the flame graph;
- manual instrumentation, Orchestrion, fresh in-process retries, process-isolated retries, skips, and benchmarks share the same contract;
- retry policy consumers such as EFD continue to use Go's duration semantics, including cleanup but excluding the parallel pause, rather than the event wall time.

The three duration values have different purposes:

```text
event duration  = complete wall-clock envelope
active duration = test body - T.Parallel scheduler wait
policy duration = active duration + cleanup
```

The implementation caches the private `testing` layout once, fails closed when the layout is unsupported, and leaves native parallel scheduling untouched. The common non-parallel paths remain allocation-free.

This is a draft because the new tag and child-span schema still needs CI Visibility backend/UI confirmation before the PR is ready for review.

### Motivation

Fixes #5137.

Go deliberately excludes the suspension inside `t.Parallel()` from its reported duration, while the CI Visibility event currently spans that wait. Preserving the wall-clock envelope and exposing the active and paused intervals separately keeps the complete timeline while making the actual test execution time queryable.

### Testing

- focused timing, fresh-retry finalization, and process-protocol tests with Go 1.25.0 and Go 1.26.5
- focused `go test -race` coverage for timing, process retries, and protocol validation
- `go vet ./internal/civisibility/integrations/gotesting`
- Windows amd64 cross-compilation with Go 1.25.0 and Go 1.26.5; Linux amd64 cross-compilation with Go 1.26.5
- timing benchmarks: 0 allocations for both manual baseline capture and the Orchestrion non-parallel path

### Reviewer's Checklist

- [x] Changed code has focused unit and integration coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for the new hot paths.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] No generated files or dependency files changed.
- [x] No `go.mod` changes were made.
