### PR TITLE
feat(profiler): add GoroutineLeakProfile

### DIFF
--- a/profiler/compression.go
+++ b/profiler/compression.go
@@ -70,7 +70,7 @@ func compressionStrategy(pt ProfileType, isDelta bool, config string) (compressi
 // uncompressed.
 func inputCompression(pt ProfileType, isDelta bool) compression {
 	switch pt {
-	case CPUProfile, GoroutineProfile, goroutineLeakProfile:
+	case CPUProfile, GoroutineProfile, GoroutineLeakProfile:
 		return gzip1Compression
 	case HeapProfile, BlockProfile, MutexProfile:
 		if isDelta {

--- a/profiler/compression.go
+++ b/profiler/compression.go
@@ -88,7 +88,7 @@ func inputCompression(pt ProfileType, isDelta bool) compression {
 // a compression level using our legacy compression strategy.
 func legacyOutputCompression(pt ProfileType, isDelta bool) compression {
 	switch pt {
-	case CPUProfile, GoroutineProfile:
+	case CPUProfile, GoroutineProfile, GoroutineLeakProfile:
 		return gzip1Compression
 	case HeapProfile, BlockProfile, MutexProfile:
 		if isDelta {

--- a/profiler/goroutineleak_test.go
+++ b/profiler/goroutineleak_test.go
@@ -6,6 +6,7 @@
 package profiler
 
 import (
+	"go/version"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -15,33 +16,65 @@ import (
 	"testing"
 )
 
+var go127OrNewer = version.Compare(runtime.Version(), "go1.27") >= 0
+
 func TestGoroutineLeakProfile(t *testing.T) {
-	if !strings.HasPrefix(runtime.Version(), "go1.26.") {
-		// This is experimental in Go 1.26. We'll need to revisit this
-		// code when Go 1.27 is released.
-		t.Skipf("goroutineleakprofile requires Go 1.26, got %s", runtime.Version())
+	if version.Compare(runtime.Version(), "go1.26") < 0 {
+		t.Skipf("goroutineleakprofile requires Go 1.26 or later")
 	}
 
 	t.Run("with_experiment", func(t *testing.T) {
-		meta := runGoroutineLeakProgram(t, true)
+		if go127OrNewer {
+			t.Skip("goroutineleakprofile is no longer an experiment")
+		}
+		meta, _ := runGoroutineLeakProgram(t, true, false)
 		if _, ok := meta.attachments["goroutineleak.pprof"]; !ok {
 			t.Errorf("expected goroutineleak.pprof attachment, got: %v", meta.event.Attachments)
 		}
 	})
 
-	t.Run("without_experiment", func(t *testing.T) {
-		meta := runGoroutineLeakProgram(t, false)
+	t.Run("with_experiment_and_explicit_profile", func(t *testing.T) {
+		if go127OrNewer {
+			t.Skip("goroutineleakprofile is no longer an experiment")
+		}
+		meta, _ := runGoroutineLeakProgram(t, true, true)
+		if _, ok := meta.attachments["goroutineleak.pprof"]; !ok {
+			t.Errorf("expected goroutineleak.pprof attachment, got: %v", meta.event.Attachments)
+		}
+	})
+
+	t.Run("explicit_without_experiment", func(t *testing.T) {
+		meta, output := runGoroutineLeakProgram(t, false, true)
+		if go127OrNewer {
+			if _, ok := meta.attachments["goroutineleak.pprof"]; !ok {
+				t.Errorf("expected goroutineleak.pprof attachment, got: %v", meta.event.Attachments)
+			}
+		} else {
+			const want = "goroutine leak profile requires Go 1.27 or later, or GOEXPERIMENT=goroutineleakprofile"
+			if !strings.Contains(output, want) {
+				t.Errorf("unexpected profiler.Start error: %s", output)
+			}
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		meta, _ := runGoroutineLeakProgram(t, false, false)
 		if _, ok := meta.attachments["goroutineleak.pprof"]; ok {
 			t.Errorf("unexpected goroutineleak.pprof attachment without GOEXPERIMENT")
 		}
 	})
 }
 
-func runGoroutineLeakProgram(t *testing.T, withExperiment bool) profileMeta {
+func runGoroutineLeakProgram(t *testing.T, withExperiment, explicit bool) (profileMeta, string) {
 	t.Helper()
 	dir := t.TempDir()
 
-	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(goroutineLeakSource), 0644); err != nil {
+	profileType := ""
+	if explicit {
+		profileType = "profiler.GoroutineLeakProfile"
+	}
+	source := strings.Replace(goroutineLeakSource, "PROFILE_TYPE", profileType, 1)
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0644); err != nil {
 		t.Fatalf("writing test source: %s", err)
 	}
 
@@ -79,6 +112,15 @@ func runGoroutineLeakProgram(t *testing.T, withExperiment bool) profileMeta {
 		t.Fatalf("%s: %s", build.String(), out)
 	}
 
+	if explicit && !withExperiment && version.Compare(runtime.Version(), "go1.27") < 0 {
+		// We expect this configuration (explicitly enabled but built
+		// for Go 1.26 and with no GOEXPERIMENT) to exit without
+		// producing any profiles.
+		cmd := exec.Command(binPath)
+		output, _ := cmd.CombinedOutput()
+		return profileMeta{}, string(output)
+	}
+
 	backend := &fakeBackend{profiles: make(chan profileMeta, 1)}
 	srv := httptest.NewServer(backend)
 	t.Cleanup(srv.Close)
@@ -97,12 +139,13 @@ func runGoroutineLeakProgram(t *testing.T, withExperiment bool) profileMeta {
 	if p.err != nil {
 		t.Fatalf("profile upload error: %s", p.err)
 	}
-	return p
+	return p, ""
 }
 
 const goroutineLeakSource = `package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/profiler"
@@ -110,11 +153,12 @@ import (
 
 func main() {
 	err := profiler.Start(
-		profiler.WithProfileTypes(), // only leak profile matters; auto-enabled if available
+		profiler.WithProfileTypes(PROFILE_TYPE), // only leak profile matters
 		profiler.WithPeriod(10*time.Millisecond),
 	)
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		return
 	}
 	defer profiler.Stop()
 

--- a/profiler/goroutineleak_test.go
+++ b/profiler/goroutineleak_test.go
@@ -115,8 +115,10 @@ func runGoroutineLeakProgram(t *testing.T, withExperiment, explicit bool) (profi
 	if explicit && !withExperiment && version.Compare(runtime.Version(), "go1.27") < 0 {
 		// We expect this configuration (explicitly enabled but built
 		// for Go 1.26 and with no GOEXPERIMENT) to exit without
-		// producing any profiles.
+		// producing any profiles. The profile type is ignored, so the
+		// test program needs to exit explicitly after Start returns.
 		cmd := exec.Command(binPath)
+		cmd.Env = []string{"GOROUTINE_LEAK_TEST_EXIT=1"}
 		output, _ := cmd.CombinedOutput()
 		return profileMeta{}, string(output)
 	}
@@ -146,6 +148,7 @@ const goroutineLeakSource = `package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/profiler"
@@ -161,6 +164,10 @@ func main() {
 		return
 	}
 	defer profiler.Stop()
+
+	if os.Getenv("GOROUTINE_LEAK_TEST_EXIT") != "" {
+		return
+	}
 
 	// Run until killed. This has the side effect of leaking a goroutine in
 	// case we care about checking for a non-empty profile.

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -54,10 +54,11 @@ const (
 	// shouldn't just be added to WithProfileTypes
 	executionTrace
 
-	// goroutineLeakProfile is the Go 1.26 experimental goroutine leak
-	// profile, which contains tracebacks of goroutines permanently blocked
-	// in synchronization
-	goroutineLeakProfile
+	// GoroutineLeakProfile reports tracebacks of goroutines permanently
+	// blocked in synchronization. It requires Go 1.27 or later, or Go 1.26,
+	// in which case the program must be built with
+	// GOEXPERIMENT=goroutineleakprofile
+	GoroutineLeakProfile
 )
 
 // profileType holds the implementation details of a ProfileType.
@@ -201,10 +202,10 @@ var profileTypes = map[ProfileType]profileType{
 			return buf.Bytes(), cmp.Or(writeErr, closeErr)
 		},
 	},
-	goroutineLeakProfile: {
+	GoroutineLeakProfile: {
 		Name:     "goroutine-leak",
 		Filename: "goroutineleak.pprof",
-		Collect:  collectGenericProfile("goroutineleak", goroutineLeakProfile),
+		Collect:  collectGenericProfile("goroutineleak", GoroutineLeakProfile),
 	},
 }
 
@@ -334,6 +335,8 @@ func (t *ProfileType) UnmarshalText(text []byte) error {
 		*t = MutexProfile
 	case "goroutine":
 		*t = GoroutineProfile
+	case "goroutineleak":
+		*t = GoroutineLeakProfile
 	default:
 		return fmt.Errorf("unknown profile type: %s", text)
 	}

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -7,7 +7,9 @@ package profiler
 
 import (
 	"bytes"
+	"go/version"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -222,6 +224,12 @@ func TestProfileTypeSoundness(t *testing.T) {
 	t.Run("enabledProfileTypes", func(t *testing.T) {
 		allProfileTypes := make([]ProfileType, 0, len(profileTypes))
 		for pt := range profileTypes {
+			if version.Compare(runtime.Version(), "go1.27") < 0 && pt == GoroutineLeakProfile {
+				// We don't accept GoroutineLeakProfile for Go
+				// 1.26 unless the experiment is enabled, and
+				// we're not going to test for that here.
+				continue
+			}
 			allProfileTypes = append(allProfileTypes, pt)
 		}
 		p, err := newProfiler(WithProfileTypes(allProfileTypes...))

--- a/profiler/profile_test.go
+++ b/profiler/profile_test.go
@@ -236,6 +236,12 @@ func TestProfileTypeSoundness(t *testing.T) {
 		require.NoError(t, err)
 		types := p.enabledProfileTypes()
 		require.ElementsMatch(t, types, allProfileTypes)
+
+		for _, pt := range allProfileTypes {
+			// This will panic if we didn't register a legacy
+			// compression configuration for the profile type.
+			legacyOutputCompression(pt, false)
+		}
 	})
 
 	t.Run("profileTypes", func(t *testing.T) {

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -156,7 +156,8 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	}
 
 	if _, ok := cfg.types[GoroutineLeakProfile]; ok && version.Compare(runtime.Version(), "go1.27") < 0 && !goroutineLeakExperiment() {
-		return nil, errors.New("goroutine leak profile requires Go 1.27 or later, or GOEXPERIMENT=goroutineleakprofile")
+		log.Warn("goroutine leak profile requires Go 1.27 or later, or GOEXPERIMENT=goroutineleakprofile")
+		delete(cfg.types, GoroutineLeakProfile)
 	}
 	if goroutineLeakExperiment() {
 		cfg.addProfileType(GoroutineLeakProfile)

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -8,6 +8,7 @@ package profiler
 import (
 	"errors"
 	"fmt"
+	"go/version"
 	"io"
 	"maps"
 	"math/rand"
@@ -154,10 +155,13 @@ func newProfiler(opts ...Option) (*profiler, error) {
 		cfg.traceConfig.Enabled = false
 	}
 
-	// Unconditionally enable goroutine leak profiling if it's available.
-	if goroutineLeakProfileAvailable() {
-		cfg.addProfileType(goroutineLeakProfile)
+	if _, ok := cfg.types[GoroutineLeakProfile]; ok && version.Compare(runtime.Version(), "go1.27") < 0 && !goroutineLeakExperiment() {
+		return nil, errors.New("goroutine leak profile requires Go 1.27 or later, or GOEXPERIMENT=goroutineleakprofile")
 	}
+	if goroutineLeakExperiment() {
+		cfg.addProfileType(GoroutineLeakProfile)
+	}
+
 	// Agentless upload is disabled by default as of v1.30.0, but
 	// DD_PROFILING_AGENTLESS can be set to enable it for testing and debugging.
 	if cfg.agentless {
@@ -264,7 +268,7 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	return &p, nil
 }
 
-var goroutineLeakProfileAvailable = sync.OnceValue(func() bool {
+var goroutineLeakExperiment = sync.OnceValue(func() bool {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return false
@@ -455,7 +459,7 @@ func (p *profiler) enabledProfileTypes() []ProfileType {
 		GoroutineProfile,
 		MetricsProfile,
 		executionTrace,
-		goroutineLeakProfile,
+		GoroutineLeakProfile,
 	}
 	enabled := []ProfileType{}
 	for _, t := range order {

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -55,7 +55,7 @@ func telemetryConfiguration(c *config) []telemetry.Configuration {
 		{Name: "block_profile_enabled", Value: profileEnabled(BlockProfile)},
 		{Name: "mutex_profile_enabled", Value: profileEnabled(MutexProfile)},
 		{Name: "goroutine_profile_enabled", Value: profileEnabled(GoroutineProfile)},
-		{Name: "goroutine_leak_profile_enabled", Value: profileEnabled(goroutineLeakProfile)},
+		{Name: "goroutine_leak_profile_enabled", Value: profileEnabled(GoroutineLeakProfile)},
 		{Name: "upload_timeout", Value: c.uploadTimeout.String()},
 		{Name: "execution_trace_enabled", Value: c.traceConfig.Enabled},
 		{Name: "execution_trace_period", Value: c.traceConfig.Period.String()},


### PR DESCRIPTION
Go 1.27 introduces the goroutine leak profiler, which reports tracebacks
of goroutines permanently stuck in synchronization. This profile type
was available as a GOEXPERIMENT in Go 1.26 and is now generally
available.

Add a GoroutineLeakProfile profile type. If this is provided on Go 1.27
or later, the goroutine leak profile is enabled. If it is provided on Go
1.26, the program must be built with GOEXPERIMENT=goroutineleakprofile.
This PR preserves the prior behavior where the profile type is
enabled automatically if the GOEXPERIMENT is set.

At the time of writing this PR, we're not running Go 1.27 in CI, but I've
tested the profiler with it locally.