### PR TITLE
feat(openfeature): send the split serial id on exposure events

### DIFF
--- a/openfeature/exposure.go
+++ b/openfeature/exposure.go
@@ -49,6 +49,7 @@ type exposureEvent struct {
 	Flag       exposureFlag       `json:"flag"`
 	Variant    exposureVariant    `json:"variant"`
 	Subject    exposureSubject    `json:"subject"`
+	SerialID   *uint32            `json:"serial_id,omitempty"`
 }
 
 // exposureAllocation represents allocation information in an exposure event
@@ -96,6 +97,8 @@ type exposureCacheKey struct {
 type exposureCacheValue struct {
 	allocationKey string
 	variant       string
+	serialID      uint32
+	hasSerialID   bool
 }
 
 // exposureCacheEntry stores the key and value for an LRU cache entry
@@ -127,10 +130,10 @@ func (c *exposureLRUCache) add(key exposureCacheKey, value exposureCacheValue) b
 		entry := elem.Value.(*exposureCacheEntry)
 		c.order.MoveToFront(elem)
 		if entry.value == value {
-			// Same allocation and variant - this is a duplicate
+			// Same allocation, variant and serial ID - this is a duplicate
 			return false
 		}
-		// Allocation or variant changed - update entry
+		// Allocation, variant or serial ID changed - update entry
 		entry.value = value
 		return true
 	}
@@ -242,6 +245,10 @@ func (w *exposureWriter) append(event exposureEvent) {
 	cacheValue := exposureCacheValue{
 		allocationKey: event.Allocation.Key,
 		variant:       event.Variant.Key,
+	}
+	if event.SerialID != nil {
+		cacheValue.serialID = *event.SerialID
+		cacheValue.hasSerialID = true
 	}
 
 	// Check deduplication cache - returns true if this is a new or changed entry

--- a/openfeature/exposure_hook.go
+++ b/openfeature/exposure_hook.go
@@ -59,6 +59,8 @@ func (h *exposureHook) After(
 		return nil
 	}
 
+	serialID := h.getSerialID(flagEvaluationDetails.FlagMetadata)
+
 	// Get targeting key (subject ID) from evaluation context
 	evalContext := hookContext.EvaluationContext()
 	targetingKey := evalContext.TargetingKey()
@@ -91,6 +93,7 @@ func (h *exposureHook) After(
 			Type:       "",           // Type is optional
 			Attributes: subjectAttrs, // Flattened, primitive-only attributes
 		},
+		SerialID: serialID,
 	}
 
 	// Send to writer for buffering and eventual flushing
@@ -123,6 +126,26 @@ func (h *exposureHook) shouldLog(metadata of.FlagMetadata) bool {
 	}
 
 	return doLogBool
+}
+
+// getSerialID extracts the split serial ID from flag metadata
+func (h *exposureHook) getSerialID(metadata of.FlagMetadata) *uint32 {
+	if metadata == nil {
+		return nil
+	}
+
+	raw, ok := metadata[metadataSplitSerialIDKey]
+	if !ok {
+		return nil
+	}
+
+	serialID, ok := raw.(uint32)
+	if !ok {
+		log.Debug("openfeature: serial id metadata is not a uint32")
+		return nil
+	}
+
+	return &serialID
 }
 
 // getAllocationKey extracts the allocation key from flag metadata

--- a/openfeature/exposure_test.go
+++ b/openfeature/exposure_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
 	of "github.com/open-feature/go-sdk/openfeature"
 )
 
