### PR TITLE
fix(ddtrace/tracer): stop variable shadowing in newHighCardinalitySpanList

### DIFF
--- a/ddtrace/tracer/payload_test.go
+++ b/ddtrace/tracer/payload_test.go
@@ -85,8 +85,9 @@ func newHighCardinalitySpanList(n int) spanList {
 		list[i].start = fixedTime
 		list[i].service = "service." + itoa[i%5+1]
 		list[i].resource = "resource." + itoa[i%5+1]
-		for i := range 50 {
-			list[i].SetTag("tag."+itoa[i%5+1], "value."+itoa[i%5+1])
+		for j := range 50 {
+			is, js := strconv.Itoa(i), strconv.Itoa(j)
+			list[i].SetTag("tag."+is+"."+js, "value."+is+"."+js)
 		}
 	}
 	return list


### PR DESCRIPTION
## Summary
- `newHighCardinalitySpanList` (used only by `BenchmarkPayloads`) shadowed the outer span-index loop variable `i` with an inner `for i := range 50`, so `SetTag` only ever wrote to `list[0..49]` while cycling through 5 static tag values, regardless of `n`.
- This silently broke `push/high_cardinality_spans`: it ran ~2x *faster* than `push/low_cardinality_spans`, which is backwards for genuinely high-cardinality tags.
- Renamed the inner variable to `j` and made each tag/value unique per span and per iteration (`tag.<i>.<j>` / `value.<i>.<j>`) so the benchmark now exercises actual high-cardinality tag data.

## Test plan
- [x] `go vet ./ddtrace/tracer/...` passes
- [x] `go test -run TestPayload ./ddtrace/tracer/` passes
- [x] `BenchmarkPayloads/*/push/high_cardinality_spans` now consistently costs more than `push/low_cardinality_spans` (previously the reverse)