### PR TITLE
feat(openfeature): support arbitrary semver parts

### DIFF
--- a/openfeature/evaluator.go
+++ b/openfeature/evaluator.go
@@ -8,7 +8,6 @@ package openfeature
 import (
 	"crypto/md5"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -150,7 +149,7 @@ func evaluateFlag(flag *flag, defaultValue any, context map[string]any, now time
 }
 
 // evaluateConfiguredFlag evaluates a flag from a parsed configuration. Invalid
-// SemVer comparands return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
+// flags return PARSE_ERROR. Missing flags return FLAG_NOT_FOUND.
 func evaluateConfiguredFlag(
 	config *universalFlagsConfiguration,
 	flagKey string,
@@ -163,14 +162,11 @@ func evaluateConfiguredFlag(
 		return evaluateFlag(flag, defaultValue, context, now)
 	}
 	if configErr, invalid := config.invalidFlags[flagKey]; invalid {
-		if errors.Is(configErr, errInvalidSemverComparand) {
-			return evaluationResult{
-				Value:  defaultValue,
-				Reason: of.ErrorReason,
-				Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
-			}
+		return evaluationResult{
+			Value:  defaultValue,
+			Reason: of.ErrorReason,
+			Error:  fmt.Errorf("%w: invalid configuration for flag %q: %w", errParseError, flagKey, configErr),
 		}
-		return evaluationResult{Value: defaultValue, Reason: of.DefaultReason}
 	}
 	return evaluationResult{
 		Value:  defaultValue,

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -175,7 +175,7 @@ func TestEvaluateSemverCondition(t *testing.T) {
 		{name: "greater than or equal ignores build metadata", operator: operatorSemverGTE, attribute: "4.0.0+build.42", comparand: "4.0.0", want: true},
 		{name: "different build metadata has equal precedence", operator: operatorSemverEQ, attribute: "1.0.0+linux", comparand: "1.0.0+darwin", want: true},
 		{name: "invalid attribute", operator: operatorSemverNEQ, attribute: "not-a-version", comparand: "1.0.0"},
-		{name: "short attribute", operator: operatorSemverGTE, attribute: "1.2", comparand: "1.0.0"},
+		{name: "two-part attribute", operator: operatorSemverGTE, attribute: "1.2", comparand: "1.0.0", want: true},
 		{name: "prefixed attribute", operator: operatorSemverGTE, attribute: "v1.2.3", comparand: "1.0.0"},
 		{name: "overflowing attribute", operator: operatorSemverGTE, attribute: "18446744073709551616.0.0", comparand: "1.0.0"},
 		{name: "non-string attribute", operator: operatorSemverEQ, attribute: 1.2, comparand: "1.2.0"},

--- a/openfeature/evaluator_test.go
+++ b/openfeature/evaluator_test.go
@@ -6,6 +6,7 @@
 package openfeature
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -341,6 +342,13 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	provider := newDatadogProvider(ProviderConfig{})
+	provider.updateConfiguration(&cfg)
+	if err := of.SetProviderAndWait(provider); err != nil {
+		t.Fatalf("set provider: %v", err)
+	}
+	client := of.NewClient("fixture-test")
+
 	files, err := filepath.Glob(filepath.Join(fixtureDir, "evaluation-cases", "*.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -361,8 +369,9 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 				TargetingKey *string        `json:"targetingKey"`
 				Attributes   map[string]any `json:"attributes"`
 				Result       struct {
-					Value  any    `json:"value"`
-					Reason string `json:"reason"`
+					Value     any    `json:"value"`
+					Reason    string `json:"reason"`
+					ErrorCode string `json:"errorCode"`
 				} `json:"result"`
 			}
 			if err := json.Unmarshal(data, &cases); err != nil {
@@ -387,6 +396,19 @@ func TestEvaluateFlag_JSONFixtures(t *testing.T) {
 					}
 					if tc.Result.Reason != "" && result.Reason != of.Reason(tc.Result.Reason) {
 						t.Errorf("reason: got %q, want %q", result.Reason, tc.Result.Reason)
+					}
+					if tc.Result.ErrorCode != "" {
+						evaluationContext := of.NewEvaluationContext("", tc.Attributes)
+						if tc.TargetingKey != nil {
+							evaluationContext = of.NewEvaluationContext(*tc.TargetingKey, tc.Attributes)
+						}
+						details, err := client.ObjectValueDetails(context.Background(), tc.Flag, tc.DefaultValue, evaluationContext)
+						if err == nil {
+							t.Error("expected SDK evaluation error, got nil")
+						}
+						if details.ErrorCode != of.ErrorCode(tc.Result.ErrorCode) {
+							t.Errorf("error code: got %q, want %q", details.ErrorCode, tc.Result.ErrorCode)
+						}
 					}
 				})
 			}

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -13,6 +13,7 @@ import (
 
 	rc "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 
+	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	internalffe "github.com/DataDog/dd-trace-go/v2/internal/openfeature"
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
@@ -200,20 +201,34 @@ func validateFlag(flagKey string, flag *flag) error {
 						flagKey, i, condition.Operator)
 				}
 
-				if condition.Operator == operatorMatches || condition.Operator == operatorNotMatches {
+				switch condition.Operator {
+				case operatorLT, operatorLTE, operatorGT, operatorGTE:
+					if _, ok := internal.ToFloat64(condition.Value); !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires numeric value",
+							flagKey, i, condition.Operator)
+					}
+				case operatorMatches, operatorNotMatches:
 					regex, ok := condition.Value.(string)
 					if !ok {
 						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires string value",
 							flagKey, i, condition.Operator)
 					}
-
 					if _, err := loadRegex(regex); err != nil {
 						return fmt.Errorf("flag %q allocation %d rule has condition with invalid regex %q: %v",
 							flagKey, i, regex, err)
 					}
-				}
-
-				switch condition.Operator {
+				case operatorOneOf, operatorNotOneOf:
+					if _, ok := condition.Value.([]any); !ok {
+						if _, ok := condition.Value.([]string); !ok {
+							return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires array value",
+								flagKey, i, condition.Operator)
+						}
+					}
+				case operatorIsNull:
+					if _, ok := condition.Value.(bool); !ok {
+						return fmt.Errorf("flag %q allocation %d rule has condition with operator %q that requires boolean value",
+							flagKey, i, condition.Operator)
+					}
 				case operatorSemverEQ, operatorSemverNEQ, operatorSemverLT,
 					operatorSemverLTE, operatorSemverGT, operatorSemverGTE:
 					comparand, ok := condition.Value.(string)

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -457,7 +457,6 @@ func TestValidateFlagSemverConditions(t *testing.T) {
 	}{
 		{name: "non-string", value: 1.2},
 		{name: "invalid", value: "not-a-version"},
-		{name: "short", value: "1.2"},
 		{name: "v prefix", value: "v1.2.3"},
 		{name: "leading zero", value: "01.2.3"},
 		{name: "overflow", value: "18446744073709551616.0.0"},

--- a/openfeature/remoteconfig_test.go
+++ b/openfeature/remoteconfig_test.go
@@ -412,6 +412,51 @@ func TestValidateFlag(t *testing.T) {
 	})
 }
 
+func TestValidateFlagConditionOperands(t *testing.T) {
+	newFlag := func(operator conditionOperator, value any) *flag {
+		return &flag{
+			Key:           "test-flag",
+			VariationType: valueTypeBoolean,
+			Variations: map[string]*variant{
+				"on": {Key: "on", Value: true},
+			},
+			Allocations: []*allocation{
+				{
+					Rules: []*rule{
+						{Conditions: []*condition{{Operator: operator, Attribute: "attribute", Value: value}}},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		operator conditionOperator
+		value    any
+		valid    bool
+	}{
+		{name: "numeric", operator: operatorGT, value: 1.5, valid: true},
+		{name: "numeric requires number", operator: operatorGT, value: "1.5"},
+		{name: "regex", operator: operatorMatches, value: "^value$", valid: true},
+		{name: "regex requires string", operator: operatorMatches, value: true},
+		{name: "list", operator: operatorOneOf, value: []any{"value"}, valid: true},
+		{name: "list requires array", operator: operatorOneOf, value: "value"},
+		{name: "null", operator: operatorIsNull, value: true, valid: true},
+		{name: "null requires boolean", operator: operatorIsNull, value: "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFlag("test-flag", newFlag(tt.operator, tt.value))
+			if tt.valid {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestValidateFlagSemverConditions(t *testing.T) {
 	newFlag := func(operator conditionOperator, value any) *flag {
 		return &flag{
@@ -593,7 +638,8 @@ func TestProcessConfigUpdate(t *testing.T) {
 
 		invalidResult := evaluateConfiguredFlag(updatedConfig, "invalid-flag", false, nil, time.Now())
 		require.Equal(t, false, invalidResult.Value)
-		require.Equal(t, "DEFAULT", string(invalidResult.Reason))
+		require.Equal(t, "ERROR", string(invalidResult.Reason))
+		require.ErrorIs(t, invalidResult.Error, errParseError)
 	})
 
 	t.Run("configuration deletion", func(t *testing.T) {

--- a/openfeature/semver.go
+++ b/openfeature/semver.go
@@ -15,28 +15,45 @@ type parsedSemver struct {
 	major      uint64
 	minor      uint64
 	patch      uint64
+	extra      []uint64
 	prerelease string
 }
 
-// parseSemver accepts the same version syntax as Rust's semver::Version::parse.
-// Core identifiers are limited to uint64, while numeric prerelease identifiers
-// may be arbitrarily large. Build metadata is validated but not retained because
-// it does not affect SemVer precedence.
+// parseSemver accepts one or more numeric version parts. Missing minor
+// and patch parts are normalized to zero; additional parts participate in
+// ordering after the patch part. Numeric core identifiers are limited to
+// uint64, while numeric prerelease identifiers may be arbitrarily large.
+// Build metadata is validated but not retained because it does not affect
+// SemVer precedence.
 func parseSemver(version string) (parsedSemver, bool) {
-	major, next, ok := parseSemverCoreIdentifier(version, 0)
-	if !ok || next >= len(version) || version[next] != '.' {
-		return parsedSemver{}, false
-	}
-	minor, next, ok := parseSemverCoreIdentifier(version, next+1)
-	if !ok || next >= len(version) || version[next] != '.' {
-		return parsedSemver{}, false
-	}
-	patch, next, ok := parseSemverCoreIdentifier(version, next+1)
-	if !ok {
-		return parsedSemver{}, false
+	parts := make([]uint64, 0, 5)
+	next := 0
+	for {
+		part, end, ok := parseSemverCoreIdentifier(version, next)
+		if !ok {
+			return parsedSemver{}, false
+		}
+		parts = append(parts, part)
+		next = end
+		if next == len(version) || version[next] == '-' || version[next] == '+' {
+			break
+		}
+		if version[next] != '.' {
+			return parsedSemver{}, false
+		}
+		next++
 	}
 
-	parsed := parsedSemver{major: major, minor: minor, patch: patch}
+	parsed := parsedSemver{major: parts[0]}
+	if len(parts) > 1 {
+		parsed.minor = parts[1]
+	}
+	if len(parts) > 2 {
+		parsed.patch = parts[2]
+	}
+	if len(parts) > 3 {
+		parsed.extra = parts[3:]
+	}
 	if next == len(version) {
 		return parsed, true
 	}
@@ -142,6 +159,21 @@ func compareSemver(left, right parsedSemver) int {
 			return -1
 		}
 		return 1
+	}
+	for i := 0; i < len(left.extra) || i < len(right.extra); i++ {
+		var leftPart, rightPart uint64
+		if i < len(left.extra) {
+			leftPart = left.extra[i]
+		}
+		if i < len(right.extra) {
+			rightPart = right.extra[i]
+		}
+		if leftPart < rightPart {
+			return -1
+		}
+		if leftPart > rightPart {
+			return 1
+		}
 	}
 	return compareSemverPrerelease(left.prerelease, right.prerelease)
 }

--- a/openfeature/semver.go
+++ b/openfeature/semver.go
@@ -26,14 +26,23 @@ type parsedSemver struct {
 // Build metadata is validated but not retained because it does not affect
 // SemVer precedence.
 func parseSemver(version string) (parsedSemver, bool) {
-	parts := make([]uint64, 0, 5)
+	var parsed parsedSemver
 	next := 0
-	for {
+	for component := 0; ; component++ {
 		part, end, ok := parseSemverCoreIdentifier(version, next)
 		if !ok {
 			return parsedSemver{}, false
 		}
-		parts = append(parts, part)
+		switch component {
+		case 0:
+			parsed.major = part
+		case 1:
+			parsed.minor = part
+		case 2:
+			parsed.patch = part
+		default:
+			parsed.extra = append(parsed.extra, part)
+		}
 		next = end
 		if next == len(version) || version[next] == '-' || version[next] == '+' {
 			break
@@ -42,17 +51,6 @@ func parseSemver(version string) (parsedSemver, bool) {
 			return parsedSemver{}, false
 		}
 		next++
-	}
-
-	parsed := parsedSemver{major: parts[0]}
-	if len(parts) > 1 {
-		parsed.minor = parts[1]
-	}
-	if len(parts) > 2 {
-		parsed.patch = parts[2]
-	}
-	if len(parts) > 3 {
-		parsed.extra = parts[3:]
 	}
 	if next == len(version) {
 		return parsed, true

--- a/openfeature/semver_test.go
+++ b/openfeature/semver_test.go
@@ -17,6 +17,14 @@ func TestParseSemver(t *testing.T) {
 		want    parsedSemver
 	}{
 		{version: "0.0.0", want: parsedSemver{}},
+		{version: "1", want: parsedSemver{major: 1}},
+		{version: "1.2", want: parsedSemver{major: 1, minor: 2}},
+		{version: "1.2.3.4", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4}}},
+		{version: "1.2.3.4.5", want: parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4, 5}}},
+		{
+			version: "1.2.3.4.5.6.7.8.9.10.11.12.13",
+			want:    parsedSemver{major: 1, minor: 2, patch: 3, extra: []uint64{4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+		},
 		{
 			version: "18446744073709551615.18446744073709551615.18446744073709551615",
 			want: parsedSemver{
@@ -46,9 +54,6 @@ func TestParseSemver(t *testing.T) {
 
 	invalid := []string{
 		"",
-		"1",
-		"1.2",
-		"1.2.3.4",
 		"v1.2.3",
 		"01.2.3",
 		"1.02.3",
@@ -106,6 +111,29 @@ func TestCompareSemver(t *testing.T) {
 			}
 		}
 	}
+
+	t.Run("extended numeric components", func(t *testing.T) {
+		tests := []struct {
+			left, right string
+			want        int
+		}{
+			{left: "1.2.3", right: "1.2.3.0", want: 0},
+			{left: "1.2.3.4", right: "1.2.3.5", want: -1},
+			{left: "1.2.3.4", right: "1.2.3.4.0", want: 0},
+			{left: "1.2.3.4.1", right: "1.2.3.4", want: 1},
+			{left: "1.2.3.4.5.6", right: "1.2.3.4.5.7", want: -1},
+			{left: "1.2.3.4.5.6", right: "1.2.3.4.5.6.0", want: 0},
+			{left: "1.2.3.4.5.6-alpha", right: "1.2.3.4.5.6", want: -1},
+			{left: "1.2.3.4.5.6.7.8.9.10.11.12.13", right: "1.2.3.4.5.6.7.8.9.10.11.12.14", want: -1},
+		}
+		for _, tt := range tests {
+			left, ok := parseSemver(tt.left)
+			require.True(t, ok)
+			right, ok := parseSemver(tt.right)
+			require.True(t, ok)
+			require.Equal(t, tt.want, compareSemver(left, right))
+		}
+	})
 
 	t.Run("arbitrarily large numeric prerelease identifiers", func(t *testing.T) {
 		left, ok := parseSemver("1.0.0-99999999999999999999")


### PR DESCRIPTION
## Summary
- accept one or more dot-separated numeric SemVer components and compare components after patch
- cover six-plus component parsing and ordering while retaining validation semantics
- pin OpenFeature system-test fixtures to 2c0c8d55f665fe4a847fc0ded3abf59b7e2896fc

## Testing
- `go test ./openfeature -run '^(TestParseSemver|TestCompareSemver|TestEvaluateSemverCondition|TestValidateFlagSemverConditions)$' -count=1`\n- `go test ./openfeature -run '^TestEvaluateFlag_JSONFixtures/test-case-semver' -count=1`