### PR TITLE
fix(civisibility): fix flaky and Go 1.27-breaking quarantined race isolation tests

### DIFF
--- a/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
+++ b/internal/civisibility/integrations/gotesting/quarantine_process_race_test.go
@@ -67,13 +67,16 @@ func runQuarantinedRaceIsolationFixture(m *testing.M) {
 	if scenario == "parallel-root-slots" || scenario == "parallel-root-coordination" {
 		requireEnv(constants.CIVisibilityRetryProcessMaxConcurrencyEnvironmentVariable, "1")
 	}
-	// These fixture limits detect protocol deadlocks, not instrumentation speed:
-	// race and coverage teardown can legitimately take several seconds in CI.
+	// These fixture limits detect protocol deadlocks, not instrumentation speed.
+	// Each scenario re-execs the test binary twice (fixture child, then the
+	// quarantine machinery's own grandchild), and that grandchild is race- and
+	// coverage-instrumented, so process startup alone can take several seconds
+	// under load or inside a sandbox (e.g. the gotip gVisor job).
 	if scenario == "parallel-atf-sibling" {
-		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "10s")
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "30s")
 	}
 	if scenario == "parallel-denied" {
-		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "5s")
+		requireEnv(constants.CIVisibilityRetryProcessTimeoutEnvironmentVariable, "30s")
 	}
 
 	module := "github.com/DataDog/dd-trace-go/v2/internal/civisibility/integrations/gotesting"
