### PR TITLE
feat(openfeature): support updated FFE fixtures

### DIFF
--- a/openfeature/evaluator.go
+++ b/openfeature/evaluator.go
@@ -8,7 +8,6 @@ package openfeature
 import (
 	"crypto/md5"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -150,7 +149,7 @@ func evaluateFlag(flag *flag, defaultValue any, context map[string]any, now time
 }
 
 // evaluateConfiguredFlag evaluates a flag from a parsed configuration. Invalid
-// SemVer comparands return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
+// flags return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
 func evaluateConfiguredFlag(
 	config *universalFlagsConfiguration,
 	flagKey string,
@@ -163,14 +162,11 @@ func evaluateConfiguredFlag(
 		return evaluateFlag(flag, defaultValue, context, now)
 	}
 	if configErr, invalid := config.invalidFlags[flagKey]; invalid {
-		if errors.Is(configErr, errInvalidSemverComparand) {
-			return evaluationResult{
-				Value:  defaultValue,
-				Reason: of.ErrorReason,
-				Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
-			}
+		return evaluationResult{
+			Value:  defaultValue,
+			Reason: of.ErrorReason,
+			Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
 		}
-		return evaluationResult{Value: defaultValue, Reason: of.DefaultReason}
 	}
 	return evaluationResult{
 		Value:  defaultValue,

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -175,7 +175,7 @@ func TestEvaluateSemverCondition(t *testing.T) {
 		{name: "greater than or equal ignores build metadata", operator: operatorSemverGTE, attribute: "4.0.0+build.42", comparand: "4.0.0", want: true},
 		{name: "different build metadata has equal precedence", operator: operatorSemverEQ, attribute: "1.0.0+linux", comparand: "1.0.0+darwin", want: true},
 		{name: "invalid attribute", operator: operatorSemverNEQ, attribute: "not-a-version", comparand: "1.0.0"},
-		{name: "short attribute", operator: operatorSemverGTE, attribute: "1.2", comparand: "1.0.0"},
+		{name: "two-part attribute", operator: operatorSemverGTE, attribute: "1.2", comparand: "1.0.0", want: true},
 		{name: "prefixed attribute", operator: operatorSemverGTE, attribute: "v1.2.3", comparand: "1.0.0"},
 		{name: "overflowing attribute", operator: operatorSemverGTE, attribute: "18446744073709551616.0.0", comparand: "1.0.0"},
 		{name: "non-string attribute", operator: operatorSemverEQ, attribute: 1.2, comparand: "1.2.0"},
@@ -326,6 +326,26 @@ func TestEvaluateFlag_VariantTypeMismatchReturnsParseError(t *testing.T) {
 				t.Errorf("expected error to wrap errParseError, got: %v", result.Error)
 			}
 		})
+	}
+}
+
+func TestEvaluateConfiguredFlag_InvalidFlagReturnsParseError(t *testing.T) {
+	config := &universalFlagsConfiguration{
+		Flags: map[string]*flag{},
+		invalidFlags: map[string]error{
+			"invalid-flag": errors.New("invalid condition operand"),
+		},
+	}
+
+	result := evaluateConfiguredFlag(config, "invalid-flag", "default", nil, time.Now())
+	if result.Value != "default" {
+		t.Errorf("value: got %v, want default", result.Value)
+	}
+	if result.Reason != of.ErrorReason {
+		t.Errorf("reason: got %q, want %q", result.Reason, of.ErrorReason)
+	}
+	if !errors.Is(result.Error, errParseError) {
+		t.Errorf("expected parse error, got %v", result.Error)
 	}
 }
 

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -6,12 +6,14 @@
 package openfeature
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -349,6 +351,48 @@ func TestEvaluateConfiguredFlag_InvalidFlagReturnsParseError(t *testing.T) {
 	}
 }
 
