### PR TITLE
feat(contrib/IBM/sarama): add WithErrorCheck option

### DIFF
--- a/contrib/IBM/sarama/option.go
+++ b/contrib/IBM/sarama/option.go
@@ -29,6 +29,7 @@ type config struct {
 	saramaConfig        *sarama.Config
 	consumerCustomTags  map[string]func(msg *sarama.ConsumerMessage) any
 	producerCustomTags  map[string]func(msg *sarama.ProducerMessage) any
+	errCheck            func(err error) bool
 }
 
 func (cfg *config) ClusterID() string {
@@ -135,6 +136,25 @@ func WithBrokers(addrs []string) OptionFn {
 	return func(cfg *config) {
 		cfg.brokerAddrs = addrs
 	}
+}
+
+// WithErrorCheck specifies a function fn which determines whether the passed
+// error should be marked as an error. The fn is called whenever a Kafka request
+// finishes with an error.
+func WithErrorCheck(fn func(err error) bool) OptionFn {
+	return func(cfg *config) {
+		// When the error is explicitly marked as not-an-error, that is
+		// when this errCheck function returns false, the APM code will
+		// just skip the error and pretend the span was successful.
+		//
+		// This only affects whether the span/trace is marked as success/error,
+		// the calls to the Kafka API still return the upstream error code.
+		cfg.errCheck = fn
+	}
+}
+
+func (c *config) shouldIgnoreError(err error) bool {
+	return c != nil && c.errCheck != nil && !c.errCheck(err)
 }
 
 // startClusterIDFetch launches a goroutine to fetch the cluster ID from one of

--- a/contrib/IBM/sarama/option.go
+++ b/contrib/IBM/sarama/option.go
@@ -139,8 +139,8 @@ func WithBrokers(addrs []string) OptionFn {
 }
 
 // WithErrorCheck specifies a function fn which determines whether the passed
-// error should be marked as an error. The fn is called whenever a Kafka request
-// finishes with an error.
+// error should be marked as an error. The fn is called whenever a Kafka producer
+// request finishes with an error.
 func WithErrorCheck(fn func(err error) bool) OptionFn {
 	return func(cfg *config) {
 		// When the error is explicitly marked as not-an-error, that is
@@ -148,13 +148,13 @@ func WithErrorCheck(fn func(err error) bool) OptionFn {
 		// just skip the error and pretend the span was successful.
 		//
 		// This only affects whether the span/trace is marked as success/error,
-		// the calls to the Kafka API still return the upstream error code.
+		// the calls to the Kafka producer API still return the upstream error code.
 		cfg.errCheck = fn
 	}
 }
 
-func (c *config) shouldIgnoreError(err error) bool {
-	return c != nil && c.errCheck != nil && !c.errCheck(err)
+func (cfg *config) shouldIgnoreError(err error) bool {
+	return cfg != nil && cfg.errCheck != nil && !cfg.errCheck(err)
 }
 
 // startClusterIDFetch launches a goroutine to fetch the cluster ID from one of

--- a/contrib/IBM/sarama/producer.go
+++ b/contrib/IBM/sarama/producer.go
@@ -31,7 +31,7 @@ func (p *syncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32
 	span := startProducerSpan(p.cfg, p.version, msg)
 	setProduceCheckpoint(p.cfg.dataStreamsEnabled, p.cfg.ClusterID(), msg, p.version)
 	partition, offset, err = p.SyncProducer.SendMessage(msg)
-	finishProducerSpan(span, partition, offset, err)
+	finishProducerSpan(span, partition, offset, err, p.cfg)
 	if err == nil && p.cfg.dataStreamsEnabled {
 		tracer.TrackKafkaProduceOffsetWithCluster(p.cfg.ClusterID(), msg.Topic, partition, offset)
 	}
@@ -49,7 +49,7 @@ func (p *syncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
 	}
 	err := p.SyncProducer.SendMessages(msgs)
 	for i, span := range spans {
-		finishProducerSpan(span, msgs[i].Partition, msgs[i].Offset, err)
+		finishProducerSpan(span, msgs[i].Partition, msgs[i].Offset, err, p.cfg)
 	}
 	if err == nil && p.cfg.dataStreamsEnabled {
 		// we only track Kafka lag if messages have been sent successfully. Otherwise, we have no way to know to which partition data was sent to.
@@ -174,7 +174,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 					// if returning successes isn't enabled, we just finish the
 					// span right away because there's no way to know when it will
 					// be done
-					span.Finish()
+					finishSpan(span, nil, cfg)
 				}
 			case msg, ok := <-p.Successes():
 				if !ok {
@@ -189,7 +189,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 					spanID := spanctx.SpanID()
 					if span, ok := spans[spanID]; ok {
 						delete(spans, spanID)
-						finishProducerSpan(span, msg.Partition, msg.Offset, nil)
+						finishProducerSpan(span, msg.Partition, msg.Offset, nil, cfg)
 					}
 				}
 				wrapped.successes <- msg
@@ -202,7 +202,7 @@ func WrapAsyncProducer(saramaConfig *sarama.Config, p sarama.AsyncProducer, opts
 					spanID := spanctx.SpanID()
 					if span, ok := spans[spanID]; ok {
 						delete(spans, spanID)
-						span.Finish(tracer.WithError(err))
+						finishSpan(span, err, cfg)
 					}
 				}
 				wrapped.errors <- err
@@ -253,10 +253,10 @@ func startProducerSpan(cfg *config, version sarama.KafkaVersion, msg *sarama.Pro
 	return span
 }
 
-func finishProducerSpan(span *tracer.Span, partition int32, offset int64, err error) {
+func finishProducerSpan(span *tracer.Span, partition int32, offset int64, err error, cfg *config) {
 	span.SetTag(ext.MessagingKafkaPartition, partition)
 	span.SetTag("offset", offset)
-	span.Finish(tracer.WithError(err))
+	finishSpan(span, err, cfg)
 }
 
 func getProducerSpanContext(msg *sarama.ProducerMessage) (ddtrace.SpanContext, bool) {
@@ -296,4 +296,12 @@ func getProducerMsgSize(msg *sarama.ProducerMessage) (size int64) {
 		size += int64(msg.Key.Length())
 	}
 	return size
+}
+
+func finishSpan(span *tracer.Span, err error, cfg *config) {
+	opts := []tracer.FinishOption{}
+	if err != nil && !cfg.shouldIgnoreError(err) {
+		opts = []tracer.FinishOption{tracer.WithError(err)}
+	}
+	span.Finish(opts...)
 }

--- a/contrib/IBM/sarama/producer.go
+++ b/contrib/IBM/sarama/producer.go
@@ -299,7 +299,7 @@ func getProducerMsgSize(msg *sarama.ProducerMessage) (size int64) {
 }
 
 func finishSpan(span *tracer.Span, err error, cfg *config) {
-	opts := []tracer.FinishOption{}
+	var opts []tracer.FinishOption
 	if err != nil && !cfg.shouldIgnoreError(err) {
 		opts = []tracer.FinishOption{tracer.WithError(err)}
 	}

--- a/contrib/IBM/sarama/producer_test.go
+++ b/contrib/IBM/sarama/producer_test.go
@@ -7,10 +7,12 @@ package sarama
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/IBM/sarama/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -252,6 +254,131 @@ func TestWrapAsyncProducer(t *testing.T) {
 			assertDSMProducerPathway(t, topic, msg1)
 		}
 	})
+}
+
+// errProduceFailed is the error the mock producers are told to fail with, so
+// that the error paths guarded by WithErrorCheck can be exercised.
+var errProduceFailed = errors.New("failed to produce message")
+
+// assertProducerSpanErrors asserts that every finished producer span is marked
+// as errored, or that none of them is, according to wantErr.
+func assertProducerSpanErrors(t *testing.T, spans []*mocktracer.Span, wantErr bool) {
+	t.Helper()
+	for _, s := range spans {
+		if !wantErr {
+			assert.Nil(t, s.Tag(ext.ErrorMsg))
+			continue
+		}
+		// the async producer reports a *sarama.ProducerError, which wraps the
+		// underlying error in a longer message, so only check for containment.
+		require.NotNil(t, s.Tag(ext.ErrorMsg))
+		assert.Contains(t, s.Tag(ext.ErrorMsg), errProduceFailed.Error())
+	}
+}
+
+func TestProducerWithErrorCheck(t *testing.T) {
+	testCases := []struct {
+		name string
+		opt  Option
+		// wantErr is whether the produced spans should be marked as errored.
+		wantErr bool
+	}{
+		{
+			name:    "errCheck true",
+			opt:     WithErrorCheck(func(error) bool { return true }),
+			wantErr: true,
+		},
+		{
+			name:    "errCheck false",
+			opt:     WithErrorCheck(func(error) bool { return false }),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("SendMessage", func(t *testing.T) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+
+				saramaCfg := newMockProducerConfig()
+				mock := mocks.NewSyncProducer(t, saramaCfg)
+				mock.ExpectSendMessageAndFail(errProduceFailed)
+
+				producer := WrapSyncProducer(saramaCfg, mock, tc.opt)
+				defer func() {
+					assert.NoError(t, producer.Close())
+				}()
+
+				_, _, err := producer.SendMessage(&sarama.ProducerMessage{
+					Topic: topicName(t),
+					Value: sarama.StringEncoder("test 1"),
+				})
+				// the option only affects the span; the caller still sees the error.
+				require.ErrorIs(t, err, errProduceFailed)
+
+				spans := mt.FinishedSpans()
+				require.Len(t, spans, 1)
+				assertProducerSpanErrors(t, spans, tc.wantErr)
+			})
+
+			t.Run("SendMessages", func(t *testing.T) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+
+				saramaCfg := newMockProducerConfig()
+				mock := mocks.NewSyncProducer(t, saramaCfg)
+				// one expectation is consumed per message, and SendMessages
+				// returns on the first failure, so both spans are finished with
+				// the same error.
+				mock.ExpectSendMessageAndFail(errProduceFailed)
+				mock.ExpectSendMessageAndSucceed()
+
+				producer := WrapSyncProducer(saramaCfg, mock, tc.opt)
+				defer func() {
+					assert.NoError(t, producer.Close())
+				}()
+
+				topic := topicName(t)
+				err := producer.SendMessages([]*sarama.ProducerMessage{
+					{Topic: topic, Value: sarama.StringEncoder("test 1")},
+					{Topic: topic, Value: sarama.StringEncoder("test 2")},
+				})
+				require.ErrorIs(t, err, errProduceFailed)
+
+				spans := mt.FinishedSpans()
+				require.Len(t, spans, 2)
+				assertProducerSpanErrors(t, spans, tc.wantErr)
+			})
+
+			t.Run("AsyncProducer", func(t *testing.T) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+
+				saramaCfg := newMockProducerConfig()
+				mock := mocks.NewAsyncProducer(t, saramaCfg)
+				mock.ExpectInputAndFail(errProduceFailed)
+
+				producer := WrapAsyncProducer(saramaCfg, mock, tc.opt)
+				defer func() {
+					assert.NoError(t, producer.Close())
+				}()
+
+				producer.Input() <- &sarama.ProducerMessage{
+					Topic: topicName(t),
+					Value: sarama.StringEncoder("test 1"),
+				}
+				// the span is finished before the error is forwarded, so once
+				// this returns the span is guaranteed to be available.
+				err := <-producer.Errors()
+				require.ErrorIs(t, err, errProduceFailed)
+
+				spans := mt.FinishedSpans()
+				require.Len(t, spans, 1)
+				assertProducerSpanErrors(t, spans, tc.wantErr)
+			})
+		})
+	}
 }
 
 func TestSyncProducerWithClusterID(t *testing.T) {

--- a/contrib/IBM/sarama/sarama_test.go
+++ b/contrib/IBM/sarama/sarama_test.go
@@ -37,6 +37,14 @@ func newIntegrationTestConfig(t *testing.T) *sarama.Config {
 	return cfg
 }
 
+func newMockProducerConfig() *sarama.Config {
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V0_11_0_0 // first version that supports headers
+	cfg.Producer.Return.Successes = true
+	cfg.Producer.Return.Errors = true
+	return cfg
+}
+
 // waitForSpans polls the mock tracer until the expected number of spans
 // appear, or fails the test if the timeout is reached.
 func waitForSpans(t *testing.T, mt mocktracer.Tracer, sz int, timeout time.Duration) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

Adds a `WithErrorCheck` option to the IBM/sarama wrapper which allows library users to drop specific errors from being sent to DataDog.

### Motivation

Implements the feature described in discussion #5243. Similar features have been merged for other wrappers such as in #773, #806, #1315.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
