### PR TITLE
WIP: profiler: remove labels we don't want from the CPU profile

### DIFF
--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -118,7 +118,7 @@ var profileTypes = map[ProfileType]profileType{
 
 			c := p.compressors[CPUProfile]
 			c.Reset(&buf)
-			_, writeErr := outBuf.WriteTo(c)
+			writeErr := stripPPROFLabelsGzip(outBuf.Bytes(), c)
 			closeErr := c.Close()
 			return buf.Bytes(), cmp.Or(writeErr, closeErr)
 		},

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -256,6 +256,11 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	for _, pt := range types {
 		isDelta := p.cfg.deltaProfiles && len(profileTypes[pt].DeltaValues) > 0
 		in, out := compressionStrategy(pt, isDelta, p.cfg.compressionConfig)
+		// CPU profiles are decompressed while their tracer labels are stripped
+		// before being passed to this pipeline.
+		if pt == CPUProfile {
+			in = noCompression
+		}
 		compressor, err := pipelineBuilder.Build(in, out)
 		if err != nil {
 			return nil, err

--- a/profiler/strip_labels.go
+++ b/profiler/strip_labels.go
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+)
+
+var strippedLabelKeyNames = map[string]struct{}{
+	traceprof.LocalRootSpanID: {},
+}
+
+// stripPPROFLabels ... TODO
+func stripPPROFLabels(data []byte, w io.Writer) error {
+	decoder := pproflite.NewDecoder(data)
+	skippedKeyStringIndices := make(map[int64]struct{})
+	n := 0
+	if err := decoder.FieldEach(func(field pproflite.Field) error {
+		if _, ok := strippedLabelKeyNames[string(field.(*pproflite.StringTable).Value)]; ok {
+			skippedKeyStringIndices[int64(n)] = struct{}{}
+		}
+		n++
+		return nil
+	}, pproflite.StringTableDecoder); err != nil {
+		return err
+	}
+
+	if n > math.MaxUint32 {
+		return fmt.Errorf("too many strings: %d", n)
+	}
+
+	// indices is zero for unreferenced strings and otherwise stores its new
+	// index plus one. It is updated in place after strings have been marked.
+	indices := make([]uint32, n)
+	if len(indices) > 0 {
+		indices[0] = 1 // profile.proto requires string_table[0] to be empty.
+	}
+	mark := func(index int64) { indices[index] = 1 }
+	isStrippedLabel := func(label pproflite.Label) bool {
+		_, ok := skippedKeyStringIndices[label.Key]
+		return ok
+	}
+
+	// First find strings used by all fields that will remain in the profile.
+	if err := decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.SampleType:
+			mark(field.ValueType.Type)
+			mark(field.ValueType.Unit)
+		case *pproflite.Sample:
+			for _, label := range field.Label {
+				if isStrippedLabel(label) {
+					continue
+				}
+				mark(label.Key)
+				mark(label.Str)
+				mark(label.NumUnit)
+			}
+		case *pproflite.Mapping:
+			mark(field.Filename)
+			mark(field.BuildID)
+		case *pproflite.Function:
+			mark(field.Name)
+			mark(field.SystemName)
+			mark(field.FileName)
+		case *pproflite.DropFrames:
+			mark(field.Value)
+		case *pproflite.KeepFrames:
+			mark(field.Value)
+		case *pproflite.PeriodType:
+			mark(field.ValueType.Type)
+			mark(field.ValueType.Unit)
+		case *pproflite.Comment:
+			mark(field.Value)
+		case *pproflite.DefaultSampleType:
+			mark(field.Value)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Build the old-to-new string table index translation in place.
+	var next uint32
+	for i, index := range indices {
+		if index != 0 {
+			next++
+			indices[i] = next
+		}
+	}
+	translate := func(index *int64) { *index = int64(indices[*index] - 1) }
+
+	encoder := pproflite.NewEncoder(w)
+	stringIndex := 0
+	return decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.StringTable:
+			keep := indices[stringIndex] != 0
+			stringIndex++
+			if !keep {
+				return nil
+			}
+		case *pproflite.SampleType:
+			translate(&field.ValueType.Type)
+			translate(&field.ValueType.Unit)
+		case *pproflite.Sample:
+			labels := field.Label[:0]
+			for _, label := range field.Label {
+				if isStrippedLabel(label) {
+					continue
+				}
+				translate(&label.Key)
+				translate(&label.Str)
+				translate(&label.NumUnit)
+				labels = append(labels, label)
+			}
+			field.Label = labels
+		case *pproflite.Mapping:
+			translate(&field.Filename)
+			translate(&field.BuildID)
+		case *pproflite.Function:
+			translate(&field.Name)
+			translate(&field.SystemName)
+			translate(&field.FileName)
+		case *pproflite.DropFrames:
+			translate(&field.Value)
+		case *pproflite.KeepFrames:
+			translate(&field.Value)
+		case *pproflite.PeriodType:
+			translate(&field.ValueType.Type)
+			translate(&field.ValueType.Unit)
+		case *pproflite.Comment:
+			translate(&field.Value)
+		case *pproflite.DefaultSampleType:
+			translate(&field.Value)
+		}
+		return encoder.Encode(field)
+	})
+}
+
+// stripPPROFLabelsGzip decompresses a runtime CPU profile before stripping
+// its labels. The caller's compression pipeline performs the final encoding.
+func stripPPROFLabelsGzip(data []byte, output io.Writer) error {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	profile, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	return stripPPROFLabels(profile, output)
+}

