### PR TITLE
fix(contrib/gin): handle nil requests in response advice

### DIFF
--- a/contrib/gin-gonic/gin/orchestrion.yml
+++ b/contrib/gin-gonic/gin/orchestrion.yml
@@ -116,8 +116,10 @@ aspects:
           template: |-
             {{- $c := .Function.Receiver -}}
             {{- $i := .Function.Argument 1 -}}
-            if __err__ := appsec.MonitorHTTPResponseBody({{ $c }}.Request.Context(), {{ $i }}); __err__ != nil {
-              // Request has been blocked by AppSec; aborting this handler right away. The AppSec
-              // handlers in the middleware chain will send the configured blocking response.
-              return
+            if __req__ := {{ $c }}.Request; __req__ != nil {
+              if __err__ := appsec.MonitorHTTPResponseBody(__req__.Context(), {{ $i }}); __err__ != nil {
+                // Request has been blocked by AppSec; aborting this handler right away. The AppSec
+                // handlers in the middleware chain will send the configured blocking response.
+                return
+              }
             }

--- a/internal/orchestrion/_integration/gin/generated_test.go
+++ b/internal/orchestrion/_integration/gin/generated_test.go
@@ -17,6 +17,10 @@ func TestBase(t *testing.T) {
 	harness.Run(t, new(TestCaseBase))
 }
 
+func TestNilRequest(t *testing.T) {
+	harness.Run(t, new(TestCaseNilRequest))
+}
+
 func TestResponse(t *testing.T) {
 	harness.Run(t, new(TestCaseResponse))
 }

--- a/internal/orchestrion/_integration/gin/nil_request.go
+++ b/internal/orchestrion/_integration/gin/nil_request.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package gin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/orchestrion/_integration/internal/trace"
+)
+
+type TestCaseNilRequest struct {
+	ctx      *gin.Context
+	recorder *httptest.ResponseRecorder
+}
+
+func (tc *TestCaseNilRequest) Setup(_ context.Context, t *testing.T) {
+	tc.recorder = httptest.NewRecorder()
+	tc.ctx, _ = gin.CreateTestContext(tc.recorder)
+	require.Nil(t, tc.ctx.Request)
+}
+
+func (tc *TestCaseNilRequest) Run(_ context.Context, t *testing.T) {
+	require.NotPanics(t, func() {
+		tc.ctx.JSON(http.StatusCreated, gin.H{"status": "ok"})
+	})
+	require.Equal(t, http.StatusCreated, tc.recorder.Code)
+}
+
+func (*TestCaseNilRequest) ExpectedTraces() trace.Traces {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Guard Gin's response-body AppSec advice when `gin.Context.Request` is nil, and add an Orchestrion integration regression test covering a render-only context created with `gin.CreateTestContext`.

### Motivation

Shepherd's scheduled Go workflow began failing consistently after its Orchestrion dependency advanced from 1.12.0 to 1.12.1. Both the default and coverage Gin jobs panic in Gin's upstream `TestContextRenderJSON` because the generated response advice calls `Context.Request.Context()` even though Gin intentionally permits test contexts without a request.

Failing scheduled run: https://github.com/DataDog/shepherd/actions/runs/32114790192

The last green and first failing Shepherd runs used the same dd-trace-go revision; only Orchestrion changed (1.12.0 to 1.12.1). Re-running the new regression test against the unmodified base with Orchestrion 1.12.1 reproduces the same nil-pointer panic. This patch makes the advice a no-op when no request exists while preserving response monitoring for normal request-backed contexts.

### Validation

- Regression test with Orchestrion 1.12.1: fails on the base revision with `net/http.(*Request).Context`; passes with this change
- `go test ./... -count=1` in `contrib/gin-gonic/gin`
- Full Gin Orchestrion integration suite with the repository-pinned Orchestrion version
- Full Gin Orchestrion integration suite with Orchestrion 1.12.1
- Shepherd `gin-default` end-to-end run against this branch with Orchestrion 1.12.1: all 702 tests passed and all 36 mockdog assertions passed
- `make lint`
- `git diff --check`

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] System-Tests covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date.
- [x] No go.mod changes.
