### PR TITLE
ci(system-tests): run apim weblog variant in system-tests matrix

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,6 +124,7 @@ jobs:
       - build-weblog-images
       - build-service-extensions-callout
       - build-haproxy
+      - build-apim-callout
     strategy:
       matrix:
         weblog-variant:
@@ -242,6 +243,14 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: haproxy-spoa-image-linux-amd64
             image_name: haproxy-spoa
+          - weblog-variant: apim
+            scenario: DEFAULT
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
+          - weblog-variant: apim
+            scenario: APPSEC_BLOCKING
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}
@@ -304,7 +313,7 @@ jobs:
         run: npm install -g @datadog/datadog-ci
 
       - name: Download pre-built weblog image
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: weblog-image-${{ matrix.weblog-variant }}
@@ -314,21 +323,21 @@ jobs:
         run: ls -la binaries
 
       - name: Build weblog
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.image_artifact }}
 
       - name: Load ${{ matrix.weblog-variant }} image
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         run: docker load -i ${{ matrix.image_artifact }}.tar
       
       - name: Set ${{ matrix.image_name }} image name
-        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' }}
+        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim' }}
         run: echo "ghcr.io/datadog/dd-trace-go/${{ matrix.image_name }}:dev" > binaries/golang-${{ matrix.image_name }}-image
 
       - name: Build runner


### PR DESCRIPTION
## Summary

Wire the `apim` weblog variant into the system-tests matrix, exactly as `envoy` and `haproxy` are wired.

Follow-up to #5186 (which added the `build-apim-callout` job) and to DataDog/system-tests#7516 (which added the apim weblog variant). Both are merged, so the two preconditions this change depended on are now satisfied.

## Preconditions verified

| Precondition | Status |
|---|---|
| `ghcr.io/datadog/dd-trace-go/apim-callout:dev` exists | ✅ ghcr manifest → `200` |
| system-tests declares the `apim` weblog | ✅ `weblog_metadata.yml`: `apim: {build_mode: none, supported_scenarios: [APPSEC_BLOCKING, DEFAULT]}` |
| `load-binary.sh` writes the apim pointer | ✅ landed in system-tests#7516 |

## Changes

1. **`system-tests.needs`** — add `build-apim-callout`.

2. **Matrix entries** — `apim` × `DEFAULT` and `apim` × `APPSEC_BLOCKING`. This is exactly the supported set: it matches `supported_scenarios` in system-tests' `weblog_metadata.yml` and the go-proxies allow-list in `test_ci_orchestrator.py`, which groups `("envoy", "haproxy", "apim")` and restricts them to `("DEFAULT", "APPSEC_BLOCKING")`.

3. **Five variant gates** — extended to cover `apim`:
   - *exclusions* on **Download pre-built weblog image** and **Build weblog** — apim is `build_mode: none`, so there is no weblog image to fetch or build
   - *inclusions* on **Download artifacts**, **Load image**, and **Set image name**

`Set image name` writes `binaries/golang-apim-callout-image` (derived from `matrix.image_name`), which is the pointer file system-tests' `ApimCalloutContainer` reads.

## Parity check

Verified structurally, not by eye — all three proxies now match:

- the three build jobs have identical `with` key sets and identical `tags` / `push` / `platforms` / `if`
- all three appear in `system-tests.needs`
- all three have the same two scenarios and the same matrix field set
- every one of the five proxy gates references all three proxies

## Verification

- `yaml.safe_load` on the workflow → valid
- Diff is `+14, -5`, one file, purely additive to existing conditions
- Cross-repo contract confirmed: dd-trace-go writes `binaries/golang-apim-callout-image`; system-tests reads `golang-apim-callout-image`

## Expected CI behavior on this PR

`build-apim-callout` builds without pushing and uploads `apim-callout-image-linux-amd64`; the two new matrix jobs skip the weblog download/build, download and `docker load` that artifact, write the pointer, and run. Draft until those two jobs go green.