@@ -104,6 +105,145 @@ func TestLRUCache_AllocationCycle(t *testing.T) {
 		if !result {
 			t.Errorf("allocation cycle step %d (%s) should return true", i+1, allocation)
 		}
+	}
+}
+
+func TestLRUCache_SerialIDAppears(t *testing.T) {
+	cache := newExposureLRUCache(defaultExposureCacheCapacity)
+
+	key := exposureCacheKey{flagKey: "test-flag", targetingKey: "user-123"}
+
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a"}) {
+		t.Fatal("first exposure should return true")
+	}
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a", serialID: 340132, hasSerialID: true}) {
+		t.Error("appearing serial id should return true")
+	}
+	if cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a", serialID: 340132, hasSerialID: true}) {
+		t.Error("repeating the same serial id should return false")
+	}
+}
+
+func TestLRUCache_SerialIDCycle(t *testing.T) {
+	cache := newExposureLRUCache(defaultExposureCacheCapacity)
+
+	key := exposureCacheKey{flagKey: "test-flag", targetingKey: "user-123"}
+
+	serialIDs := []uint32{340132, 340133, 340132}
+
+	for i, serialID := range serialIDs {
+		value := exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a", serialID: serialID, hasSerialID: true}
+		result := cache.add(key, value)
+		if !result {
+			t.Errorf("serial id cycle step %d (%d) should return true", i+1, serialID)
+		}
+	}
+}
+
+func TestLRUCache_SerialIDDisappears(t *testing.T) {
+	cache := newExposureLRUCache(defaultExposureCacheCapacity)
+
+	key := exposureCacheKey{flagKey: "test-flag", targetingKey: "user-123"}
+
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a", serialID: 340132, hasSerialID: true}) {
+		t.Fatal("first exposure should return true")
+	}
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a"}) {
+		t.Error("disappearing serial id should return true")
+	}
+}
+
+func TestLRUCache_SerialIDZeroIsNotAbsent(t *testing.T) {
+	cache := newExposureLRUCache(defaultExposureCacheCapacity)
+
+	key := exposureCacheKey{flagKey: "test-flag", targetingKey: "user-123"}
+
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a"}) {
+		t.Fatal("first exposure should return true")
+	}
+	if !cache.add(key, exposureCacheValue{allocationKey: "allocation-a", variant: "variant-a", serialID: 0, hasSerialID: true}) {
+		t.Error("serial id of zero should not match an absent serial id")
+	}
+}
+
+func TestExposureWriter_AppendCarriesSerialIDIntoCache(t *testing.T) {
+	writer := &exposureWriter{
+		buffer: make([]exposureEvent, 0, 256),
+		cache:  newExposureLRUCache(defaultExposureCacheCapacity),
+	}
+
+	event := exposureEvent{
+		Allocation: exposureAllocation{Key: "allocation-a"},
+		Flag:       exposureFlag{Key: "test-flag"},
+		Variant:    exposureVariant{Key: "variant-a"},
+		Subject:    exposureSubject{ID: "user-123"},
+	}
+
+	writer.append(event)
+
+	withSerialID := event
+	withSerialID.SerialID = uint32Ptr(340132)
+	writer.append(withSerialID)
+	writer.append(withSerialID)
+
+	if len(writer.buffer) != 2 {
+		t.Fatalf("expected 2 buffered events, got %d", len(writer.buffer))
+	}
+	if writer.buffer[0].SerialID != nil {
+		t.Errorf("expected no serial id on the first event, got %d", *writer.buffer[0].SerialID)
+	}
+	if writer.buffer[1].SerialID == nil {
+		t.Fatal("expected a serial id on the second event, got none")
+	}
+	if *writer.buffer[1].SerialID != 340132 {
+		t.Errorf("expected serial id 340132, got %d", *writer.buffer[1].SerialID)
+	}
+}
+
+func TestExposureEvent_SerialIDWireShape(t *testing.T) {
+	api := jsoniter.Config{}.Froze()
+
+	event := exposureEvent{
+		Timestamp:  1,
+		Allocation: exposureAllocation{Key: "allocation-a"},
+		Flag:       exposureFlag{Key: "test-flag"},
+		Variant:    exposureVariant{Key: "variant-a"},
+		Subject:    exposureSubject{ID: "user-123"},
+	}
+
+	tests := []struct {
+		name     string
+		serialID *uint32
+		expected any
+		present  bool
+	}{
+		{name: "serial id present", serialID: uint32Ptr(340132), expected: float64(340132), present: true},
+		{name: "serial id of zero is sent", serialID: uint32Ptr(0), expected: float64(0), present: true},
+		{name: "absent serial id is omitted", serialID: nil, present: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			event.SerialID = tc.serialID
+
+			data, err := api.Marshal(event)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %v", err)
+			}
+
+			var decoded map[string]any
+			if err := api.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+
+			got, ok := decoded["serial_id"]
+			if ok != tc.present {
+				t.Fatalf("expected serial_id present=%v, got present=%v (payload: %s)", tc.present, ok, data)
+			}
+			if tc.present && got != tc.expected {
+				t.Errorf("expected serial_id %v, got %v", tc.expected, got)
+			}
+		})
 	}
 }
 