+type fixtureEvaluationResult struct {
+	value     any
+	reason    of.Reason
+	errorCode of.ErrorCode
+}
+
+func resolutionErrorCode(err of.ResolutionError) of.ErrorCode {
+	code, _, _ := strings.Cut(err.Error(), ":")
+	return of.ErrorCode(code)
+}
+
+// evaluateFixture uses the public provider methods so fixture assertions cover
+// both evaluation and OpenFeature resolution-error conversion.
+func evaluateFixture(
+	provider *DatadogProvider,
+	flagKey string,
+	defaultValue any,
+	variationType valueType,
+	evaluationContext map[string]any,
+) fixtureEvaluationResult {
+	flatContext := of.FlattenedContext(evaluationContext)
+	switch variationType {
+	case valueTypeBoolean:
+		details := provider.BooleanEvaluation(context.Background(), flagKey, defaultValue.(bool), flatContext)
+		return fixtureEvaluationResult{details.Value, details.Reason, resolutionErrorCode(details.ResolutionError)}
+	case valueTypeString:
+		details := provider.StringEvaluation(context.Background(), flagKey, defaultValue.(string), flatContext)
+		return fixtureEvaluationResult{details.Value, details.Reason, resolutionErrorCode(details.ResolutionError)}
+	case valueTypeInteger:
+		details := provider.IntEvaluation(context.Background(), flagKey, int64(defaultValue.(float64)), flatContext)
+		return fixtureEvaluationResult{details.Value, details.Reason, resolutionErrorCode(details.ResolutionError)}
+	case valueTypeNumeric:
+		details := provider.FloatEvaluation(context.Background(), flagKey, defaultValue.(float64), flatContext)
+		return fixtureEvaluationResult{details.Value, details.Reason, resolutionErrorCode(details.ResolutionError)}
+	case valueTypeJSON:
+		details := provider.ObjectEvaluation(context.Background(), flagKey, defaultValue, flatContext)
+		return fixtureEvaluationResult{details.Value, details.Reason, resolutionErrorCode(details.ResolutionError)}
+	default:
+		panic(fmt.Sprintf("unsupported fixture variation type %q", variationType))
+	}
+}
+
 func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 	fixtureDir := "ffe-system-test-data"
 
@@ -360,6 +404,8 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 	if err := json.Unmarshal(configData, &cfg); err != nil {
 		t.Fatal(err)
 	}
+	provider := newDatadogProvider(ProviderConfig{})
+	provider.updateConfiguration(&cfg)
 
 	files, err := filepath.Glob(filepath.Join(fixtureDir, "evaluation-cases", "*.json"))
 	if err != nil {
@@ -376,13 +422,15 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 				t.Fatal(err)
 			}
 			var cases []struct {
-				Flag         string         `json:"flag"`
-				DefaultValue any            `json:"defaultValue"`
-				TargetingKey *string        `json:"targetingKey"`
-				Attributes   map[string]any `json:"attributes"`
-				Result       struct {
-					Value  any    `json:"value"`
-					Reason string `json:"reason"`
+				Flag          string         `json:"flag"`
+				DefaultValue  any            `json:"defaultValue"`
+				TargetingKey  *string        `json:"targetingKey"`
+				Attributes    map[string]any `json:"attributes"`
+				VariationType valueType      `json:"variationType"`
+				Result        struct {
+					Value     any    `json:"value"`
+					Reason    string `json:"reason"`
+					ErrorCode string `json:"errorCode"`
 				} `json:"result"`
 			}
 			if err := json.Unmarshal(data, &cases); err != nil {
@@ -400,14 +448,27 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 						ctx["targetingKey"] = *tc.TargetingKey
 					}
 
-					result := evaluateConfiguredFlag(&cfg, tc.Flag, tc.DefaultValue, ctx, time.Now())
+					result := evaluateFixture(provider, tc.Flag, tc.DefaultValue, tc.VariationType, ctx)
 
-					if fmt.Sprintf("%v", result.Value) != fmt.Sprintf("%v", tc.Result.Value) {
-						t.Errorf("value: got %v, want %v", result.Value, tc.Result.Value)
+					if fmt.Sprintf("%v", result.value) != fmt.Sprintf("%v", tc.Result.Value) {
+						t.Errorf("value: got %v, want %v", result.value, tc.Result.Value)
 					}
-					if tc.Result.Reason != "" && result.Reason != of.Reason(tc.Result.Reason) {
-						t.Errorf("reason: got %q, want %q", result.Reason, tc.Result.Reason)
+					if tc.Result.Reason != "" && result.reason != of.Reason(tc.Result.Reason) {
+						t.Errorf("reason: got %q, want %q", result.reason, tc.Result.Reason)
 					}
+					// Fixtures that declare an errorCode must resolve to that code through
+					// the public provider path. A fixture with an ERROR reason but no
+					// errorCode intentionally leaves the code unspecified; otherwise an
+					// omitted code means the resolution must not contain an error.
+					switch {
+					case tc.Result.ErrorCode != "":
+						if result.errorCode != of.ErrorCode(tc.Result.ErrorCode) {
+							t.Errorf("error code: got %q, want %q", result.errorCode, tc.Result.ErrorCode)
+						}
+					case tc.Result.Reason != string(of.ErrorReason) && result.errorCode != "":
+						t.Errorf("error code: got %q, want no error", result.errorCode)
+					}
+
 				})
 			}
 		})

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -110,14 +110,21 @@ func validateConfiguration(config *universalFlagsConfiguration) error {
 	}
 
 	hasFlags := len(config.Flags) > 0
