### PR TITLE
fix(ddtrace/tracer): make v1 stats workaround opt-in

### DIFF
--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -205,18 +205,21 @@
 // span's language dimension. (The same defect exists in versions 7.73.0
 // through 7.76.x, but those don't advertise /v1.0/traces by default, so the
 // protocol guard above already excludes them in practice.) The tracer
-// detects this from the agent's reported version and enables client-side
-// stats computation regardless of DD_TRACE_STATS_COMPUTATION_ENABLED /
-// WithStatsComputation(false), so that the tracer computes the affected
-// stats itself instead of relying on the agent. This also enables P0 trace
-// dropping, since the two capabilities are not independently controllable
-// (see WithStatsComputation). To opt out, either upgrade the trace-agent to
-// 7.79.0 or later, or set DD_TRACE_AGENT_PROTOCOL_VERSION=0.4. Two cases are
-// explicitly excluded from this override: the Datadog Lambda extension,
-// which already computes trace stats server-side (contrib/aws/datadog-lambda-go
-// starts the tracer with WithStatsComputation(false) on purpose), and CI
-// Visibility, whose transport never sends stats through this path regardless.
-// Other trace-agent implementations that do not follow this versioning
-// scheme (for example, an OpenTelemetry Collector exporter acting as a
-// Datadog trace-agent) are never affected by this override.
+// detects this from the agent's reported version and, when
+// DD_TRACE_FORCE_V1_STATS_ENABLED=true, enables client-side stats computation
+// regardless of DD_TRACE_STATS_COMPUTATION_ENABLED /
+// WithStatsComputation(false), so that the tracer computes the affected stats
+// itself instead of relying on the agent. This also enables P0 trace dropping,
+// since the two capabilities are not independently controllable
+// (see WithStatsComputation). The workaround is disabled by default because it
+// increases stats traffic. To use the configured stats behavior, leave that
+// setting unset or false; upgrading the trace-agent to 7.79.0 or later, or
+// setting DD_TRACE_AGENT_PROTOCOL_VERSION=0.4, also avoids the affected path.
+// Two cases are explicitly excluded from this override: the Datadog Lambda
+// extension, which already computes trace stats server-side
+// (contrib/aws/datadog-lambda-go starts the tracer with WithStatsComputation(false)
+// on purpose), and CI Visibility, whose transport never sends stats through
+// this path regardless. Other trace-agent implementations that do not follow
+// this versioning scheme (for example, an OpenTelemetry Collector exporter
+// acting as a Datadog trace-agent) are never affected by this override.
 package tracer // import "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -739,11 +739,15 @@ func (c *config) canComputeStatsWithAgent(a agentFeatures) bool {
 	return c.statsComputationRequested() || c.forcesStatsForV1Agent(a)
 }
 