@@ -721,11 +724,11 @@ func TestQuarantinedRaceFailfastEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceParallelAdmissionEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$", "-test.timeout=15s")
+	runQuarantinedRaceEndToEnd(t, "parallel-admission", "^TestQuarantinedRaceParallelFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceParallelDeniedEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-denied", "^TestQuarantinedRaceParallelDeniedFixture$", "-test.timeout=10s")
+	runQuarantinedRaceEndToEnd(t, "parallel-denied", "^TestQuarantinedRaceParallelDeniedFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceParallelRootsReleaseProcessSlotsEndToEnd(t *testing.T) {
@@ -740,7 +743,7 @@ func TestQuarantinedRaceParallelCoverageEndToEnd(t *testing.T) {
 	if testing.CoverMode() == "" {
 		t.Skip("requires coverage instrumentation")
 	}
-	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$", "-test.timeout=15s")
+	runQuarantinedRaceEndToEnd(t, "parallel-coverage", "^TestQuarantinedRaceParallelCoverageFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceNestedAggregateCoverageEndToEnd(t *testing.T) {
@@ -843,7 +846,7 @@ func TestQuarantinedRaceOwnerGenerationFinalityEndToEnd(t *testing.T) {
 }
 
 func TestQuarantinedRaceParallelATFSiblingEndToEnd(t *testing.T) {
-	runQuarantinedRaceEndToEnd(t, "parallel-atf-sibling", "^TestQuarantinedRaceParallelATFFixture$", "-test.timeout=15s")
+	runQuarantinedRaceEndToEnd(t, "parallel-atf-sibling", "^TestQuarantinedRaceParallelATFFixture$", "-test.timeout=1m")
 }
 
 func TestQuarantinedRaceSerialATFDoesNotRepeatSiblingEndToEnd(t *testing.T) {
@@ -929,6 +932,18 @@ func processCoverageCountForFunction(t *testing.T, profilePath, sourcePath, func
 	return total
 }
 
+// processCoverageCountForFunctionBody returns the execution count of the
+// entry block of functionName's body: among the profile's blocks contained
+// within the body's brace positions, the one that starts earliest.
+//
+// This can't match the body's brace positions exactly: Go 1.27's cmd/cover
+// trims blocks to lines containing executable code, so a body block no
+// longer spans from '{' to '}' the way it did on earlier toolchains (e.g. a
+// gapless single-statement body now starts at the first code token instead
+// of the opening brace). Both shapes still yield exactly one contained
+// block for the functions this helper is used on, so containment plus
+// "earliest start" preserves the original per-entry counting semantics
+// across toolchains.
 func processCoverageCountForFunctionBody(t *testing.T, profilePath, sourcePath, functionName string) int {
 	t.Helper()
 	fset := token.NewFileSet()
@@ -944,19 +959,31 @@ func processCoverageCountForFunctionBody(t *testing.T, profilePath, sourcePath, 
 	require.NotZero(t, start.Line)
 	profile, err := os.ReadFile(profilePath)
 	require.NoError(t, err)
+	found := false
+	var entryStartLine, entryStartColumn, entryCount int
 	for _, line := range strings.Split(string(profile), "\n") {
 		separator := strings.LastIndexByte(line, ':')
 		if separator < 0 || !strings.HasSuffix(filepath.ToSlash(line[:separator]), "/gotesting/"+filepath.Base(sourcePath)) {
 			continue
 		}
 		var startLine, startColumn, endLine, endColumn, statements, count int
-		if _, err := fmt.Sscanf(line[separator+1:], "%d.%d,%d.%d %d %d", &startLine, &startColumn, &endLine, &endColumn, &statements, &count); err == nil &&
-			startLine == start.Line && startColumn == start.Column && endLine == finish.Line && endColumn == finish.Column {
-			return count
+		if _, err := fmt.Sscanf(line[separator+1:], "%d.%d,%d.%d %d %d", &startLine, &startColumn, &endLine, &endColumn, &statements, &count); err != nil {
+			continue
+		}
+		if startLine < start.Line || (startLine == start.Line && startColumn < start.Column) {
+			continue
+		}
+		if endLine > finish.Line || (endLine == finish.Line && endColumn > finish.Column) {
+			continue
+		}
+		if !found || startLine < entryStartLine || (startLine == entryStartLine && startColumn < entryStartColumn) {
+			found, entryStartLine, entryStartColumn, entryCount = true, startLine, startColumn, count
 		}
 	}
-	t.Fatalf("coverage block for %s not found", functionName)
-	return 0
+	if !found {
+		t.Fatalf("coverage block for %s not found", functionName)
+	}
+	return entryCount
 }
 
 func writeQuarantinedRaceIsolationPID(t *testing.T, name string) {


### PR DESCRIPTION
## What does this PR do?

Fixes the `internal/civisibility/integrations/gotesting` test failures seen in the nightly [Gotip Testing job](https://github.com/DataDog/dd-trace-go/actions/runs/31981258703/job/95248317571) on `main`, and in the [stable-Go main-branch-tests job](https://github.com/DataDog/dd-trace-go/actions/runs/31980880002) on the same commit. All failures trace back to `#5166`, the PR that introduced these tests, and split into two independent root causes.

### 1. Go 1.27 changed `cmd/cover` block coordinates

`TestQuarantinedRaceDeferredAggregateCoverageEndToEnd` and `TestQuarantinedRaceNestedAggregateCoverageEndToEnd` fail with `coverage block for ... not found` on every gotip run, never on stable Go.

`processCoverageCountForFunctionBody` exact-matched a coverage profile block's `start/end` against a function body's brace positions (`fn.Body.Pos()`/`fn.Body.End()`). Go 1.27 added `codeRanges` to `cmd/cover`, which trims blocks to the lines that actually contain executable code — a gapless single-statement body no longer produces a block starting at `{`. Verified empirically: for the same source file, the emitted start column moved from the `{` (col 45, go1.26.6) to the first code token (col 47, go1.27rc1).

Fix: match by containment (the profile block falls within the body's span) and take the earliest-starting contained block, instead of requiring exact coordinates. Both toolchain shapes still produce exactly one contained block for the two marker functions this helper targets, so the `controlCount+1` assertions keep their original per-entry-execution semantics.

This isn't gotip-only forever — it will break the regular PR/main CI once `actions/setup-go`'s `stable` reaches Go 1.27.

### 2. Fixture process budgets are too tight

`TestQuarantinedRaceParallelAdmissionEndToEnd`, `...ParallelDeniedEndToEnd`, `...ParallelATFSiblingEndToEnd`, and `...ParallelCoverageEndToEnd` override the inherited `-test.timeout` down to 10-15s (two also set `DD_CIVISIBILITY_RETRY_PROCESS_TIMEOUT` to 5s/10s). That budget has to cover a *double* re-exec: the fixture binary re-runs itself, and the quarantine machinery then spawns a grandchild re-exec of the same race- and coverage-instrumented binary, whose usable budget is further reduced by the parent's ~5.5s shutdown/reserve margin.

The stable-Go failure log is decisive — the grandchild **passed** and the parent still gave up:

```
quarantine_process.go:1614: CI Visibility quarantined test isolation failed: timeout: <nil>
    --- PASS: TestQuarantinedRaceParallelCoverageFixture (7.19s)
    PASS
```

Fix: raise these budgets to `1m` / `30s`, matching the neighboring `parallel-root-slots` / `parallel-root-coordination` scenarios that already use `1m` and have never flaked. The bound stays finite, so a genuine protocol deadlock still fails — just with more headroom for process-startup cost under load or inside the gotip job's gVisor sandbox.

## Verification

- `go vet -race ./internal/civisibility/integrations/gotesting/...` — clean.
- Ran the full package test suite (`-race -covermode=atomic -timeout=20m`) on both `go1.25.0` (stable-equivalent) and `go1.27rc1` (gotip-equivalent). On both toolchains the `ProcessRetryUnitTests` scenario — which contains every `TestQuarantinedRace*EndToEnd` test touched here — completed with no `FAILED WITH EXIT CODE`.
- Ran `TestQuarantinedRaceDeferredAggregateCoverageEndToEnd` / `...NestedAggregateCoverageEndToEnd` individually: both pass.
- The only failures observed in the full-suite runs are in unrelated legacy scenarios (`TestImpactedTests`, `TestFlakyTestRetriesAndEarlyFlakeDetection`); confirmed via `git stash` that these reproduce identically on the unmodified base commit, so they're pre-existing flakiness, out of scope here.

## Why?

CI has been red on `main` for the last several nights, and the same failure now also hits the stable-Go job — this isn't a gotip-only flake.