+	if config.invalidFlags == nil {
+		config.invalidFlags = make(map[string]error)
+	}
 
-	// Validate each flag and delete invalid ones from the map
-	// Collect errors for reporting
+	// Validate each flag and delete invalid ones from the map.
+	// Keep their errors so evaluations return PARSE_ERROR rather than FLAG_NOT_FOUND.
 	errs := make([]error, 0, len(config.Flags))
 	maps.DeleteFunc(config.Flags, func(flagKey string, flag *flag) bool {
 		err := validateFlag(flagKey, flag)
-		errs = append(errs, err)
-		return err != nil
+		if err != nil {
+			config.invalidFlags[flagKey] = err
+			errs = append(errs, err)
+			return true
+		}
+		return false
 	})
 
 	if hasFlags && len(config.Flags) == 0 {
@@ -142,6 +149,22 @@ func validateFlag(flagKey string, flag *flag) error {
 		// Valid types
 	default:
 		return fmt.Errorf("flag %q has invalid variation type %q", flagKey, flag.VariationType)
+	}
+
+	// Validate every variation before evaluating any allocation. A malformed
+	// variation invalidates the complete flag, even if it is disabled or never
+	// selected by an allocation.
+	for variationKey, variation := range flag.Variations {
+		if variation == nil {
+			return fmt.Errorf("flag %q variation %q is nil", flagKey, variationKey)
+		}
+		if variation.Key != variationKey {
+			return fmt.Errorf("flag %q variation key mismatch: map key %q != variation.Key %q",
+				flagKey, variationKey, variation.Key)
+		}
+		if err := validateVariantType(variation.Value, flag.VariationType); err != nil {
+			return fmt.Errorf("flag %q variation %q has incompatible value: %w", flagKey, variationKey, err)
+		}
 	}
 
 	for i, allocation := range flag.Allocations {

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -13,6 +13,7 @@ import (
 
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 
+	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	internalffe "github.com/DataDog/dd-trace-go/v2/internal/openfeature"
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
@@ -200,16 +201,33 @@ func validateFlag(flagKey string, flag *flag) error {
 						flagKey, i, condition.Operator)
 				}
 
-				if condition.Operator == operatorMatches || condition.Operator == operatorNotMatches {
+				switch condition.Operator {
+				case operatorLT, operatorLTE, operatorGT, operatorGTE:
+					if _, ok := internal.ToFloat64(condition.Value); !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires numeric value",
+							flagKey, i, condition.Operator)
+					}
+				case operatorMatches, operatorNotMatches:
 					regex, ok := condition.Value.(string)
 					if !ok {
 						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires string value",
 							flagKey, i, condition.Operator)
 					}
-
 					if _, err := loadRegex(regex); err != nil {
 						return fmt.Errorf("flag %q allocation %d rule has condition with invalid regex %q: %v",
 							flagKey, i, regex, err)
+					}
+				case operatorOneOf, operatorNotOneOf:
+					switch condition.Value.(type) {
+					case []any, []string:
+					default:
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires array value",
+							flagKey, i, condition.Operator)
+					}
+				case operatorIsNull:
+					if _, ok := condition.Value.(bool); !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires boolean value",
+							flagKey, i, condition.Operator)
 					}
 				}
 

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -447,7 +447,7 @@ func TestMalformedVariationsReturnParseErrorBeforeEvaluation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := []byte(fmt.Sprintf(`{
+			data := fmt.Appendf(nil, `{
 				"format":"SERVER",
 				"flags":{"flag":{
 					"key":"flag",
@@ -456,7 +456,7 @@ func TestMalformedVariationsReturnParseErrorBeforeEvaluation(t *testing.T) {
 					"variations":%s,
 					"allocations":[{"splits":[{"shards":[],"variationKey":"on"}]}]
 				}}
-			}`, tt.enabled, tt.variations))
+			}`, tt.enabled, tt.variations)
 
 			var config universalFlagsConfiguration
 			require.NoError(t, json.Unmarshal(data, &config))

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -6,12 +6,14 @@
 package openfeature
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	of "github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
@@ -387,29 +389,88 @@ func TestValidateFlag(t *testing.T) {
 	})
 
 	t.Run("all variation types are valid", func(t *testing.T) {
-		validTypes := []valueType{
-			valueTypeBoolean,
-			valueTypeString,
-			valueTypeInteger,
-			valueTypeNumeric,
-			valueTypeJSON,
+		validTypes := []struct {
+			variationType valueType
+			value         any
+		}{
+			{valueTypeBoolean, true},
+			{valueTypeString, "test-value"},
+			{valueTypeInteger, int64(1)},
+			{valueTypeNumeric, 1.5},
+			{valueTypeJSON, map[string]any{"key": "value"}},
 		}
 
-		for _, vType := range validTypes {
+		for _, tt := range validTypes {
 			flag := &flag{
 				Key:           "test-flag",
-				VariationType: vType,
+				VariationType: tt.variationType,
 				Variations: map[string]*variant{
-					"v1": {Key: "v1", Value: "test-value"},
+					"v1": {Key: "v1", Value: tt.value},
 				},
 			}
 
 			err := validateFlag("test-flag", flag)
 			if err != nil {
-				t.Errorf("expected %s to be valid, got error: %v", vType, err)
+				t.Errorf("expected %s to be valid, got error: %v", tt.variationType, err)
 			}
 		}
 	})
+}
+
+func TestMalformedVariationsReturnParseErrorBeforeEvaluation(t *testing.T) {
+	tests := []struct {
+		name       string
+		enabled    bool
+		variations string
+	}{
+		{
+			name:       "nil variation",
+			enabled:    true,
+			variations: `{"on":{"key":"on","value":true},"bad":null}`,
+		},
+		{
+			name:       "variation map key mismatch",
+			enabled:    true,
+			variations: `{"on":{"key":"on","value":true},"bad":{"key":"other","value":true}}`,
+		},
+		{
+			name:       "unselected variation type mismatch",
+			enabled:    true,
+			variations: `{"on":{"key":"on","value":true},"bad":{"key":"bad","value":"true"}}`,
+		},
+		{
+			name:       "disabled variation type mismatch",
+			enabled:    false,
+			variations: `{"on":{"key":"on","value":"true"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(fmt.Sprintf(`{
+				"format":"SERVER",
+				"flags":{"flag":{
+					"key":"flag",
+					"enabled":%t,
+					"variationType":"BOOLEAN",
+					"variations":%s,
+					"allocations":[{"splits":[{"shards":[],"variationKey":"on"}]}]
+				}}
+			}`, tt.enabled, tt.variations))
+
+			var config universalFlagsConfiguration
+			require.NoError(t, json.Unmarshal(data, &config))
+			require.NotContains(t, config.Flags, "flag")
+			require.Contains(t, config.invalidFlags, "flag")
+
+			provider := newDatadogProvider(ProviderConfig{})
+			provider.updateConfiguration(&config)
+			details := provider.BooleanEvaluation(context.Background(), "flag", false, nil)
+			require.Equal(t, false, details.Value)
+			require.Equal(t, of.ErrorReason, details.Reason)
+			require.Equal(t, of.ParseErrorCode, resolutionErrorCode(details.ResolutionError))
+		})
+	}
 }
 
 func TestValidateFlagConditionOperandTypes(t *testing.T) {

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -412,6 +412,34 @@ func TestValidateFlag(t *testing.T) {
 	})
 }
 
+func TestValidateFlagConditionOperandTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator conditionOperator
+		value    any
+	}{
+		{name: "numeric", operator: operatorGT, value: "not-a-number"},
+		{name: "one of", operator: operatorOneOf, value: "not-an-array"},
+		{name: "is null", operator: operatorIsNull, value: "not-a-boolean"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := &flag{
+				Key:           "test-flag",
+				VariationType: valueTypeString,
+				Allocations: []*allocation{{
+					Rules: []*rule{{Conditions: []*condition{{
+						Operator: tt.operator,
+						Value:    tt.value,
+					}}}},
+				}},
+			}
+			require.Error(t, validateFlag("test-flag", flag))
+		})
+	}
+}
+
 func TestValidateFlagSemverConditions(t *testing.T) {
 	newFlag := func(operator conditionOperator, value any) *flag {
 		return &flag{
@@ -457,7 +485,6 @@ func TestValidateFlagSemverConditions(t *testing.T) {
 	}{
 		{name: "non-string", value: 1.2},
 		{name: "invalid", value: "not-a-version"},
-		{name: "short", value: "1.2"},
 		{name: "v prefix", value: "v1.2.3"},
 		{name: "leading zero", value: "01.2.3"},
 		{name: "overflow", value: "18446744073709551616.0.0"},
@@ -594,7 +621,8 @@ func TestProcessConfigUpdate(t *testing.T) {
 
 		invalidResult := evaluateConfiguredFlag(updatedConfig, "invalid-flag", false, nil, time.Now())
 		require.Equal(t, false, invalidResult.Value)
-		require.Equal(t, "DEFAULT", string(invalidResult.Reason))
+		require.Equal(t, "ERROR", string(invalidResult.Reason))
+		require.ErrorIs(t, invalidResult.Error, errParseError)
 	})
 
 	t.Run("configuration deletion", func(t *testing.T) {

--- a/openfeature/semver.go
+++ b/openfeature/semver.go
@@ -26,7 +26,7 @@ type parsedSemver struct {
 // Build metadata is validated but not retained because it does not affect
 // SemVer precedence.
 func parseSemver(version string) (parsedSemver, bool) {
-	parts := make([]uint64, 0, 12)
+	parts := make([]uint64, 0, 5)
 	next := 0
 	for {
 		part, end, ok := parseSemverCoreIdentifier(version, next)

--- a/openfeature/semver.go
+++ b/openfeature/semver.go
@@ -19,14 +19,14 @@ type parsedSemver struct {
 	prerelease string
 }
 
-// parseSemver accepts one through five numeric version parts. Missing minor
+// parseSemver accepts one or more numeric version parts. Missing minor
 // and patch parts are normalized to zero; additional parts participate in
 // ordering after the patch part. Numeric core identifiers are limited to
 // uint64, while numeric prerelease identifiers may be arbitrarily large.
 // Build metadata is validated but not retained because it does not affect
 // SemVer precedence.
 func parseSemver(version string) (parsedSemver, bool) {
-	parts := make([]uint64, 0, 5)
+	parts := make([]uint64, 0, 12)
 	next := 0
 	for {
 		part, end, ok := parseSemverCoreIdentifier(version, next)
@@ -38,7 +38,7 @@ func parseSemver(version string) (parsedSemver, bool) {
 		if next == len(version) || version[next] == '-' || version[next] == '+' {
 			break
 		}
-		if version[next] != '.' || len(parts) == 5 {
+		if version[next] != '.' {
 			return parsedSemver{}, false
 		}
 		next++

--- a/openfeature/semver.go
+++ b/openfeature/semver.go
@@ -15,28 +15,45 @@ type parsedSemver struct {
 	major      uint64
 	minor      uint64
 	patch      uint64
+	extra      []uint64
 	prerelease string
 }
 
-// parseSemver accepts the same version syntax as Rust's semver::Version::parse.
-// Core identifiers are limited to uint64, while numeric prerelease identifiers
-// may be arbitrarily large. Build metadata is validated but not retained because
-// it does not affect SemVer precedence.
+// parseSemver accepts one through five numeric version parts. Missing minor
+// and patch parts are normalized to zero; additional parts participate in
+// ordering after the patch part. Numeric core identifiers are limited to
+// uint64, while numeric prerelease identifiers may be arbitrarily large.
+// Build metadata is validated but not retained because it does not affect
+// SemVer precedence.
 func parseSemver(version string) (parsedSemver, bool) {
-	major, next, ok := parseSemverCoreIdentifier(version, 0)
-	if !ok || next >= len(version) || version[next] != '.' {
-		return parsedSemver{}, false
-	}
-	minor, next, ok := parseSemverCoreIdentifier(version, next+1)
-	if !ok || next >= len(version) || version[next] != '.' {
-		return parsedSemver{}, false
-	}
-	patch, next, ok := parseSemverCoreIdentifier(version, next+1)
-	if !ok {
-		return parsedSemver{}, false
+	parts := make([]uint64, 0, 5)
+	next := 0
+	for {
+		part, end, ok := parseSemverCoreIdentifier(version, next)
+		if !ok {
+			return parsedSemver{}, false
+		}
+		parts = append(parts, part)
+		next = end
+		if next == len(version) || version[next] == '-' || version[next] == '+' {
+			break
+		}
+		if version[next] != '.' || len(parts) == 5 {
+			return parsedSemver{}, false
+		}
+		next++
 	}
 
-	parsed := parsedSemver{major: major, minor: minor, patch: patch}
+	parsed := parsedSemver{major: parts[0]}
+	if len(parts) > 1 {
+		parsed.minor = parts[1]
+	}
+	if len(parts) > 2 {
+		parsed.patch = parts[2]
+	}
+	if len(parts) > 3 {
+		parsed.extra = parts[3:]
+	}
 	if next == len(version) {
 		return parsed, true
 	}
@@ -142,6 +159,21 @@ func compareSemver(left, right parsedSemver) int {
 			return -1
 		}
 		return 1
+	}
+	for i := 0; i < len(left.extra) || i < len(right.extra); i++ {
+		var leftPart, rightPart uint64
+		if i < len(left.extra) {
+			leftPart = left.extra[i]
+		}
+		if i < len(right.extra) {
+			rightPart = right.extra[i]
+		}
+		if leftPart < rightPart {
+			return -1
+		}
+		if leftPart > rightPart {
+			return 1
+		}
 	}
 	return compareSemverPrerelease(left.prerelease, right.prerelease)
 }

--- a/openfeature/semver_test.go
+++ b/openfeature/semver_test.go
@@ -17,6 +17,10 @@ func TestParseSemver(t *testing.T) {
 		want    parsedSemver
 	}{
 		{version: "0.0.0", want: parsedSemver{}},
+		{version: "1", want: parsedSemver{major: 1}},
+		{version: "1.2", want: parsedSemver{major: 1, minor: 2}},
+		{version: "1.2.3.4", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4}}},
+		{version: "1.2.3.4.5", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4, 5}}},
 		{
 			version: "18446744073709551615.18446744073709551615.18446744073709551615",
 			want: parsedSemver{
@@ -46,9 +50,7 @@ func TestParseSemver(t *testing.T) {
 
 	invalid := []string{
 		"",
-		"1",
-		"1.2",
-		"1.2.3.4",
+		"1.2.3.4.5.6",
 		"v1.2.3",
 		"01.2.3",
 		"1.02.3",

--- a/openfeature/semver_test.go
+++ b/openfeature/semver_test.go
@@ -22,6 +22,10 @@ func TestParseSemver(t *testing.T) {
 		{version: "1.2.3.4", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4}}},
 		{version: "1.2.3.4.5", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4, 5}}},
 		{
+			version: "1.2.3.4.5.6.7.8.9.10.11.12.13",
+			want:    parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		},
+		{
 			version: "18446744073709551615.18446744073709551615.18446744073709551615",
 			want: parsedSemver{
 				major: ^uint64(0),
@@ -50,7 +54,6 @@ func TestParseSemver(t *testing.T) {
 
 	invalid := []string{
 		"",
-		"1.2.3.4.5.6",
 		"v1.2.3",
 		"01.2.3",
 		"1.02.3",

--- a/openfeature/semver_test.go
+++ b/openfeature/semver_test.go
@@ -109,6 +109,25 @@ func TestCompareSemver(t *testing.T) {
 		}
 	}
 
+	t.Run("fourth and fifth numeric components", func(t *testing.T) {
+		tests := []struct {
+			left, right string
+			want        int
+		}{
+			{left: "1.2.3", right: "1.2.3.0", want: 0},
+			{left: "1.2.3.4", right: "1.2.3.5", want: -1},
+			{left: "1.2.3.4", right: "1.2.3.4.0", want: 0},
+			{left: "1.2.3.4.1", right: "1.2.3.4", want: 1},
+		}
+		for _, tt := range tests {
+			left, ok := parseSemver(tt.left)
+			require.True(t, ok)
+			right, ok := parseSemver(tt.right)
+			require.True(t, ok)
+			require.Equal(t, tt.want, compareSemver(left, right))
+		}
+	})
+
 	t.Run("arbitrarily large numeric prerelease identifiers", func(t *testing.T) {
 		left, ok := parseSemver("1.0.0-99999999999999999999")
 		require.True(t, ok)


### PR DESCRIPTION
## Summary
- Pin `ffe-system-test-data` to d9b05ae23d861228e210b9f4b7b1e5a926f88878.
- Add invalid-flag parse errors, condition validation, and semantic-version support with an indefinite number of numeric core parts.

## Validation
- `go test ./openfeature -count=1`
- `go vet ./openfeature`
- `git diff --check`

Pre-existing local fixture edits were backed up externally before pinning the final clean fixture checkout.