### PR TITLE
fix(appsec): bound service extension memory to the container limit

### DIFF
--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/README.md
@@ -34,6 +34,8 @@ The ASM Service Extension expose some configuration. The configuration can be tw
 | `DD_SERVICE_EXTENSION_TLS_CERT_FILE`      | `localhost.crt` | Change the default gRPC TLS layer cert. Do not modify if you are using GCP.                                   |
 | `DD_SERVICE_EXTENSION_UDS_PATH`           | _(unset)_       | Path to a Unix domain socket for the gRPC server. When set, overrides `DD_SERVICE_EXTENSION_HOST`/`PORT` and TLS is disabled. Only for self-managed Envoy deployments. |
 
+> `GOMEMLIMIT` is derived at startup from the container memory limit (85% of it, leaving room for the non-Go memory the runtime cannot see) unless you set it explicitly, so the garbage collector reclaims memory instead of the container being OOM-killed.
+
 > The Service Extension need to be connected to a deployed [Datadog agent](https://docs.datadoghq.com/agent).
 
 | Environment variable  | Default value | Description                      |

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
-	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/env"
 
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -113,10 +112,12 @@ func configureObservabilityMode(mode bool) error {
 }
 
 const (
-	// Where the container memory limit lives under cgroup v2 and cgroup v1. Paths are
-	// relative so tests can resolve them against a fixture tree.
-	cgroupV2MemoryLimitPath = "sys/fs/cgroup/memory.max"
-	cgroupV1MemoryLimitPath = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+	// The cgroup filesystem, and the memory limit file within a v2 and a v1 hierarchy.
+	// Paths are relative so tests can resolve them against a fixture tree.
+	cgroupMountPath     = "sys/fs/cgroup"
+	cgroupV2MemoryLimit = "memory.max"
+	cgroupV1MemoryLimit = "memory/memory.limit_in_bytes"
+	procSelfCgroupPath  = "proc/self/cgroup"
 
 	// goMemLimitRatio is the share of the container memory limit handed to the Go
 	// runtime. The remainder covers what GOMEMLIMIT cannot account for: the binary's
@@ -142,7 +143,11 @@ const (
 // An explicitly configured GOMEMLIMIT always wins, and an unreadable or unlimited
 // cgroup leaves the runtime default untouched.
 func configureGoMemoryLimit() {
-	if _, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+	// An empty value is not an opt-out: the runtime treats GOMEMLIMIT="" exactly like an
+	// unset variable and keeps math.MaxInt64, so a manifest that templates the variable
+	// to an empty string would otherwise silently disable this. A non-empty value,
+	// including "off", is a deliberate choice and is left alone.
+	if value, ok := os.LookupEnv("GOMEMLIMIT"); ok && value != "" {
 		return
 	}
 
@@ -162,14 +167,62 @@ func configureGoMemoryLimit() {
 
 // cgroupMemoryLimit reports the container memory limit in bytes, preferring cgroup v2
 // over v1. root is the filesystem root to resolve the cgroup paths against.
+//
+// The limit is not necessarily at the root of the cgroup mount. With a private cgroup
+// namespace — the common container case — the process sees its own cgroup as "/" and
+// the mount root is correct. Running in the host cgroup namespace, as some Kubernetes
+// runtimes still do, the mount root is the host's cgroup and reading it would report
+// no limit at all or the whole machine's. /proc/self/cgroup names the path this
+// process actually lives under, so try that first and walk up towards the root, since
+// the limit may be set on an ancestor such as the pod rather than the container.
 func cgroupMemoryLimit(root string) (int64, bool) {
-	for _, path := range []string{cgroupV2MemoryLimitPath, cgroupV1MemoryLimitPath} {
-		if limit, ok := readCgroupMemoryLimit(filepath.Join(root, path)); ok {
-			return limit, true
+	for _, limitFile := range []string{cgroupV2MemoryLimit, cgroupV1MemoryLimit} {
+		mount := filepath.Join(root, cgroupMountPath)
+		// The v1 memory controller is mounted in its own subdirectory, which the relative
+		// cgroup path is expressed underneath.
+		base := filepath.Join(mount, filepath.Dir(limitFile))
+		name := filepath.Base(limitFile)
+
+		for _, relative := range cgroupSelfPaths(root) {
+			if limit, ok := readCgroupMemoryLimit(filepath.Join(base, relative, name)); ok {
+				return limit, true
+			}
 		}
 	}
 
 	return 0, false
+}
+
+// cgroupSelfPaths returns the cgroup paths to try, from the process's own cgroup up to
+// the mount root. The root is always included so a missing or unreadable
+// /proc/self/cgroup degrades to the previous behaviour rather than to nothing.
+func cgroupSelfPaths(root string) []string {
+	content, err := os.ReadFile(filepath.Join(root, procSelfCgroupPath))
+	if err != nil {
+		return []string{"/"}
+	}
+
+	// Lines are "hierarchy:controllers:path"; cgroup v2 uses the single "0::<path>".
+	var self string
+	for _, line := range strings.Split(string(content), "\n") {
+		fields := strings.SplitN(strings.TrimSpace(line), ":", 3)
+		if len(fields) != 3 || fields[2] == "" {
+			continue
+		}
+		// Prefer the v2 unified entry or the v1 memory controller; anything else describes
+		// a hierarchy that does not carry the memory limit.
+		if fields[0] == "0" || strings.Contains(fields[1], "memory") {
+			self = fields[2]
+			break
+		}
+	}
+
+	paths := []string{}
+	for current := self; current != "" && current != "/" && current != "."; current = filepath.Dir(current) {
+		paths = append(paths, current)
+	}
+
+	return append(paths, "/")
 }
 
 // readCgroupMemoryLimit reads a single cgroup memory limit file, reporting false when
@@ -202,13 +255,17 @@ func readCgroupMemoryLimit(path string) (int64, bool) {
 // memory, these three numbers are the first thing worth knowing, and they are
 // otherwise invisible from outside the container.
 func logRuntimeEnvelope(config serviceExtensionConfig) {
-	bodyParsingSizeLimit := proxy.DefaultBodyParsingSizeLimit
+	// Only report a number when one was actually configured. Left unset, the limit is
+	// resolved per request from the gateway integration — and GCP Service Extensions
+	// resolves it to 0, disabling body parsing entirely — so printing the proxy-wide
+	// default here would misreport the primary deployment this diagnostic exists for.
+	bodyParsingSizeLimit := "unset (resolved per gateway integration)"
 	if config.bodyParsingSizeLimit != nil {
-		bodyParsingSizeLimit = *config.bodyParsingSizeLimit
+		bodyParsingSizeLimit = strconv.Itoa(*config.bodyParsingSizeLimit) + " bytes"
 	}
 
 	// A negative argument retrieves the limit without adjusting it.
-	log.Info("service_extension: runtime envelope: GOMEMLIMIT=%d bytes, GOMAXPROCS=%d, body parsing size limit=%d bytes\n",
+	log.Info("service_extension: runtime envelope: GOMEMLIMIT=%d bytes, GOMAXPROCS=%d, body parsing size limit=%s\n",
 		debug.SetMemoryLimit(-1), runtime.GOMAXPROCS(0), bodyParsingSizeLimit)
 }
 

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main.go
@@ -14,7 +14,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -25,6 +29,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	"github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/proxy"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation/env"
 
 	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -107,6 +112,106 @@ func configureObservabilityMode(mode bool) error {
 	return nil
 }
 
+const (
+	// Where the container memory limit lives under cgroup v2 and cgroup v1. Paths are
+	// relative so tests can resolve them against a fixture tree.
+	cgroupV2MemoryLimitPath = "sys/fs/cgroup/memory.max"
+	cgroupV1MemoryLimitPath = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+	// goMemLimitRatio is the share of the container memory limit handed to the Go
+	// runtime. The remainder covers what GOMEMLIMIT cannot account for: the binary's
+	// own mappings, kernel memory held on our behalf, and — the reason this sits below
+	// the 90% commonly used elsewhere — libddwaf's C allocations, since this binary is
+	// built with cgo and that memory is invisible to the Go runtime yet still counts
+	// against the cgroup.
+	goMemLimitRatio = 0.85
+
+	// cgroup v1 reports "unlimited" as a huge sentinel rather than a keyword, so treat
+	// implausibly large values as absent.
+	cgroupMemoryUnlimited = int64(1) << 62
+)
+
+// configureGoMemoryLimit derives GOMEMLIMIT from the container memory limit.
+//
+// The Go runtime does not read cgroup memory limits, in any version up to and
+// including Go 1.26: with GOMEMLIMIT unset the limit is math.MaxInt64, so the garbage
+// collector paces itself purely off heap growth and never learns that a ceiling
+// exists. The kernel then OOM-kills the process while the runtime still believes it
+// has room. Deriving the limit here turns that hard kill into GC pressure.
+//
+// An explicitly configured GOMEMLIMIT always wins, and an unreadable or unlimited
+// cgroup leaves the runtime default untouched.
+func configureGoMemoryLimit() {
+	if _, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+		return
+	}
+
+	limit, ok := cgroupMemoryLimit("/")
+	if !ok {
+		return
+	}
+
+	budget := int64(float64(limit) * goMemLimitRatio)
+	if budget <= 0 {
+		return
+	}
+
+	debug.SetMemoryLimit(budget)
+	log.Info("service_extension: GOMEMLIMIT set to %d bytes, derived from a %d byte container memory limit\n", budget, limit)
+}
+
+// cgroupMemoryLimit reports the container memory limit in bytes, preferring cgroup v2
+// over v1. root is the filesystem root to resolve the cgroup paths against.
+func cgroupMemoryLimit(root string) (int64, bool) {
+	for _, path := range []string{cgroupV2MemoryLimitPath, cgroupV1MemoryLimitPath} {
+		if limit, ok := readCgroupMemoryLimit(filepath.Join(root, path)); ok {
+			return limit, true
+		}
+	}
+
+	return 0, false
+}
+
+// readCgroupMemoryLimit reads a single cgroup memory limit file, reporting false when
+// the file is absent, unparseable, or denotes no limit.
+func readCgroupMemoryLimit(path string) (int64, bool) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+
+	// cgroup v2 spells "no limit" as the literal "max".
+	raw := strings.TrimSpace(string(content))
+	if raw == "max" {
+		return 0, false
+	}
+
+	limit, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || limit <= 0 || limit >= cgroupMemoryUnlimited {
+		return 0, false
+	}
+
+	return limit, true
+}
+
+// logRuntimeEnvelope reports the resource envelope the process actually resolved.
+//
+// Every one of these is derived rather than declared — GOMEMLIMIT from the cgroup
+// above, GOMAXPROCS from the cgroup CPU quota by the runtime itself since Go 1.25,
+// and the body parsing limit from configuration. When a deployment runs out of
+// memory, these three numbers are the first thing worth knowing, and they are
+// otherwise invisible from outside the container.
+func logRuntimeEnvelope(config serviceExtensionConfig) {
+	bodyParsingSizeLimit := proxy.DefaultBodyParsingSizeLimit
+	if config.bodyParsingSizeLimit != nil {
+		bodyParsingSizeLimit = *config.bodyParsingSizeLimit
+	}
+
+	// A negative argument retrieves the limit without adjusting it.
+	log.Info("service_extension: runtime envelope: GOMEMLIMIT=%d bytes, GOMAXPROCS=%d, body parsing size limit=%d bytes\n",
+		debug.SetMemoryLimit(-1), runtime.GOMAXPROCS(0), bodyParsingSizeLimit)
+}
+
 // loadConfig loads the configuration from the environment variables
 func loadConfig() serviceExtensionConfig {
 	extensionPortInt := intEnv("DD_SERVICE_EXTENSION_PORT", 443)
@@ -143,8 +248,10 @@ func loadConfig() serviceExtensionConfig {
 
 func main() {
 	initializeEnvironment()
+	configureGoMemoryLimit()
 
 	config := loadConfig()
+	logRuntimeEnvelope(config)
 
 	if err := configureObservabilityMode(config.observabilityMode); err != nil {
 		log.Error("service_extension: %s\n", err.Error())

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main_test.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main_test.go
@@ -213,6 +213,13 @@ func setEnv(env map[string]string) {
 	}
 }
 
+const (
+	// Fixture paths, mirroring the layout the code reads under a filesystem root.
+	fixtureV2Limit  = "sys/fs/cgroup/memory.max"
+	fixtureV1Limit  = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+	fixtureSelfCgrp = "proc/self/cgroup"
+)
+
 func TestCgroupMemoryLimit(t *testing.T) {
 	tests := []struct {
 		name string
@@ -223,30 +230,30 @@ func TestCgroupMemoryLimit(t *testing.T) {
 	}{
 		{
 			name:      "cgroup-v2",
-			files:     map[string]string{cgroupV2MemoryLimitPath: "536870912\n"},
+			files:     map[string]string{fixtureV2Limit: "536870912\n"},
 			wantLimit: 536870912,
 			wantOK:    true,
 		},
 		{
 			name:  "cgroup-v2-unlimited-is-the-literal-max",
-			files: map[string]string{cgroupV2MemoryLimitPath: "max\n"},
+			files: map[string]string{fixtureV2Limit: "max\n"},
 		},
 		{
 			name:      "cgroup-v1",
-			files:     map[string]string{cgroupV1MemoryLimitPath: "268435456"},
+			files:     map[string]string{fixtureV1Limit: "268435456"},
 			wantLimit: 268435456,
 			wantOK:    true,
 		},
 		{
 			name: "cgroup-v1-unlimited-is-a-huge-sentinel",
 			// The value cgroup v1 reports when no limit is set.
-			files: map[string]string{cgroupV1MemoryLimitPath: "9223372036854771712"},
+			files: map[string]string{fixtureV1Limit: "9223372036854771712"},
 		},
 		{
 			name: "v2-wins-over-v1",
 			files: map[string]string{
-				cgroupV2MemoryLimitPath: "111",
-				cgroupV1MemoryLimitPath: "222",
+				fixtureV2Limit: "111",
+				fixtureV1Limit: "222",
 			},
 			wantLimit: 111,
 			wantOK:    true,
@@ -254,8 +261,8 @@ func TestCgroupMemoryLimit(t *testing.T) {
 		{
 			name: "falls-back-to-v1-when-v2-is-unlimited",
 			files: map[string]string{
-				cgroupV2MemoryLimitPath: "max",
-				cgroupV1MemoryLimitPath: "222",
+				fixtureV2Limit: "max",
+				fixtureV1Limit: "222",
 			},
 			wantLimit: 222,
 			wantOK:    true,
@@ -265,11 +272,56 @@ func TestCgroupMemoryLimit(t *testing.T) {
 		},
 		{
 			name:  "unparseable",
-			files: map[string]string{cgroupV2MemoryLimitPath: "not-a-number"},
+			files: map[string]string{fixtureV2Limit: "not-a-number"},
 		},
 		{
 			name:  "zero-is-not-a-usable-limit",
-			files: map[string]string{cgroupV2MemoryLimitPath: "0"},
+			files: map[string]string{fixtureV2Limit: "0"},
+		},
+		{
+			// Host cgroup namespace: the mount root is the host's cgroup and carries no
+			// limit, while the process's own cgroup below it does. Reading the root would
+			// silently skip the protection.
+			name: "host-namespace-reads-the-process-own-cgroup",
+			files: map[string]string{
+				fixtureSelfCgrp: "0::/kubepods/burstable/podabc/container123\n",
+				fixtureV2Limit:  "max",
+				"sys/fs/cgroup/kubepods/burstable/podabc/container123/memory.max": "268435456",
+			},
+			wantLimit: 268435456,
+			wantOK:    true,
+		},
+		{
+			// The limit is frequently set on the pod rather than the container, so the
+			// walk up towards the root has to find it.
+			name: "walks-up-to-an-ancestor-cgroup",
+			files: map[string]string{
+				fixtureSelfCgrp: "0::/kubepods/burstable/podabc/container123\n",
+				"sys/fs/cgroup/kubepods/burstable/podabc/memory.max": "134217728",
+			},
+			wantLimit: 134217728,
+			wantOK:    true,
+		},
+		{
+			// Private cgroup namespace, the common container case: the process reports "/"
+			// and the limit sits at the mount root.
+			name: "private-namespace-reports-root",
+			files: map[string]string{
+				fixtureSelfCgrp: "0::/\n",
+				fixtureV2Limit:  "536870912",
+			},
+			wantLimit: 536870912,
+			wantOK:    true,
+		},
+		{
+			// cgroup v1 lists one hierarchy per line; only the memory controller matters.
+			name: "cgroup-v1-picks-the-memory-controller-line",
+			files: map[string]string{
+				fixtureSelfCgrp: "5:cpu,cpuacct:/some/cpu/path\n4:memory:/mem/path\n",
+				"sys/fs/cgroup/memory/mem/path/memory.limit_in_bytes": "99999",
+			},
+			wantLimit: 99999,
+			wantOK:    true,
 		},
 	}
 
@@ -300,6 +352,20 @@ func TestConfigureGoMemoryLimitLeavesAnExplicitSettingAlone(t *testing.T) {
 	configureGoMemoryLimit()
 
 	require.Equal(t, before, currentGoMemoryLimit())
+}
+
+// A manifest that templates GOMEMLIMIT to an empty string means "unset" to the Go
+// runtime, so it must not be read as an operator opt-out here either.
+func TestConfigureGoMemoryLimitTreatsEmptyAsUnset(t *testing.T) {
+	t.Setenv("GOMEMLIMIT", "")
+
+	value, present := os.LookupEnv("GOMEMLIMIT")
+	require.True(t, present, "the variable is present but empty, which is the case under test")
+	require.Empty(t, value)
+
+	// There is no cgroup limit on the test host, so the call must reach the derivation
+	// path and leave the limit untouched rather than return early on the env check.
+	require.NotPanics(t, configureGoMemoryLimit)
 }
 
 // currentGoMemoryLimit reads the limit without changing it: a negative argument to

--- a/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main_test.go
+++ b/contrib/envoyproxy/go-control-plane/cmd/serviceextensions/main_test.go
@@ -7,9 +7,13 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gocontrolplane "github.com/DataDog/dd-trace-go/contrib/envoyproxy/go-control-plane/v2"
 )
@@ -207,4 +211,99 @@ func setEnv(env map[string]string) {
 			panic(err)
 		}
 	}
+}
+
+func TestCgroupMemoryLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		// files maps a path relative to the fixture root to its contents.
+		files     map[string]string
+		wantLimit int64
+		wantOK    bool
+	}{
+		{
+			name:      "cgroup-v2",
+			files:     map[string]string{cgroupV2MemoryLimitPath: "536870912\n"},
+			wantLimit: 536870912,
+			wantOK:    true,
+		},
+		{
+			name:  "cgroup-v2-unlimited-is-the-literal-max",
+			files: map[string]string{cgroupV2MemoryLimitPath: "max\n"},
+		},
+		{
+			name:      "cgroup-v1",
+			files:     map[string]string{cgroupV1MemoryLimitPath: "268435456"},
+			wantLimit: 268435456,
+			wantOK:    true,
+		},
+		{
+			name: "cgroup-v1-unlimited-is-a-huge-sentinel",
+			// The value cgroup v1 reports when no limit is set.
+			files: map[string]string{cgroupV1MemoryLimitPath: "9223372036854771712"},
+		},
+		{
+			name: "v2-wins-over-v1",
+			files: map[string]string{
+				cgroupV2MemoryLimitPath: "111",
+				cgroupV1MemoryLimitPath: "222",
+			},
+			wantLimit: 111,
+			wantOK:    true,
+		},
+		{
+			name: "falls-back-to-v1-when-v2-is-unlimited",
+			files: map[string]string{
+				cgroupV2MemoryLimitPath: "max",
+				cgroupV1MemoryLimitPath: "222",
+			},
+			wantLimit: 222,
+			wantOK:    true,
+		},
+		{
+			name: "no-cgroup-files-at-all",
+		},
+		{
+			name:  "unparseable",
+			files: map[string]string{cgroupV2MemoryLimitPath: "not-a-number"},
+		},
+		{
+			name:  "zero-is-not-a-usable-limit",
+			files: map[string]string{cgroupV2MemoryLimitPath: "0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for path, content := range tt.files {
+				full := filepath.Join(root, path)
+				require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+				require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+			}
+
+			limit, ok := cgroupMemoryLimit(root)
+
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantLimit, limit)
+		})
+	}
+}
+
+// The runtime default is math.MaxInt64, which is precisely the state that lets the
+// kernel OOM-kill us, so leaving it in place must be a deliberate decision rather
+// than an accident.
+func TestConfigureGoMemoryLimitLeavesAnExplicitSettingAlone(t *testing.T) {
+	before := currentGoMemoryLimit()
+	t.Setenv("GOMEMLIMIT", strconv.FormatInt(before, 10))
+
+	configureGoMemoryLimit()
+
+	require.Equal(t, before, currentGoMemoryLimit())
+}
+
+// currentGoMemoryLimit reads the limit without changing it: a negative argument to
+// SetMemoryLimit is documented as a pure retrieval.
+func currentGoMemoryLimit() int64 {
+	return debug.SetMemoryLimit(-1)
 }

--- a/instrumentation/appsec/proxy/body_buffer.go
+++ b/instrumentation/appsec/proxy/body_buffer.go
@@ -40,9 +40,9 @@ func (b *bodyBuffer) append(chunk []byte) {
 	b.buffer = append(b.buffer, chunk[:bytesToAdd]...)
 }
 
-// minBodyBufferCapacity is the smallest allocation worth making. A streamed body
-// arrives in many small chunks, and starting at the size of the first one costs a
-// reallocation and a full copy for every chunk that follows.
+// minBodyBufferCapacity is the smallest allocation worth making once a body has shown
+// it arrives in more than one chunk, at which point reallocating per chunk costs more
+// than the slack does.
 const minBodyBufferCapacity = 4096
 
 // grow ensures the buffer can hold size bytes without reallocating.
@@ -51,12 +51,19 @@ const minBodyBufferCapacity = 4096
 // append cannot do on its own: left to itself it rounds the final chunk of a large
 // body up past the limit we promised to respect. Bodies never exceed sizeLimit, so
 // clamping only ever removes waste.
+//
+// The first allocation is sized exactly to the chunk. Most bodies arrive whole and are
+// released right after analysis, so rounding those up to a page would add allocation
+// traffic at request rate for no amortization in return.
 func (b *bodyBuffer) grow(size int) {
 	if cap(b.buffer) >= size {
 		return
 	}
 
-	capacity := max(2*cap(b.buffer), size, minBodyBufferCapacity)
+	capacity := max(2*cap(b.buffer), size)
+	if cap(b.buffer) > 0 {
+		capacity = max(capacity, minBodyBufferCapacity)
+	}
 	capacity = min(capacity, b.sizeLimit)
 
 	grown := make([]byte, len(b.buffer), capacity)

--- a/instrumentation/appsec/proxy/body_buffer.go
+++ b/instrumentation/appsec/proxy/body_buffer.go
@@ -36,9 +36,30 @@ func (b *bodyBuffer) append(chunk []byte) {
 		b.truncated = true
 	}
 
-	if b.buffer == nil {
-		b.buffer = make([]byte, 0, bytesToAdd)
+	b.grow(currentSize + bytesToAdd)
+	b.buffer = append(b.buffer, chunk[:bytesToAdd]...)
+}
+
+// minBodyBufferCapacity is the smallest allocation worth making. A streamed body
+// arrives in many small chunks, and starting at the size of the first one costs a
+// reallocation and a full copy for every chunk that follows.
+const minBodyBufferCapacity = 4096
+
+// grow ensures the buffer can hold size bytes without reallocating.
+//
+// Capacity is doubled to keep appends amortized, then clamped to sizeLimit, which
+// append cannot do on its own: left to itself it rounds the final chunk of a large
+// body up past the limit we promised to respect. Bodies never exceed sizeLimit, so
+// clamping only ever removes waste.
+func (b *bodyBuffer) grow(size int) {
+	if cap(b.buffer) >= size {
+		return
 	}
 
-	b.buffer = append(b.buffer, chunk[:bytesToAdd]...)
+	capacity := max(2*cap(b.buffer), size, minBodyBufferCapacity)
+	capacity = min(capacity, b.sizeLimit)
+
+	grown := make([]byte, len(b.buffer), capacity)
+	copy(grown, b.buffer)
+	b.buffer = grown
 }

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -6,6 +6,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -246,4 +247,81 @@ func TestOnResponseBodyMisconfigurationAcknowledgesMessage(t *testing.T) {
 
 	require.ErrorIs(t, err, io.EOF)
 	require.Equal(t, 1, continueCalls)
+}
+
+func TestBodyBufferAppend(t *testing.T) {
+	t.Run("retains-everything-under-the-limit", func(t *testing.T) {
+		b := newBodyBuffer(64)
+
+		b.append([]byte("hello "))
+		b.append([]byte("world"))
+
+		require.Equal(t, "hello world", string(b.buffer))
+		require.False(t, b.truncated)
+	})
+
+	t.Run("truncates-at-the-limit", func(t *testing.T) {
+		b := newBodyBuffer(4)
+
+		b.append([]byte("ab"))
+		b.append([]byte("cdef"))
+
+		require.Equal(t, "abcd", string(b.buffer))
+		require.True(t, b.truncated)
+	})
+
+	t.Run("ignores-chunks-once-truncated", func(t *testing.T) {
+		b := newBodyBuffer(2)
+		b.append([]byte("abcd"))
+		require.True(t, b.truncated)
+
+		b.append([]byte("efgh"))
+
+		require.Equal(t, "ab", string(b.buffer))
+	})
+
+	t.Run("empty-chunk-allocates-nothing", func(t *testing.T) {
+		b := newBodyBuffer(64)
+
+		b.append(nil)
+		b.append([]byte{})
+
+		require.Nil(t, b.buffer)
+		require.Zero(t, cap(b.buffer))
+	})
+}
+
+// A streamed body arrives in many small chunks. Growth has to stay amortized without
+// ever reserving more than the limit the caller was promised.
+func TestBodyBufferGrowthStaysWithinTheLimit(t *testing.T) {
+	const (
+		// Deliberately not a power of two: append's doubling lands exactly on a
+		// power-of-two limit, which would hide the overshoot this guards against. Real
+		// limits look like the 10485760 default, not 65536.
+		sizeLimit = 100_000
+		chunkSize = 512
+	)
+
+	b := newBodyBuffer(sizeLimit)
+	chunk := bytes.Repeat([]byte("x"), chunkSize)
+
+	// Overshoot the limit deliberately so the final chunk straddles it, which is where
+	// append's own rounding would have reserved past sizeLimit.
+	for range (sizeLimit / chunkSize) + 10 {
+		b.append(chunk)
+		require.LessOrEqual(t, cap(b.buffer), sizeLimit, "capacity must never exceed the size limit")
+	}
+
+	require.True(t, b.truncated)
+	require.Len(t, b.buffer, sizeLimit)
+}
+
+func TestBodyBufferSmallBodyDoesNotReserveTheWholeLimit(t *testing.T) {
+	b := newBodyBuffer(10 * 1024 * 1024)
+
+	b.append([]byte("{}"))
+
+	require.Equal(t, "{}", string(b.buffer))
+	require.LessOrEqual(t, cap(b.buffer), minBodyBufferCapacity,
+		"a tiny body must not reserve the full parsing limit")
 }

--- a/instrumentation/appsec/proxy/metrics_test.go
+++ b/instrumentation/appsec/proxy/metrics_test.go
@@ -316,12 +316,37 @@ func TestBodyBufferGrowthStaysWithinTheLimit(t *testing.T) {
 	require.Len(t, b.buffer, sizeLimit)
 }
 
-func TestBodyBufferSmallBodyDoesNotReserveTheWholeLimit(t *testing.T) {
+// Most bodies arrive in a single chunk and are released straight after analysis, so
+// the first allocation must be exact. Rounding those up to a page would add allocation
+// traffic at request rate for no amortization in return.
+func TestBodyBufferSingleChunkAllocatesExactly(t *testing.T) {
 	b := newBodyBuffer(10 * 1024 * 1024)
 
 	b.append([]byte("{}"))
 
 	require.Equal(t, "{}", string(b.buffer))
-	require.LessOrEqual(t, cap(b.buffer), minBodyBufferCapacity,
-		"a tiny body must not reserve the full parsing limit")
+	require.Equal(t, 2, cap(b.buffer), "a single-chunk body must not over-allocate")
+}
+
+// Once a second chunk proves the body is streamed, reallocating per chunk costs more
+// than the slack, so growth takes over.
+func TestBodyBufferSecondChunkGrowsToThePageFloor(t *testing.T) {
+	b := newBodyBuffer(10 * 1024 * 1024)
+
+	b.append([]byte("{"))
+	b.append([]byte("}"))
+
+	require.Equal(t, "{}", string(b.buffer))
+	require.Equal(t, minBodyBufferCapacity, cap(b.buffer))
+}
+
+// The floor must never push capacity past a size limit smaller than a page.
+func TestBodyBufferFloorRespectsATinyLimit(t *testing.T) {
+	b := newBodyBuffer(8)
+
+	b.append([]byte("ab"))
+	b.append([]byte("cd"))
+
+	require.Equal(t, "abcd", string(b.buffer))
+	require.LessOrEqual(t, cap(b.buffer), 8)
 }


### PR DESCRIPTION
### What does this PR do?

Bounds the memory of the published Service Extensions callout container against the limit its operator actually set. Three changes, none of which require knowing anything about the deployment:

- **`GOMEMLIMIT` derived from the cgroup at startup** (`cmd/serviceextensions/main.go`). Reads cgroup v2 (`memory.max`) then v1 (`memory.limit_in_bytes`), and hands the runtime 85% of it. An explicitly configured `GOMEMLIMIT` always wins; an unreadable, absent, or unlimited cgroup leaves the runtime default untouched.
- **Bounded body buffer growth** (`instrumentation/appsec/proxy/body_buffer.go`). `append` now grows explicitly — double, clamp to `sizeLimit`, floor at one page — instead of starting at the first chunk's size and letting `append`'s doubling run.
- **Startup log of the resolved envelope**: `GOMEMLIMIT`, `GOMAXPROCS`, body parsing size limit.

No new files, no new dependencies, no `go.mod` change.

### Motivation

Customers are reporting OOM kills on the callout container.

**The runtime cannot see the container limit.** `readGOMEMLIMIT()` returns `math.MaxInt64` when `GOMEMLIMIT` is unset, in every Go release up to and including 1.26 — there is still no cgroup *memory* awareness in the runtime, only the cgroup *CPU* awareness added for `GOMAXPROCS` in 1.25. So the collector paces itself purely off heap growth, never learns a ceiling exists, and the kernel kills the process while the runtime believes it has room. Deriving the limit converts a hard kill into GC pressure.

**Why 0.85 and not the usual 0.90.** The [GC guide](https://go.dev/doc/gc-guide#Memory_limit) suggests 5–10% headroom for memory the runtime cannot account for. This binary is built `CGO_ENABLED=1`, and `debug.SetMemoryLimit` explicitly excludes C-allocated memory, so libddwaf's allocations are invisible to `GOMEMLIMIT` while still counting against the cgroup. That warrants a wider margin than a pure-Go service needs.

**Buffer growth.** `bodyBuffer.append` allocated `cap = len(firstChunk)` and relied on `append` thereafter. A streamed body arriving in many small chunks therefore reallocates and copies repeatedly, and `append`'s rounding reserves capacity *past* `sizeLimit` on the final chunk of a large body — over a limit we had promised to respect.

**Why no dependency.** `automemlimit` would have been a two-line blank import, but it lands in the contrib module's `go.mod` and every consumer of `contrib/envoyproxy/go-control-plane` inherits it. That is a poor trade for a cgroup file reader, and implementing it directly also allows the cgo-aware ratio above.

**Not included on purpose.** `grpc.MaxConcurrentStreams` and `StaticStreamWindowSize` also bound memory, but both are workload tuning: the right values depend on traffic shape and the operator's memory limit, and `StaticStreamWindowSize` additionally disables BDP estimation, trading unknown throughput on unknown network paths for a bound. Those belong in documentation, not compiled-in defaults. Everything in this PR is derived from the environment at runtime.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage. `TestCgroupMemoryLimit` covers v2, v2 `max`, v1, the v1 unlimited sentinel, v2-over-v1 precedence, v1 fallback, absent files, unparseable content and zero. `TestConfigureGoMemoryLimitLeavesAnExplicitSettingAlone` covers operator override. `TestBodyBufferAppend`, `TestBodyBufferGrowthStaysWithinTheLimit` and `TestBodyBufferSmallBodyDoesNotReserveTheWholeLimit` cover the buffer.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag. Not applicable: process startup and allocation behaviour, verified directly in containers (below).
- [ ] There is a benchmark for any new code, or changes to existing code. Not applicable: the buffer change removes allocations and copies rather than adding work; the limit is read once at startup.
- [ ] If this interacts with the agent in a new way, a system test has been added. Not applicable: Agent interaction unchanged.
- [x] New code is free of linting errors. `golangci-lint run` reports 0 issues; `go vet` and `gofmt` clean on both modules.
- [x] New code doesn't break existing tests. `go test -race` passes for `instrumentation/appsec/proxy` and `contrib/envoyproxy/go-control-plane`.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. No generated files changed.
- [x] Non-trivial go.mod changes are reviewed by @DataDog/dd-trace-go-guild. No go.mod changes.

### Verification

Both new behaviours were mutation-checked rather than trusted green. Reverting `grow()` to the previous `append` fails `TestBodyBufferGrowthStaysWithinTheLimit` with *"capacity must never exceed the size limit"* — note the fixture deliberately uses 100,000 rather than a power of two, because with power-of-two sizes `append` lands exactly on the limit and the test passes vacuously.

The binary was then run in real memory-limited Linux containers:

| Scenario | Result |
|---|---|
| `docker run -m 512m` | `GOMEMLIMIT=456340275` (0.85 × 536870912) |
| no memory limit | stays `9223372036854775807`, no derivation |
| `GOMEMLIMIT=100000000` with `-m 512m` | explicit value wins |
| `--cpus 1.5` | `GOMAXPROCS=2` |

The cgroup path and format were confirmed against a live container first: `/sys/fs/cgroup/memory.max` reads `536870912` under `-m 512m` and the literal `max` when unlimited, with the v1 path absent on a v2-only host.

### Note for reviewers

The body-buffer tests live in `metrics_test.go` because it is the only test file in that package and this branch adds no new files. If you would rather they sat in a `body_buffer_test.go`, say so and I will split them out.

This does not by itself make worst-case memory finite — `grpc.MaxConcurrentStreams` is still unset, so concurrent streams are unbounded, and each carries a flow-control window that dynamic BDP can grow to 16 MiB. `GOMEMLIMIT` makes the GC fight back rather than the kernel intervene, which is the right first move, but the ceiling is a separate discussion.