@@ -349,6 +489,7 @@ func TestExposureHook_After(t *testing.T) {
 		metadata          of.FlagMetadata
 		expectEvent       bool
 		expectedSubjectID string
+		expectedSerialID  *uint32
 	}{
 		{
 			name:         "with targeting key",
@@ -405,6 +546,65 @@ func TestExposureHook_After(t *testing.T) {
 			variant:      "variant-a",
 			metadata:     nil,
 			expectEvent:  false, // no allocation key means no event
+		},
+		{
+			name:         "with serial id",
+			targetingKey: "user-123",
+			attributes:   map[string]any{},
+			flagKey:      "holdout-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey:    "test-allocation",
+				metadataDoLogKey:         true,
+				metadataSplitSerialIDKey: uint32(340132),
+			},
+			expectEvent:       true,
+			expectedSubjectID: "user-123",
+			expectedSerialID:  uint32Ptr(340132),
+		},
+		{
+			name:         "with serial id of zero",
+			targetingKey: "user-123",
+			attributes:   map[string]any{},
+			flagKey:      "holdout-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey:    "test-allocation",
+				metadataDoLogKey:         true,
+				metadataSplitSerialIDKey: uint32(0),
+			},
+			expectEvent:       true,
+			expectedSubjectID: "user-123",
+			expectedSerialID:  uint32Ptr(0),
+		},
+		{
+			name:         "without serial id",
+			targetingKey: "user-123",
+			attributes:   map[string]any{},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey: "test-allocation",
+				metadataDoLogKey:      true,
+			},
+			expectEvent:       true,
+			expectedSubjectID: "user-123",
+			expectedSerialID:  nil,
+		},
+		{
+			name:         "malformed serial id still reports the exposure",
+			targetingKey: "user-123",
+			attributes:   map[string]any{},
+			flagKey:      "test-flag",
+			variant:      "variant-a",
+			metadata: of.FlagMetadata{
+				metadataAllocationKey:    "test-allocation",
+				metadataDoLogKey:         true,
+				metadataSplitSerialIDKey: "340132",
+			},
+			expectEvent:       true,
+			expectedSubjectID: "user-123",
+			expectedSerialID:  nil,
 		},
 	}
 
@@ -464,6 +664,14 @@ func TestExposureHook_After(t *testing.T) {
 				}
 				if event.Variant.Key != tc.variant {
 					t.Errorf("expected variant %q, got %q", tc.variant, event.Variant.Key)
+				}
+				switch {
+				case tc.expectedSerialID == nil && event.SerialID != nil:
+					t.Errorf("expected no serial id, got %d", *event.SerialID)
+				case tc.expectedSerialID != nil && event.SerialID == nil:
+					t.Errorf("expected serial id %d, got none", *tc.expectedSerialID)
+				case tc.expectedSerialID != nil && *event.SerialID != *tc.expectedSerialID:
+					t.Errorf("expected serial id %d, got %d", *tc.expectedSerialID, *event.SerialID)
 				}
 			} else {
 				if len(writer.buffer) != 0 {

--- a/openfeature/integration_test.go
+++ b/openfeature/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	of "github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/require"
 )
@@ -1999,4 +2000,63 @@ func TestEndToEnd_AllThreeFixes(t *testing.T) {
 			t.Errorf("expected 'premium' or 'basic', got %q", value)
 		}
 	})