--- a/profiler/strip_labels_test.go
+++ b/profiler/strip_labels_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+
+	pprofile "github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkStripTracerLabels(b *testing.B) {
+	path := os.Getenv("STRIP_TRACER_LABELS_PROFILE")
+	if path == "" {
+		b.Skip("set STRIP_TRACER_LABELS_PROFILE to a raw CPU profile path")
+	}
+	profile, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Logf("input size: %d bytes", len(profile))
+	buf := new(bytes.Buffer)
+	stripPPROFLabels(profile, buf)
+	b.Logf("output size: %d bytes", buf.Len())
+
+	b.SetBytes(int64(len(profile)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := stripPPROFLabels(profile, io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestStripTracerLabels(t *testing.T) {
+	// Include a value used outside a tracer label to verify that only unreferenced
+	// string table entries are removed.
+	strings := []string{"", "samples", "count", traceprof.SpanID, "123", traceprof.LocalRootSpanID, "456", traceprof.TraceEndpoint, "/users", "custom", "kept"}
+	var input bytes.Buffer
+	encoder := pproflite.NewEncoder(&input)
+	for _, value := range strings {
+		require.NoError(t, encoder.Encode(&pproflite.StringTable{Value: []byte(value)}))
+	}
+	require.NoError(t, encoder.Encode(&pproflite.SampleType{ValueType: pproflite.ValueType{Type: 1, Unit: 2}}))
+	require.NoError(t, encoder.Encode(&pproflite.Sample{Value: []int64{1}, Label: []pproflite.Label{
+		{Key: 3, Str: 4},
+		{Key: 5, Str: 6},
+		{Key: 7, Str: 8},
+		{Key: 9, Str: 10},
+	}}))
+
+	var output bytes.Buffer
+	require.NoError(t, stripPPROFLabels(input.Bytes(), &output))
+
+	// Ensure index remapping produced a valid pprof profile, not just protobuf
+	// which pproflite can decode.
+	_, err := pprofile.ParseData(output.Bytes())
+	require.NoError(t, err)
+
+	var gotLabels []pproflite.Label
+	var gotStrings []string
+	decoder := pproflite.NewDecoder(output.Bytes())
+	require.NoError(t, decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.Sample:
+			gotLabels = append(gotLabels, field.Label...)
+		case *pproflite.StringTable:
+			gotStrings = append(gotStrings, string(field.Value))
+		}
+		return nil
+	}))
+
+	require.Len(t, gotLabels, 3)
+	require.Equal(t, traceprof.SpanID, gotStrings[gotLabels[0].Key])
+	require.Equal(t, "123", gotStrings[gotLabels[0].Str])
+	require.Equal(t, traceprof.TraceEndpoint, gotStrings[gotLabels[1].Key])
+	require.Equal(t, "/users", gotStrings[gotLabels[1].Str])
+	require.Equal(t, "custom", gotStrings[gotLabels[2].Key])
+	require.Equal(t, "kept", gotStrings[gotLabels[2].Str])
+	require.NotContains(t, gotStrings, traceprof.LocalRootSpanID)
+	require.NotContains(t, gotStrings, "456")
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Demonstrates labels from CPU profiles that we don't need.
Basically, we define labels we don't want (in this case,
the local root span ID), go through the profile and figure out
which strings in the string table are referenced, _excluding_ the
unwanted labels, and then write out the profile without those
labels and with a new, smaller string table.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->
For discussion purposes. We can have the tracer stop adding local root span
IDs, which this PR removes  But #5114 will add trace ID goroutine labels.
Those labels will end up in the CPU profile and make the profiles on average
~10% bigger. We don't actually need the labels to be in the profile, though;
an eBPF process will read them.  We can't stop the runtime from attaching the
labels to CPU profile samples, so we either eat the cost of bigger profiles or
strip them from the profiles before uploading them.  This PR demonstrates
stripping the labels.

With a ~2.3MiB CPU profile of a Datadog production service, I get this output
from the included benchmark:

```
BenchmarkStripTracerLabels
    strip_labels_test.go:31: input size: 2378731 bytes
    strip_labels_test.go:34: output size: 2093234 bytes
BenchmarkStripTracerLabels-10                 44          25415905 ns/op          93.59 MB/s      109458 B/op         33 allocs/op
PASS
ok      github.com/DataDog/dd-trace-go/v2/profiler      1.661s
```

The benchmark doesn't include the added work of decompressing the CPU profile,
which is necessary since we take multiple passes over the profile to strip
the labels.

For trace ID or local root span ID, this doesn't affect how samples are
aggregated together since we still keep the span ID on each sample, which is
higher cardinality.

I've tested this with a toy program that does some busy work in an HTTP handler,
and confirmed that the resulting CPU profiles are still valid and accepted
by our backend and UI.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