-// forcesStatsForV1Agent reports whether client-side stats must be turned on
-// against the user's configuration because the tracer is on the v1.0 wire
-// protocol and this trace-agent's own v1.0 stats concentrator would aggregate
-// stats under an empty `lang` (see agentOmitsLangInV1Stats).
+// forcesStatsForV1Agent reports whether client-side stats should be turned on
+// against the user's configuration because the opt-in workaround is enabled,
+// the tracer is on the v1.0 wire protocol, and this trace-agent's own v1.0
+// stats concentrator would aggregate stats under an empty `lang`
+// (see agentOmitsLangInV1Stats).
 func (c *config) forcesStatsForV1Agent(a agentFeatures) bool {
+	if !c.internalConfig.ForceV1StatsEnabled() {
+		return false
+	}
 	if !a.v1StatsLangUnfixed {
 		return false
 	}
@@ -1312,13 +1316,13 @@ func WithPartialFlushing(numSpans int) StartOption {
 // This option does not affect the Datadog trace protocol version used to send
 // traces; see DD_TRACE_AGENT_PROTOCOL_VERSION.
 //
-// WithStatsComputation(false) may still be overridden: on the 1.0 protocol,
+// WithStatsComputation(false) is normally authoritative. The v1.0 agent stats
+// workaround can be explicitly enabled with DD_TRACE_FORCE_V1_STATS_ENABLED=true:
 // against a trace-agent reporting version 7.77.x, 7.78.x, or an unreleased
-// 7.79.0 pre-release predating 7.79.0-rc.6, the tracer forces stats
+// 7.79.0 pre-release predating 7.79.0-rc.6, the tracer then forces stats
 // computation (and P0 trace dropping — the two are not independently
 // controllable) on to work around a defect in that agent's own v1.0 stats
-// aggregation. See the "Trace Protocol" section of this package's doc.go for
-// how to opt out.
+// aggregation. See the "Trace Protocol" section of this package's doc.go.
 func WithStatsComputation(enabled bool) StartOption {
 	return func(c *config) {
 		c.internalConfig.SetStatsComputationEnabled(enabled, internalconfig.OriginCode)

--- a/ddtrace/tracer/poll_agent_info_test.go
+++ b/ddtrace/tracer/poll_agent_info_test.go
@@ -546,6 +546,8 @@ func TestTraceProtocolChangeLoggedOncePerTransition(t *testing.T) {
 // version to a fixed one therefore lifts the client-side-stats workaround
 // without a tracer restart.
 func TestPollAgentInfoLiftsV1StatsWorkaround(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
+
 	var agentVersion atomic.Pointer[string]
 	affected := "7.77.0"
 	agentVersion.Store(&affected)
@@ -623,6 +625,8 @@ func effectiveStatsReports(rec *telemetrytest.RecordClient) []bool {
 // silent"). Both directions must reach the log and config telemetry, and a
 // steady state must stay quiet so a 5s poll cannot spam either.
 func TestPollAgentInfoSurfacesV1StatsWorkaroundTransitions(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
+
 	t.Run("engages on a later poll", func(t *testing.T) {
 		rec := new(telemetrytest.RecordClient)
 		defer telemetry.MockClient(rec)()

--- a/ddtrace/tracer/trace_protocol_selection_test.go
+++ b/ddtrace/tracer/trace_protocol_selection_test.go
@@ -133,6 +133,19 @@ func TestTraceProtocolDecoupling(t *testing.T) {
 	}
 }
 
+func TestV1StatsWorkaroundDisabledByDefault(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "false")
+
+	agent := startTestAgent(t)
+	agent.SetInfo(v1StatsWorkaroundAffectedInfo)
+
+	tr := newTracerTest(t, agent, WithStatsComputation(false))
+	defer stopTracerTest(tr)
+
+	assert.False(t, tr.config.canComputeStats(), "the v1.0 stats workaround must be opt-in")
+	assert.False(t, tr.config.canDropP0s(), "the v1.0 stats workaround must not enable P0 dropping by default")
+}
+
 // TestPinTestTracerToV04RotatesWriterPayload pins a gap flagged in review:
 // startTestTracer's v1-capability override used to run after newTracer had already
 // built the writer's initial payload, so on a developer machine where a real Agent at
@@ -183,6 +196,8 @@ func TestPinTestTracerToV04RotatesWriterPayload(t *testing.T) {
 // move together for this workaround, so one column pins that invariant
 // structurally instead of two columns repeating the same value.
 func TestV1StatsWorkaroundForcesStatsAndP0Dropping(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
+
 	cases := []struct {
 		name              string
 		agentVersion      string // "" omits the "version" field from /info entirely
@@ -313,6 +328,8 @@ const v1StatsWorkaroundAffectedInfo = `{"endpoints":["/v0.4/traces","/v1.0/trace
 // In every case the wire protocol must stay v1.0: an exclusion suppresses the
 // stats override, never the protocol.
 func TestV1StatsWorkaroundExclusions(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
+
 	cases := []struct {
 		name string
 		// env is applied before the tracer is built, for exclusions whose
@@ -401,6 +418,7 @@ func TestV1StatsWorkaroundStartupOrderVsTracingAsTransport(t *testing.T) {
 	defer telemetry.MockClient(rec)()
 	logs := new(log.RecordLogger)
 
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
 	t.Setenv("DD_APM_TRACING_ENABLED", "false")
 	agent := startTestAgent(t)
 	agent.SetInfo(v1StatsWorkaroundAffectedInfo)
@@ -426,6 +444,8 @@ func TestV1StatsWorkaroundStartupOrderVsTracingAsTransport(t *testing.T) {
 // actually changes what goes out on the wire, which is what makes the agent
 // skip its buggy v1.0 stats path in the first place.
 func TestV1StatsWorkaroundWireBehavior(t *testing.T) {
+	t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", "true")
+
 	agent := startTestAgent(t)
 	agent.SetInfo(infoJSON([]string{"/v0.4/traces", "/v1.0/traces", "/v0.6/stats"}, true, "7.77.0"))
 	tr := newTracerTest(t, agent, WithStatsComputation(false))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,7 +127,11 @@ type Config struct {
 	internalMetricsEnabled bool
 	// statsComputationEnabled enables client-side stats computation (aka trace metrics).
 	statsComputationEnabled bool
-	traceAnalyticsEnabled   bool
+	// forceV1StatsEnabled enables the v1.0 agent stats workaround. It is opt-in
+	// because the workaround increases client-side stats traffic and can
+	// overwhelm agents that already have high stats volume.
+	forceV1StatsEnabled   bool
+	traceAnalyticsEnabled bool
 	// experimentalFeaturesEnabled controls tracer features that are not generally available.
 	experimentalFeaturesEnabled bool
 	// statsAdditionalTags is a list of tag keys to extract from spans and use as
@@ -348,6 +352,7 @@ func loadConfig() *Config {
 	cfg.partialFlushMinSpans = p.GetIntWithValidator("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 1000, validatePartialFlushMinSpans)
 	cfg.partialFlushEnabled = p.GetBool("DD_TRACE_PARTIAL_FLUSH_ENABLED", false)
 	cfg.statsComputationEnabled = p.GetBool("DD_TRACE_STATS_COMPUTATION_ENABLED", true)
+	cfg.forceV1StatsEnabled = p.GetBool("DD_TRACE_FORCE_V1_STATS_ENABLED", false)
 	cfg.traceAnalyticsEnabled = p.GetBool("DD_TRACE_ANALYTICS_ENABLED", false)
 	cfg.experimentalFeaturesEnabled = p.GetBool("DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", false)
 	if v := p.GetString("DD_TRACE_STATS_ADDITIONAL_TAGS", ""); v != "" {
@@ -1049,6 +1054,13 @@ func (c *Config) StatsComputationEnabled() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.statsComputationEnabled
+}
+
+// ForceV1StatsEnabled reports whether the v1.0 agent stats workaround is enabled.
+func (c *Config) ForceV1StatsEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.forceV1StatsEnabled
 }
 
 func (c *Config) SetStatsComputationEnabled(enabled bool, origin telemetry.Origin, product ...Product) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -428,6 +428,26 @@ func resetGlobalState() {
 	useFreshConfig = false
 }
 
+func TestForceV1StatsEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "disabled by default", want: false},
+		{name: "enabled explicitly", env: "true", want: true},
+		{name: "disabled explicitly", env: "false", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobalState()
+			defer resetGlobalState()
+			t.Setenv("DD_TRACE_FORCE_V1_STATS_ENABLED", tc.env)
+
+			assert.Equal(t, tc.want, Get().ForceV1StatsEnabled())
+		})
+	}
+}
+
 func TestStatsAdditionalTagsExperimentalGate(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -192,6 +192,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_TRACE_FASTHTTP_ANALYTICS_ENABLED":                             {},
 	"DD_TRACE_FEATURES":                                               {},
 	"DD_TRACE_FIBER_ANALYTICS_ENABLED":                                {},
+	"DD_TRACE_FORCE_V1_STATS_ENABLED":                                 {},
 	"DD_TRACE_GCP_PUBSUB_ANALYTICS_ENABLED":                           {},
 	"DD_TRACE_GIN_ANALYTICS_ENABLED":                                  {},
 	"DD_TRACE_GIT_METADATA_ENABLED":                                   {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -1290,6 +1290,13 @@
         "default": "false"
       }
     ],
+    "DD_TRACE_FORCE_V1_STATS_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false"
+      }
+    ],
     "DD_TRACE_GCP_PUBSUB_ANALYTICS_ENABLED": [
       {
         "implementation": "A",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9e357d41-84b8-4292-92e9-1b08ac983bfd","source":"chat","resourceId":"60e4e98f-b77a-45e6-8cf9-3e53e1c05ca1","workflowId":"1714b8b1-279c-4ecb-b075-07c0e660e24e","codeChangeId":"1714b8b1-279c-4ecb-b075-07c0e660e24e","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/cef28204-9556-409f-9777-6ae9c987f5f0)

Makes the v1.0 trace-agent stats workaround opt-in. This prevents affected agents from receiving unexpected client-side stats and P0-dropping load that can contribute to stats endpoint timeouts and trace loss, while preserving the workaround for deployments that explicitly need it.

Addresses #5258 partially.

### Motivation

The v1.0 stats workaround currently overrides DD_TRACE_STATS_COMPUTATION_ENABLED=false for affected agent versions. In high-volume services this can increase stats traffic and overload the agent's stats concentrator. The workaround is useful for the agent-side language aggregation defect, but it should not silently override a user's resource and traffic decision.

### Changes

- Add DD_TRACE_FORCE_V1_STATS_ENABLED, defaulting to false, to gate forcesStatsForV1Agent.
- Document the opt-in behavior and register the configuration in the supported configuration inventory.
- Add coverage for the default-off behavior and retain coverage for explicit opt-in, polling transitions, exclusions, and wire-level behavior.

### Testing

- go test ./internal/config ./ddtrace/tracer -count=1
- go test ./internal/env -count=1
- go run ./scripts/configinverter/main.go check
- git diff --check

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during review. The signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/60e4e98f-b77a-45e6-8cf9-3e53e1c05ca1)

Comment @datadog to request changes