+}
+
+func TestEndToEnd_ExposureSerialID(t *testing.T) {
+	provider := newDatadogProvider(ProviderConfig{})
+	status := processConfigUpdate(provider, "datadog/2/ASM_FEATURES/test/config", []byte(`{
+		"createdAt":"2026-01-01T00:00:00Z",
+		"format":"SERVER",
+		"environment":{"name":"test"},
+		"flags":{
+			"holdout-flag":{
+				"key":"holdout-flag",
+				"enabled":true,
+				"variationType":"BOOLEAN",
+				"variations":{"on":{"key":"on","value":true}},
+				"allocations":[{
+					"key":"holdout-allocation",
+					"doLog":true,
+					"splits":[{"variationKey":"on","serialId":340132,"shards":[]}]
+				}]
+			},
+			"plain-flag":{
+				"key":"plain-flag",
+				"enabled":true,
+				"variationType":"BOOLEAN",
+				"variations":{"on":{"key":"on","value":true}},
+				"allocations":[{
+					"key":"plain-allocation",
+					"doLog":true,
+					"splits":[{"variationKey":"on","shards":[]}]
+				}]
+			}
+		}
+	}`))
+	require.Equal(t, rc.ApplyStateAcknowledged, status.State)
+
+	domain := "exposure-serial-id-test-app"
+	require.NoError(t, of.SetNamedProviderAndWait(domain, provider))
+	client := of.NewClient(domain)
+
+	writer := getExposureWriter(provider)
+	evalCtx := of.NewEvaluationContext("user-123", map[string]any{})
+
+	value, err := client.BooleanValue(context.Background(), "holdout-flag", false, evalCtx)
+	require.NoError(t, err)
+	require.True(t, value)
+
+	value, err = client.BooleanValue(context.Background(), "plain-flag", false, evalCtx)
+	require.NoError(t, err)
+	require.True(t, value)
+
+	exposures := getExposureBuffer(writer)
+	require.Len(t, exposures, 2)
+
+	require.Equal(t, "holdout-flag", exposures[0].Flag.Key)
+	require.NotNil(t, exposures[0].SerialID)
+	require.Equal(t, uint32(340132), *exposures[0].SerialID)
+
+	require.Equal(t, "plain-flag", exposures[1].Flag.Key)
+	require.Nil(t, exposures[1].SerialID)
 }


### PR DESCRIPTION
### What does this PR do?

This change adds a `serial_id` field to the exposure event.

The serial id identifies the split that the subject was assigned to. The intake uses the serial id to find more information about the exposure, for example the holdout that the allocation comes from. The exposure event does not record that information in another way.

The provider already receives the serial id and uses it for span enrichment. This change also sends the serial id on the exposure event.

Two source files change:

| File | Change |
|---|---|
| `openfeature/exposure.go` | Add the optional field to `exposureEvent`, and include the serial id in the deduplication cache value. |
| `openfeature/exposure_hook.go` | Read the serial id from the evaluation metadata and set the field. |

The field is a `*uint32`. A pointer is necessary because `omitempty` on a value type drops a serial id of `0`. The cache holds the serial id as a value and a presence flag, not as a pointer, because the cache compares entries with struct equality.

A malformed value in the metadata gives no serial id, and the provider still sends the exposure. `buildEvaluation` in `openfeature/span_enrichment.go` instead abandons the evaluation. An exposure that the provider does not send is a permanent loss of experiment data.

The provider does not validate the value. The flag configuration layer validates it.

### Motivation

The compiler changes a holdout into a usual allocation before an SDK receives the flag configuration. An exposure event therefore shows no holdout, and the serial id is the only link back to it. The compiler, the evaluator in this repository, and the exposures intake all carry the serial id already. The exposure hook discarded it.

### Testing

Ten new tests: five for the deduplication cache, four rows on `TestExposureHook_After`, and one that sends a flag configuration through the evaluator. A test of the wire format uses the same `jsoniter` configuration as the EVP client, because no test pinned that behaviour before.

```
git submodule update --init --recursive
go test ./openfeature/... ./internal/openfeature/... -count=1
```

All tests pass. Each new test also failed without its fix. `golangci-lint run ./openfeature/...` reports no issues.

### Risks

Low. The field is optional. An exposure event without a serial id does not change.

The deduplication cache now compares the serial id in addition to the allocation key and the variant key. A subject therefore reports one more exposure when its serial id appears or changes. This is intended: a configuration refresh can add a serial id, or change it, while both keys stay the same, and the intake must receive that value.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild.

*This description was generated by Claude.*
