### PR TITLE
feat(openfeature): add agentless EVP fallback

### DIFF
--- a/openfeature/doc.go
+++ b/openfeature/doc.go
@@ -195,9 +195,10 @@
 // DD_FEATURE_FLAGS_CONFIGURATION_SOURCE selects how configuration is delivered:
 //
 //   - "agentless" (default): the provider polls a Datadog endpoint directly over
-//     HTTPS on an interval. No Agent dependency. Requires DD_API_KEY unless a
-//     custom endpoint is configured; DD_SITE optionally selects the managed
-//     endpoint's host and has no effect without DD_API_KEY. See
+//     HTTPS on an interval, without using the Agent for configuration. Requires
+//     DD_API_KEY unless a custom endpoint is configured; DD_SITE optionally
+//     selects the managed endpoint's host and has no effect without DD_API_KEY.
+//     EVP event delivery may still use a compatible local Agent route. See
 //     "# Environment Variables" below.
 //   - "remote_config": the provider subscribes to Datadog Remote Config updates
 //     using the FFE_FLAGS product (capability 46), via the Agent. Configuration
@@ -212,6 +213,17 @@
 // first: the tracer eagerly subscribes to the FFE_FLAGS Remote Config product
 // and may fetch and buffer configuration before NewDatadogProvider is called.
 //
+// Exposure and flag-evaluation events use EVP. With the agentless configuration
+// source, the first event flush queries the trace Agent's /info endpoint once,
+// preferring /evp_proxy/v4 and then /evp_proxy/v2. When neither route is
+// advertised or the Agent cannot be reached, delivery uses the direct
+// event-platform intake derived from DD_SITE and authenticates with DD_API_KEY.
+// Discovery runs only once. A selected local route can transition to direct
+// delivery after an incompatible HTTP response or transport failure. Without a
+// compatible Agent route or valid direct credentials, EVP event delivery is
+// disabled. The remote_config source continues to send EVP events through the
+// Agent's /evp_proxy/v2 route.
+//
 // # Configuration
 //
 // The provider can be configured using ProviderConfig when creating a new instance:
@@ -224,7 +236,7 @@
 // Configuration Options:
 //
 //   - ExposureFlushInterval: Duration between automatic flushes of exposure events
-//     to the Datadog agent. Defaults to 1 second if not specified. Exposure events
+//     through EVP. Defaults to 1 second if not specified. Exposure events
 //     track which feature flags are evaluated and by which users, providing visibility
 //     into feature flag usage. Set to 0 to disable automatic flushing (not recommended).
 //
@@ -277,6 +289,10 @@
 //     overflow when converted to a time.Duration) or unparseable value falls back
 //     to the default rather than being clamped.
 //
+//   - DD_FLAGGING_EVALUATION_COUNTS_ENABLED: Set to "false" to disable EVP
+//     flag-evaluation count events. Defaults to true. Exposure events are not
+//     affected.
+//
 // Example (Agentless, the default):
 //
 //	export DD_API_KEY=<your API key>
@@ -284,16 +300,24 @@
 //
 // Standard Datadog environment variables also apply:
 //
-//   - DD_API_KEY: Required for the default, managed Agentless endpoint.
+//   - DD_API_KEY: Required for the default, managed Agentless configuration
+//     endpoint and direct EVP event fallback.
 //   - DD_SITE: Datadog site (default: datadoghq.com). Determines the managed
-//     Agentless endpoint's host.
-//   - DD_AGENT_HOST: Datadog agent host (default: localhost). Only relevant to
-//     the remote_config source.
-//   - DD_TRACE_AGENT_PORT: Datadog agent port (default: 8126). Only relevant to
-//     the remote_config source.
+//     Agentless configuration endpoint and direct EVP intake hosts.
+//   - DD_TRACE_AGENT_URL: Trace Agent URL. Takes precedence over DD_AGENT_HOST
+//     and DD_TRACE_AGENT_PORT. Used for remote_config and for Agentless EVP route
+//     discovery and local event delivery.
+//   - DD_AGENT_HOST: Trace Agent host (default: localhost). Used with
+//     DD_TRACE_AGENT_PORT when DD_TRACE_AGENT_URL is unset.
+//   - DD_TRACE_AGENT_PORT: Trace Agent port (default: 8126). Used with
+//     DD_AGENT_HOST when DD_TRACE_AGENT_URL is unset.
 //   - DD_SERVICE: Service name for tagging
 //   - DD_ENV: Environment name (e.g., production, staging)
 //   - DD_VERSION: Application version
+//
+// With no Agent address variables set, EVP route discovery uses the standard
+// trace Agent resolution: an existing /var/run/datadog/apm.socket, then
+// localhost:8126.
 //
 // # Prerequisites
 //
@@ -331,8 +355,8 @@
 // The cache uses LRU eviction when capacity is reached, ensuring recently active
 // flag/subject combinations remain cached while older entries are evicted.
 //
-// Exposure events are buffered and flushed periodically to the Datadog Agent
-// (default: every 1 second, configurable via ExposureFlushInterval).
+// Exposure events are buffered and flushed periodically through EVP (default:
+// every 1 second, configurable via ExposureFlushInterval).
 //
 // # Performance Considerations
 //

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -110,15 +110,60 @@ func newEVPClientBase() *evpClient {
 }
 
 func buildDirectEVPURL(site string) *url.URL {
-	site = strings.TrimSpace(site)
-	if site == "" || strings.ContainsAny(site, "/?#@") {
+	site = strings.ToLower(strings.TrimSpace(site))
+	if !isValidDirectEVPSite(site) {
 		return nil
 	}
-	u, err := url.Parse("https://" + directEVPHostPrefix + site)
-	if err != nil || u.Hostname() == "" {
+	expectedHost := directEVPHostPrefix + site
+	u, err := url.Parse("https://" + expectedHost)
+	if err != nil ||
+		u.Scheme != "https" ||
+		u.User != nil ||
+		u.Host != expectedHost ||
+		u.Hostname() != expectedHost ||
+		u.Port() != "" ||
+		u.Path != "" ||
+		u.RawPath != "" ||
+		u.RawQuery != "" ||
+		u.Fragment != "" {
 		return nil
 	}
 	return u
+}
+
+func isValidDirectEVPSite(site string) bool {
+	if site == "" || len(site) > 230 {
+		return false
+	}
+
+	labelLength := 0
+	previousWasHyphen := false
+	for i := 0; i < len(site); i++ {
+		character := site[i]
+		if character == '.' {
+			if labelLength == 0 || previousWasHyphen {
+				return false
+			}
+			labelLength = 0
+			previousWasHyphen = false
+			continue
+		}
+
+		if (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') {
+			labelLength++
+			previousWasHyphen = false
+		} else if character == '-' && labelLength > 0 {
+			labelLength++
+			previousWasHyphen = true
+		} else {
+			return false
+		}
+		if labelLength > 63 {
+			return false
+		}
+	}
+
+	return labelLength > 0 && !previousWasHyphen
 }
 
 func (c *evpClient) post(endpoint, eventName string, payload any) error {

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -8,11 +8,9 @@ package openfeature
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -35,11 +33,7 @@ const (
 
 	directEVPHostPrefix = "event-platform-intake."
 
-	apiKeyHeader            = "DD-API-KEY"
-	apiKeyFingerprintHeader = "DD-API-KEY-FINGERPRINT"
-	apiKeyFingerprintPrefix = "rijn_"
-	sha256Base62Length      = 43
-	base62Alphabet          = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	apiKeyHeader = "DD-API-KEY"
 )
 
 var errNoEVPRoute = errors.New("no compatible EVP route is available")
@@ -68,7 +62,6 @@ type evpClient struct {
 	agentURL     *url.URL
 	directURL    *url.URL
 	apiKey       string
-	fingerprint  string
 	jsonConfig   jsoniter.API
 
 	discoveryOnce sync.Once
@@ -94,7 +87,6 @@ func newAgentlessEVPClient(settings internalffe.Settings) *evpClient {
 	c.directClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
 	c.apiKey = settings.APIKey
 	if c.apiKey != "" {
-		c.fingerprint = createAPIKeyFingerprint(c.apiKey)
 		c.directURL = buildDirectEVPURL(settings.Site)
 	}
 	return c
@@ -127,28 +119,6 @@ func buildDirectEVPURL(site string) *url.URL {
 		return nil
 	}
 	return u
-}
-
-func createAPIKeyFingerprint(apiKey string) string {
-	digest := sha256.Sum256([]byte(apiKey))
-	value := new(big.Int).SetBytes(digest[:])
-	radix := big.NewInt(62)
-	remainder := new(big.Int)
-	encoded := make([]byte, 0, sha256Base62Length)
-	for value.Sign() > 0 {
-		value.QuoRem(value, radix, remainder)
-		encoded = append(encoded, base62Alphabet[remainder.Int64()])
-	}
-	if len(encoded) == 0 {
-		encoded = append(encoded, base62Alphabet[0])
-	}
-	for len(encoded) < sha256Base62Length {
-		encoded = append(encoded, base62Alphabet[0])
-	}
-	for left, right := 0, len(encoded)-1; left < right; left, right = left+1, right-1 {
-		encoded[left], encoded[right] = encoded[right], encoded[left]
-	}
-	return apiKeyFingerprintPrefix + string(encoded)
 }
 
 func (c *evpClient) post(endpoint, eventName string, payload any) error {
@@ -249,7 +219,6 @@ func (c *evpClient) send(
 	req.Header.Set("Content-Type", "application/json")
 	if direct {
 		req.Header.Set(apiKeyHeader, c.apiKey)
-		req.Header.Set(apiKeyFingerprintHeader, c.fingerprint)
 	} else {
 		req.Header.Set(evpSubdomainHeader, evpSubdomainValue)
 	}
@@ -363,7 +332,7 @@ func (c *evpClient) canUseDirect() bool {
 }
 
 func (c *evpClient) canUseDirectLocked() bool {
-	return c.directClient != nil && c.directURL != nil && c.apiKey != "" && c.fingerprint != ""
+	return c.directClient != nil && c.directURL != nil && c.apiKey != ""
 }
 
 func (c *evpClient) selectDirect() {

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -8,25 +8,99 @@ package openfeature
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
 
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
+	internalffe "github.com/DataDog/dd-trace-go/v2/internal/openfeature"
 )
 
-type evpClient struct {
-	httpClient *http.Client
-	agentURL   *url.URL
-	jsonConfig jsoniter.API
+const (
+	evpProxyV4Path = "/evp_proxy/v4"
+	evpProxyV2Path = "/evp_proxy/v2"
+
+	directEVPHostPrefix = "event-platform-intake."
+
+	apiKeyHeader            = "DD-API-KEY"
+	apiKeyFingerprintHeader = "DD-API-KEY-FINGERPRINT"
+	apiKeyFingerprintPrefix = "rijn_"
+	sha256Base62Length      = 43
+	base62Alphabet          = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+var errNoEVPRoute = errors.New("no compatible EVP route is available")
+
+type evpRouteMode uint8
+
+const (
+	evpRouteUnknown evpRouteMode = iota
+	evpRouteLocal
+	evpRouteDirect
+	evpRouteDisabled
+)
+
+type evpHTTPStatusError struct {
+	statusCode int
+	body       string
 }
 
+func (e *evpHTTPStatusError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %s", e.statusCode, e.body)
+}
+
+type evpClient struct {
+	httpClient   *http.Client
+	directClient *http.Client
+	agentURL     *url.URL
+	directURL    *url.URL
+	apiKey       string
+	fingerprint  string
+	jsonConfig   jsoniter.API
+
+	discoveryOnce sync.Once
+	warnNoRoute   sync.Once
+	routeMu       sync.RWMutex
+	routeMode     evpRouteMode
+	localBase     string
+}
+
+// newEVPClient returns the historical Agent-only transport. Remote Configuration
+// must never fall back to direct intake.
 func newEVPClient() *evpClient {
+	c := newEVPClientBase()
+	c.routeMode = evpRouteLocal
+	c.localBase = evpProxyV2Path
+	return c
+}
+
+// newAgentlessEVPClient builds a source-aware client. Discovery is intentionally
+// lazy so provider readiness never waits for the Agent-compatible relay.
+func newAgentlessEVPClient(settings internalffe.Settings) *evpClient {
+	c := newEVPClientBase()
+	c.directClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
+	c.apiKey = settings.APIKey
+	if c.apiKey != "" {
+		c.fingerprint = createAPIKeyFingerprint(c.apiKey)
+		c.directURL = buildDirectEVPURL(settings.Site)
+	}
+	return c
+}
+
+func newEVPClientBase() *evpClient {
 	agentURL := internal.AgentURLFromEnv()
 	var httpClient *http.Client
 	if agentURL.Scheme == "unix" {
@@ -43,6 +117,40 @@ func newEVPClient() *evpClient {
 	}
 }
 
+func buildDirectEVPURL(site string) *url.URL {
+	site = strings.TrimSpace(site)
+	if site == "" || strings.ContainsAny(site, "/?#@") {
+		return nil
+	}
+	u, err := url.Parse("https://" + directEVPHostPrefix + site)
+	if err != nil || u.Hostname() == "" {
+		return nil
+	}
+	return u
+}
+
+func createAPIKeyFingerprint(apiKey string) string {
+	digest := sha256.Sum256([]byte(apiKey))
+	value := new(big.Int).SetBytes(digest[:])
+	radix := big.NewInt(62)
+	remainder := new(big.Int)
+	encoded := make([]byte, 0, sha256Base62Length)
+	for value.Sign() > 0 {
+		value.QuoRem(value, radix, remainder)
+		encoded = append(encoded, base62Alphabet[remainder.Int64()])
+	}
+	if len(encoded) == 0 {
+		encoded = append(encoded, base62Alphabet[0])
+	}
+	for len(encoded) < sha256Base62Length {
+		encoded = append(encoded, base62Alphabet[0])
+	}
+	for left, right := 0, len(encoded)-1; left < right; left, right = left+1, right-1 {
+		encoded[left], encoded[right] = encoded[right], encoded[left]
+	}
+	return apiKeyFingerprintPrefix + string(encoded)
+}
+
 func (c *evpClient) post(endpoint, eventName string, payload any) error {
 	if c == nil {
 		return errors.New("EVP client is not configured")
@@ -56,39 +164,223 @@ func (c *evpClient) post(endpoint, eventName string, payload any) error {
 	return c.postRaw(endpoint, eventName, bytesBuffer.Bytes())
 }
 
-// postRaw sends already-encoded JSON bytes to the EVP proxy. Used by the flagevaluation flush
-// path, which splits a flush into multiple size-bounded payloads and encodes each incrementally
-// (see buildFlagEvalPayloads) rather than handing a whole struct to post().
+// postRaw sends already-encoded JSON bytes through the selected EVP route. Used by the
+// flagevaluation flush path, which splits a flush into multiple size-bounded payloads.
 func (c *evpClient) postRaw(endpoint, eventName string, body []byte) error {
 	if c == nil {
 		return errors.New("EVP client is not configured")
 	}
 
-	u := *c.agentURL
-	u.Path = endpoint
+	mode, localBase := c.resolveRoute()
+	switch mode {
+	case evpRouteLocal:
+		result := c.send(c.httpClient, c.agentURL, localBase, endpoint, eventName, body, false)
+		if result.err == nil {
+			return nil
+		}
+
+		if !c.canUseDirect() {
+			return result.err
+		}
+
+		var statusErr *evpHTTPStatusError
+		if errors.As(result.err, &statusErr) {
+			if statusErr.statusCode != http.StatusForbidden &&
+				statusErr.statusCode != http.StatusNotFound &&
+				statusErr.statusCode != http.StatusMethodNotAllowed {
+				return result.err
+			}
+			c.selectDirect()
+			return c.sendDirect(endpoint, eventName, body)
+		}
+
+		// Every transport error changes only future routing. Replaying the current
+		// body is allowed solely when the request was never written and the error
+		// proves DNS/socket establishment failed.
+		c.selectDirect()
+		if !result.wroteRequest && isDefinitivePreSendError(result.err) {
+			return c.sendDirect(endpoint, eventName, body)
+		}
+		return result.err
+	case evpRouteDirect:
+		return c.sendDirect(endpoint, eventName, body)
+	default:
+		c.warnNoRoute.Do(func() {
+			log.Warn("openfeature: disabling EVP event delivery because no compatible local route or direct credentials are available")
+		})
+		return errNoEVPRoute
+	}
+}
+
+type evpSendResult struct {
+	err          error
+	wroteRequest bool
+}
+
+func (c *evpClient) send(
+	client *http.Client,
+	baseURL *url.URL,
+	basePath string,
+	endpoint string,
+	eventName string,
+	body []byte,
+	direct bool,
+) evpSendResult {
+	if client == nil || baseURL == nil {
+		return evpSendResult{err: errNoEVPRoute}
+	}
+
+	u := *baseURL
+	u.Path = joinEVPPath(basePath, endpoint)
 	requestURL := u.String()
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST", requestURL, bytes.NewReader(body))
+	var wroteRequest atomic.Bool
+	trace := &httptrace.ClientTrace{
+		WroteRequest: func(httptrace.WroteRequestInfo) {
+			wroteRequest.Store(true)
+		},
+	}
+	ctx := httptrace.WithClientTrace(context.Background(), trace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return evpSendResult{err: fmt.Errorf("failed to create request: %w", err)}
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(evpSubdomainHeader, evpSubdomainValue)
+	if direct {
+		req.Header.Set(apiKeyHeader, c.apiKey)
+		req.Header.Set(apiKeyFingerprintHeader, c.fingerprint)
+	} else {
+		req.Header.Set(evpSubdomainHeader, evpSubdomainValue)
+	}
 
-	log.Debug("openfeature: sending %s events to %s", eventName, requestURL)
+	log.Debug("openfeature: sending %s events through %s EVP route", eventName, routeName(direct))
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return evpSendResult{
+			err:          fmt.Errorf("request failed: %w", err),
+			wroteRequest: wroteRequest.Load(),
+		}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(respBody))
+		return evpSendResult{
+			err: &evpHTTPStatusError{
+				statusCode: resp.StatusCode,
+				body:       string(respBody),
+			},
+			wroteRequest: wroteRequest.Load(),
+		}
 	}
-	return nil
+	return evpSendResult{wroteRequest: wroteRequest.Load()}
+}
+
+func routeName(direct bool) string {
+	if direct {
+		return "direct"
+	}
+	return "local"
+}
+
+func (c *evpClient) sendDirect(endpoint, eventName string, body []byte) error {
+	return c.send(c.directClient, c.directURL, "", endpoint, eventName, body, true).err
+}
+
+func (c *evpClient) resolveRoute() (evpRouteMode, string) {
+	c.routeMu.RLock()
+	mode, localBase := c.routeMode, c.localBase
+	c.routeMu.RUnlock()
+	if mode != evpRouteUnknown {
+		return mode, localBase
+	}
+
+	c.discoveryOnce.Do(c.discoverLocalRoute)
+	c.routeMu.RLock()
+	defer c.routeMu.RUnlock()
+	return c.routeMode, c.localBase
+}
+
+func (c *evpClient) discoverLocalRoute() {
+	selected := ""
+	if c.httpClient != nil && c.agentURL != nil {
+		u := *c.agentURL
+		u.Path = joinEVPPath("", "/info")
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u.String(), nil)
+		if err == nil {
+			resp, doErr := c.httpClient.Do(req)
+			if doErr == nil {
+				defer resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					var info struct {
+						Endpoints []string `json:"endpoints"`
+					}
+					if decodeErr := c.jsonConfig.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&info); decodeErr == nil {
+						selected = selectEVPProxyPath(info.Endpoints)
+					}
+				}
+			}
+		}
+	}
+
+	c.routeMu.Lock()
+	defer c.routeMu.Unlock()
+	if selected != "" {
+		c.routeMode = evpRouteLocal
+		c.localBase = selected
+	} else if c.canUseDirectLocked() {
+		c.routeMode = evpRouteDirect
+	} else {
+		c.routeMode = evpRouteDisabled
+	}
+}
+
+func selectEVPProxyPath(endpoints []string) string {
+	advertised := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		advertised[strings.TrimRight(endpoint, "/")] = struct{}{}
+	}
+	for _, supported := range []string{evpProxyV4Path, evpProxyV2Path} {
+		if _, ok := advertised[supported]; ok {
+			return supported
+		}
+	}
+	return ""
+}
+
+func joinEVPPath(basePath, endpoint string) string {
+	basePath = strings.TrimRight(basePath, "/")
+	endpoint = "/" + strings.TrimLeft(endpoint, "/")
+	return basePath + endpoint
+}
+
+func (c *evpClient) canUseDirect() bool {
+	c.routeMu.RLock()
+	defer c.routeMu.RUnlock()
+	return c.canUseDirectLocked()
+}
+
+func (c *evpClient) canUseDirectLocked() bool {
+	return c.directClient != nil && c.directURL != nil && c.apiKey != "" && c.fingerprint != ""
+}
+
+func (c *evpClient) selectDirect() {
+	c.routeMu.Lock()
+	defer c.routeMu.Unlock()
+	if c.canUseDirectLocked() {
+		c.routeMode = evpRouteDirect
+		c.localBase = ""
+	}
+}
+
+func isDefinitivePreSendError(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr) && (dnsErr.IsNotFound || dnsErr.IsTemporary)
 }
 
 // marshalJSON encodes a value with the EVP client's jsoniter config. Used by the flagevaluation

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -85,6 +85,13 @@ func newEVPClient() *evpClient {
 func newAgentlessEVPClient(settings internalffe.Settings) *evpClient {
 	c := newEVPClientBase()
 	c.directClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
+	// Direct EVP intake has no legitimate reason to redirect. Refusing redirects
+	// prevents DD-API-KEY from being forwarded to a redirect target: Go strips
+	// only built-in sensitive headers on cross-origin redirects, not this custom
+	// credential header.
+	c.directClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	c.apiKey = settings.APIKey
 	if c.apiKey != "" {
 		c.directURL = buildDirectEVPURL(settings.Site)

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	testAPIKey         = "system-tests-mock-api-key"
-	testAPIFingerprint = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
+	testAPIKey = "system-tests-mock-api-key"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -58,12 +57,6 @@ func configuredAgentlessEVP(local, direct http.RoundTripper) *evpClient {
 	c.routeMode = evpRouteLocal
 	c.localBase = evpProxyV2Path
 	return c
-}
-
-func TestCreateAPIKeyFingerprint(t *testing.T) {
-	if got := createAPIKeyFingerprint(testAPIKey); got != testAPIFingerprint {
-		t.Fatalf("createAPIKeyFingerprint() = %q, want %q", got, testAPIFingerprint)
-	}
 }
 
 func TestSelectEVPProxyPath(t *testing.T) {
@@ -106,9 +99,6 @@ func TestAgentlessEVPDiscoveryAndLocalHeaders(t *testing.T) {
 					eventRequests.Add(1)
 					if got := r.Header.Get(apiKeyHeader); got != "" {
 						t.Errorf("local request carried API key %q", got)
-					}
-					if got := r.Header.Get(apiKeyFingerprintHeader); got != "" {
-						t.Errorf("local request carried fingerprint %q", got)
 					}
 					if got := r.Header.Get(evpSubdomainHeader); got != evpSubdomainValue {
 						t.Errorf("local EVP header = %q, want %q", got, evpSubdomainValue)
@@ -157,9 +147,6 @@ func TestAgentlessEVPDirectCredentialsAndBothSignals(t *testing.T) {
 		if got := r.Header.Get(apiKeyHeader); got != testAPIKey {
 			t.Errorf("direct API key = %q, want configured key", got)
 		}
-		if got := r.Header.Get(apiKeyFingerprintHeader); got != testAPIFingerprint {
-			t.Errorf("direct fingerprint = %q, want %q", got, testAPIFingerprint)
-		}
 		if got := r.Header.Get(evpSubdomainHeader); got != "" {
 			t.Errorf("direct request carried local EVP header %q", got)
 		}
@@ -198,7 +185,7 @@ func TestRemoteConfigEVPRemainsAgentOnly(t *testing.T) {
 		if r.URL.Path != joinEVPPath(evpProxyV2Path, exposureEndpoint) {
 			t.Errorf("unexpected Agent path %q", r.URL.Path)
 		}
-		if r.Header.Get(apiKeyHeader) != "" || r.Header.Get(apiKeyFingerprintHeader) != "" {
+		if r.Header.Get(apiKeyHeader) != "" {
 			t.Error("Remote Configuration Agent request carried direct credentials")
 		}
 		w.WriteHeader(http.StatusAccepted)

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -1,0 +1,401 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package openfeature
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	internalffe "github.com/DataDog/dd-trace-go/v2/internal/openfeature"
+)
+
+const (
+	testAPIKey         = "system-tests-mock-api-key"
+	testAPIFingerprint = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(&emptyReader{}),
+	}
+}
+
+type emptyReader struct{}
+
+func (*emptyReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+func configuredAgentlessEVP(local, direct http.RoundTripper) *evpClient {
+	c := newAgentlessEVPClient(internalffe.Settings{
+		Source: internalffe.SourceAgentless,
+		Site:   "mock-intake.invalid",
+		APIKey: testAPIKey,
+	})
+	c.httpClient = &http.Client{Transport: local}
+	c.directClient = &http.Client{Transport: direct}
+	c.agentURL = &url.URL{Scheme: "http", Host: "local.invalid"}
+	c.directURL = &url.URL{Scheme: "https", Host: "event-platform-intake.mock-intake.invalid"}
+	c.routeMode = evpRouteLocal
+	c.localBase = evpProxyV2Path
+	return c
+}
+
+func TestCreateAPIKeyFingerprint(t *testing.T) {
+	if got := createAPIKeyFingerprint(testAPIKey); got != testAPIFingerprint {
+		t.Fatalf("createAPIKeyFingerprint() = %q, want %q", got, testAPIFingerprint)
+	}
+}
+
+func TestSelectEVPProxyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoints []string
+		want      string
+	}{
+		{name: "v4 preferred", endpoints: []string{"/evp_proxy/v2/", "/evp_proxy/v4/"}, want: evpProxyV4Path},
+		{name: "v2 fallback", endpoints: []string{"/v0.4/traces", "/evp_proxy/v2/"}, want: evpProxyV2Path},
+		{name: "unsupported", endpoints: []string{"/v0.4/traces"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectEVPProxyPath(tt.endpoints); got != tt.want {
+				t.Fatalf("selectEVPProxyPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentlessEVPDiscoveryAndLocalHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		endpoints string
+		wantBase  string
+	}{
+		{name: "v4", endpoints: `{"endpoints":["/evp_proxy/v2/","/evp_proxy/v4/"]}`, wantBase: evpProxyV4Path},
+		{name: "v2", endpoints: `{"endpoints":["/evp_proxy/v2/"]}`, wantBase: evpProxyV2Path},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var infoRequests atomic.Int64
+			var eventRequests atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/info":
+					infoRequests.Add(1)
+					_, _ = io.WriteString(w, tc.endpoints)
+				case joinEVPPath(tc.wantBase, exposureEndpoint):
+					eventRequests.Add(1)
+					if got := r.Header.Get(apiKeyHeader); got != "" {
+						t.Errorf("local request carried API key %q", got)
+					}
+					if got := r.Header.Get(apiKeyFingerprintHeader); got != "" {
+						t.Errorf("local request carried fingerprint %q", got)
+					}
+					if got := r.Header.Get(evpSubdomainHeader); got != evpSubdomainValue {
+						t.Errorf("local EVP header = %q, want %q", got, evpSubdomainValue)
+					}
+					w.WriteHeader(http.StatusAccepted)
+				default:
+					t.Errorf("unexpected request path %q", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			agentURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := newAgentlessEVPClient(internalffe.Settings{Source: internalffe.SourceAgentless})
+			client.agentURL = agentURL
+			client.httpClient = server.Client()
+
+			if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err != nil {
+				t.Fatal(err)
+			}
+			if infoRequests.Load() != 1 || eventRequests.Load() != 1 {
+				t.Fatalf("requests: info=%d event=%d, want 1 each", infoRequests.Load(), eventRequests.Load())
+			}
+		})
+	}
+}
+
+func TestAgentlessEVPDirectCredentialsAndBothSignals(t *testing.T) {
+	local := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/info" {
+			t.Errorf("unexpected local path %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"endpoints":[]}`)
+	}))
+	defer local.Close()
+
+	var mu sync.Mutex
+	var paths []string
+	direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if got := r.Header.Get(apiKeyHeader); got != testAPIKey {
+			t.Errorf("direct API key = %q, want configured key", got)
+		}
+		if got := r.Header.Get(apiKeyFingerprintHeader); got != testAPIFingerprint {
+			t.Errorf("direct fingerprint = %q, want %q", got, testAPIFingerprint)
+		}
+		if got := r.Header.Get(evpSubdomainHeader); got != "" {
+			t.Errorf("direct request carried local EVP header %q", got)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer direct.Close()
+
+	localURL, _ := url.Parse(local.URL)
+	directURL, _ := url.Parse(direct.URL)
+	client := newAgentlessEVPClient(internalffe.Settings{
+		Source: internalffe.SourceAgentless,
+		Site:   "mock-intake.invalid",
+		APIKey: testAPIKey,
+	})
+	client.agentURL = localURL
+	client.httpClient = local.Client()
+	client.directURL = directURL
+	client.directClient = direct.Client()
+
+	for _, endpoint := range []string{exposureEndpoint, flagEvalLoggingEndpoint} {
+		if err := client.postRaw(endpoint, "test", []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 2 || paths[0] != exposureEndpoint || paths[1] != flagEvalLoggingEndpoint {
+		t.Fatalf("direct paths = %v", paths)
+	}
+}
+
+func TestRemoteConfigEVPRemainsAgentOnly(t *testing.T) {
+	var requests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != joinEVPPath(evpProxyV2Path, exposureEndpoint) {
+			t.Errorf("unexpected Agent path %q", r.URL.Path)
+		}
+		if r.Header.Get(apiKeyHeader) != "" || r.Header.Get(apiKeyFingerprintHeader) != "" {
+			t.Error("Remote Configuration Agent request carried direct credentials")
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	agentURL, _ := url.Parse(server.URL)
+	client := newEVPClient()
+	client.agentURL = agentURL
+	client.httpClient = server.Client()
+	if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("Agent requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestAgentlessEVPFallbackFailureMatrix(t *testing.T) {
+	t.Run("definitive connect failure replays current batch direct", func(t *testing.T) {
+		var localRequests, directRequests atomic.Int64
+		client := configuredAgentlessEVP(
+			roundTripFunc(func(*http.Request) (*http.Response, error) {
+				localRequests.Add(1)
+				return nil, syscall.ECONNREFUSED
+			}),
+			roundTripFunc(func(*http.Request) (*http.Response, error) {
+				directRequests.Add(1)
+				return newResponse(http.StatusAccepted), nil
+			}),
+		)
+		if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+		if localRequests.Load() != 1 || directRequests.Load() != 1 {
+			t.Fatalf("requests: local=%d direct=%d, want 1 each", localRequests.Load(), directRequests.Load())
+		}
+	})
+
+	t.Run("403 404 and 405 replay current batch direct", func(t *testing.T) {
+		for _, status := range []int{http.StatusForbidden, http.StatusNotFound, http.StatusMethodNotAllowed} {
+			t.Run(http.StatusText(status), func(t *testing.T) {
+				var localRequests, directRequests atomic.Int64
+				client := configuredAgentlessEVP(
+					roundTripFunc(func(*http.Request) (*http.Response, error) {
+						localRequests.Add(1)
+						return newResponse(status), nil
+					}),
+					roundTripFunc(func(*http.Request) (*http.Response, error) {
+						directRequests.Add(1)
+						return newResponse(http.StatusAccepted), nil
+					}),
+				)
+				if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err != nil {
+					t.Fatal(err)
+				}
+				if localRequests.Load() != 1 || directRequests.Load() != 1 {
+					t.Fatalf("requests: local=%d direct=%d, want 1 each", localRequests.Load(), directRequests.Load())
+				}
+			})
+		}
+	})
+
+	t.Run("ambiguous failures never replay current batch", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			err  error
+		}{
+			{name: "connection reset", err: syscall.ECONNRESET},
+			{name: "broken pipe", err: syscall.EPIPE},
+			{name: "timeout", err: context.DeadlineExceeded},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				var localRequests, directRequests atomic.Int64
+				client := configuredAgentlessEVP(
+					roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						localRequests.Add(1)
+						if trace := httptrace.ContextClientTrace(req.Context()); trace != nil && trace.WroteRequest != nil {
+							trace.WroteRequest(httptrace.WroteRequestInfo{})
+						}
+						return nil, tc.err
+					}),
+					roundTripFunc(func(*http.Request) (*http.Response, error) {
+						directRequests.Add(1)
+						return newResponse(http.StatusAccepted), nil
+					}),
+				)
+				if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{"batch":1}`)); err == nil {
+					t.Fatal("ambiguous local failure unexpectedly succeeded")
+				}
+				if directRequests.Load() != 0 {
+					t.Fatalf("current ambiguous batch was replayed direct %d times", directRequests.Load())
+				}
+				if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{"batch":2}`)); err != nil {
+					t.Fatal(err)
+				}
+				if localRequests.Load() != 1 || directRequests.Load() != 1 {
+					t.Fatalf("requests after next batch: local=%d direct=%d, want 1 each", localRequests.Load(), directRequests.Load())
+				}
+			})
+		}
+	})
+
+	t.Run("429 and 5xx remain local", func(t *testing.T) {
+		for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+			t.Run(http.StatusText(status), func(t *testing.T) {
+				var localRequests, directRequests atomic.Int64
+				client := configuredAgentlessEVP(
+					roundTripFunc(func(*http.Request) (*http.Response, error) {
+						localRequests.Add(1)
+						return newResponse(status), nil
+					}),
+					roundTripFunc(func(*http.Request) (*http.Response, error) {
+						directRequests.Add(1)
+						return newResponse(http.StatusAccepted), nil
+					}),
+				)
+				for range 2 {
+					if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err == nil {
+						t.Fatalf("status %d unexpectedly succeeded", status)
+					}
+				}
+				if localRequests.Load() != 2 || directRequests.Load() != 0 {
+					t.Fatalf("requests: local=%d direct=%d, want local=2 direct=0", localRequests.Load(), directRequests.Load())
+				}
+			})
+		}
+	})
+}
+
+func TestAgentlessEVPDiscoveryRunsOnceConcurrently(t *testing.T) {
+	var infoRequests, eventRequests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			infoRequests.Add(1)
+			_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2/"]}`)
+			return
+		}
+		eventRequests.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	agentURL, _ := url.Parse(server.URL)
+	client := newAgentlessEVPClient(internalffe.Settings{Source: internalffe.SourceAgentless})
+	client.agentURL = agentURL
+	client.httpClient = server.Client()
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		wg.Go(func() {
+			errs <- client.postRaw(exposureEndpoint, "exposure", []byte(`{}`))
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if infoRequests.Load() != 1 || eventRequests.Load() != goroutines {
+		t.Fatalf("requests: info=%d event=%d, want info=1 event=%d", infoRequests.Load(), eventRequests.Load(), goroutines)
+	}
+}
+
+func TestAgentlessEVPDirectClientUsesEnvironmentProxy(t *testing.T) {
+	client := newAgentlessEVPClient(internalffe.Settings{
+		Source: internalffe.SourceAgentless,
+		Site:   "datadoghq.com",
+		APIKey: testAPIKey,
+	})
+	transport, ok := client.directClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("direct transport type = %T, want *http.Transport", client.directClient.Transport)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("direct transport does not honor HTTP(S)_PROXY and NO_PROXY")
+	}
+}
+
+func TestDefinitivePreSendErrors(t *testing.T) {
+	for _, err := range []error{
+		syscall.ECONNREFUSED,
+		syscall.ENOENT,
+		&url.Error{Err: &net.DNSError{Err: "not found", Name: "missing.invalid", IsNotFound: true}},
+		&url.Error{Err: &net.DNSError{Err: "temporary", Name: "retry.invalid", IsTemporary: true}},
+	} {
+		if !isDefinitivePreSendError(err) {
+			t.Errorf("error %v was not classified as definitive", err)
+		}
+	}
+	for _, err := range []error{syscall.ECONNRESET, syscall.EPIPE, context.DeadlineExceeded, errors.New("unknown")} {
+		if isDefinitivePreSendError(err) {
+			t.Errorf("error %v was classified as definitive", err)
+		}
+	}
+}

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -488,6 +488,53 @@ func TestAgentlessEVPDirectClientUsesEnvironmentProxy(t *testing.T) {
 	}
 }
 
+func TestAgentlessEVPDirectClientDoesNotFollowRedirects(t *testing.T) {
+	for _, status := range []int{
+		http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var redirectTargetRequests atomic.Int64
+			redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				redirectTargetRequests.Add(1)
+				if got := r.Header.Get(apiKeyHeader); got != "" {
+					t.Errorf("redirect target received direct API key %q", got)
+				}
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer redirectTarget.Close()
+
+			redirectingIntake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get(apiKeyHeader); got != testAPIKey {
+					t.Errorf("direct intake API key = %q, want configured key", got)
+				}
+				http.Redirect(w, r, redirectTarget.URL, status)
+			}))
+			defer redirectingIntake.Close()
+
+			client := newAgentlessEVPClient(internalffe.Settings{
+				Source: internalffe.SourceAgentless,
+				Site:   "mock-intake.invalid",
+				APIKey: testAPIKey,
+			})
+			client.directURL, _ = url.Parse(redirectingIntake.URL)
+			client.directClient.Transport = redirectingIntake.Client().Transport
+			client.routeMode = evpRouteDirect
+
+			err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`))
+			var statusErr *evpHTTPStatusError
+			if !errors.As(err, &statusErr) || statusErr.statusCode != status {
+				t.Fatalf("postRaw() error = %v, want HTTP status %d", err, status)
+			}
+			if got := redirectTargetRequests.Load(); got != 0 {
+				t.Fatalf("redirect target received %d request(s), want 0", got)
+			}
+		})
+	}
+}
+
 func TestDefinitivePreSendErrors(t *testing.T) {
 	for _, err := range []error{
 		syscall.ECONNREFUSED,

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/http/httptrace"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -57,6 +58,124 @@ func configuredAgentlessEVP(local, direct http.RoundTripper) *evpClient {
 	c.routeMode = evpRouteLocal
 	c.localBase = evpProxyV2Path
 	return c
+}
+
+func TestBuildDirectEVPURL(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		site     string
+		wantHost string
+	}{
+		{name: "default site", site: "datadoghq.com", wantHost: "event-platform-intake.datadoghq.com"},
+		{name: "custom domain", site: "custom.example", wantHost: "event-platform-intake.custom.example"},
+		{name: "uppercase domain with outer whitespace", site: "  DATADOGHQ.EU\t", wantHost: "event-platform-intake.datadoghq.eu"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := buildDirectEVPURL(tc.site)
+			if u == nil {
+				t.Fatal("buildDirectEVPURL() returned nil")
+			}
+			if u.Scheme != "https" || u.User != nil || u.Host != tc.wantHost || u.Hostname() != tc.wantHost || u.Port() != "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+				t.Fatalf("buildDirectEVPURL() = %#v, want exact HTTPS host %q", u, tc.wantHost)
+			}
+		})
+	}
+}
+
+func TestBuildDirectEVPURLRejectsUnsafeSite(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		site string
+	}{
+		{name: "empty", site: ""},
+		{name: "userinfo", site: "datadoghq.com@evil.example"},
+		{name: "userinfo with password", site: "datadoghq.com:password@evil.example"},
+		{name: "scheme", site: "https://datadoghq.com"},
+		{name: "default port", site: "datadoghq.com:443"},
+		{name: "custom port", site: "datadoghq.com:8443"},
+		{name: "path", site: "datadoghq.com/path"},
+		{name: "query", site: "datadoghq.com?query=value"},
+		{name: "fragment", site: "datadoghq.com#fragment"},
+		{name: "internal whitespace", site: "data doghq.com"},
+		{name: "backslash", site: "datadoghq.com\\evil.example"},
+		{name: "percent-encoded dot", site: "datadoghq.com%2eattacker.example"},
+		{name: "ideographic full stop", site: "datadoghq.com。attacker.example"},
+		{name: "fullwidth full stop", site: "datadoghq.com．attacker.example"},
+		{name: "halfwidth ideographic full stop", site: "datadoghq.com｡attacker.example"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildDirectEVPURL(tc.site); got != nil {
+				t.Fatalf("buildDirectEVPURL(%q) = %s, want nil", tc.site, got)
+			}
+		})
+	}
+}
+
+func TestAgentlessEVPDirectConstructorPreservesExactHostAndCredentials(t *testing.T) {
+	client := newAgentlessEVPClient(internalffe.Settings{
+		Source: internalffe.SourceAgentless,
+		Site:   "  CUSTOM.EXAMPLE  ",
+		APIKey: testAPIKey,
+	})
+	client.agentURL = &url.URL{Scheme: "http", Host: "agent.invalid"}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"endpoints":[]}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	client.directClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Scheme != "https" || req.URL.Host != "event-platform-intake.custom.example" {
+			t.Fatalf("direct request URL = %s, want exact configured HTTPS host", req.URL)
+		}
+		if got := req.Header.Get(apiKeyHeader); got != testAPIKey {
+			t.Fatalf("direct API key = %q, want configured key", got)
+		}
+		return newResponse(http.StatusAccepted), nil
+	})}
+
+	if err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentlessEVPUnsafeSiteNeverReachesDirectTransport(t *testing.T) {
+	for _, site := range []string{
+		"datadoghq.com%2eattacker.example",
+		"datadoghq.com。attacker.example",
+		"datadoghq.com．attacker.example",
+		"datadoghq.com｡attacker.example",
+	} {
+		t.Run(site, func(t *testing.T) {
+			var directRequests atomic.Int64
+			client := newAgentlessEVPClient(internalffe.Settings{
+				Source: internalffe.SourceAgentless,
+				Site:   site,
+				APIKey: testAPIKey,
+			})
+			client.agentURL = &url.URL{Scheme: "http", Host: "agent.invalid"}
+			client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"endpoints":[]}`)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+			client.directClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				directRequests.Add(1)
+				return newResponse(http.StatusAccepted), nil
+			})}
+
+			err := client.postRaw(exposureEndpoint, "exposure", []byte(`{}`))
+			if !errors.Is(err, errNoEVPRoute) {
+				t.Fatalf("postRaw() error = %v, want %v", err, errNoEVPRoute)
+			}
+			if directRequests.Load() != 0 {
+				t.Fatalf("direct transport received %d request(s), want 0", directRequests.Load())
+			}
+		})
+	}
 }
 
 func TestSelectEVPProxyPath(t *testing.T) {

--- a/openfeature/exposure.go
+++ b/openfeature/exposure.go
@@ -24,8 +24,8 @@ const (
 	// Matches the dd-trace-js implementation (1 second)
 	defaultExposureFlushInterval = 1 * time.Second
 
-	// exposureEndpoint is the EVP proxy endpoint for exposure events
-	exposureEndpoint = "/evp_proxy/v2/api/v2/exposures"
+	// exposureEndpoint is the direct EVP intake path for exposure events.
+	exposureEndpoint = "/api/v2/exposures"
 
 	// evpSubdomainHeader is the HTTP header name for EVP subdomain routing
 	evpSubdomainHeader = "X-Datadog-EVP-Subdomain"

--- a/openfeature/flageval_logging.go
+++ b/openfeature/flageval_logging.go
@@ -32,8 +32,8 @@ const (
 	// Dedicated 10 s timer; separate from exposureWriter's 1 s interval.
 	defaultFlagEvalFlushInterval = 10 * time.Second
 
-	// flagEvalLoggingEndpoint is the EVP proxy endpoint for flag evaluation events.
-	flagEvalLoggingEndpoint = "/evp_proxy/v2/api/v2/flagevaluation"
+	// flagEvalLoggingEndpoint is the direct EVP intake path for flag evaluation events.
+	flagEvalLoggingEndpoint = "/api/v2/flagevaluation"
 
 	// Context pruning limits — mirror worker.ts MAX_EVALUATION_CONTEXT_FIELDS / MAX_FIELD_LENGTH
 	// and align with the cross-SDK RFC (see Java DDEvaluator.copyPrunedContext caps).

--- a/openfeature/flageval_logging_test.go
+++ b/openfeature/flageval_logging_test.go
@@ -37,7 +37,7 @@ func mustMarshalJSONMap(t *testing.T, payload any) map[string]any {
 }
 
 func TestFlagEvaluationEndpointUsesTrackName(t *testing.T) {
-	const want = "/evp_proxy/v2/api/v2/flagevaluation"
+	const want = "/api/v2/flagevaluation"
 	if flagEvalLoggingEndpoint != want {
 		t.Fatalf("flagEvalLoggingEndpoint = %q, want %q", flagEvalLoggingEndpoint, want)
 	}
@@ -1231,8 +1231,9 @@ func TestStopDrainsAndFlushesQueuedFlagEvaluations(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
-		if r.URL.Path != flagEvalLoggingEndpoint {
-			t.Errorf("unexpected EVP path: got %q, want %q", r.URL.Path, flagEvalLoggingEndpoint)
+		wantPath := joinEVPPath(evpProxyV2Path, flagEvalLoggingEndpoint)
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected EVP path: got %q, want %q", r.URL.Path, wantPath)
 		}
 
 		var payload flagEvalLoggingPayload

--- a/openfeature/integration_test.go
+++ b/openfeature/integration_test.go
@@ -1350,8 +1350,9 @@ func TestEndToEnd_ExposurePayloadStructure(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify request path
-		if r.URL.Path != exposureEndpoint {
-			t.Errorf("unexpected path: expected %s, got %s", exposureEndpoint, r.URL.Path)
+		wantPath := joinEVPPath(evpProxyV2Path, exposureEndpoint)
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: expected %s, got %s", wantPath, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -1529,7 +1530,7 @@ func TestEndToEnd_ExposureFlushInterval(t *testing.T) {
 	var mu sync.Mutex
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == exposureEndpoint {
+		if r.URL.Path == joinEVPPath(evpProxyV2Path, exposureEndpoint) {
 			mu.Lock()
 			flushCount++
 			mu.Unlock()
@@ -1596,7 +1597,7 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 	var mu sync.Mutex
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == exposureEndpoint {
+		if r.URL.Path == joinEVPPath(evpProxyV2Path, exposureEndpoint) {
 			mu.Lock()
 			receivedCount++
 			mu.Unlock()
@@ -1691,7 +1692,7 @@ func TestEndToEnd_ExposureContextAttributes(t *testing.T) {
 	var mu sync.Mutex
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == exposureEndpoint {
+		if r.URL.Path == joinEVPPath(evpProxyV2Path, exposureEndpoint) {
 			var payload exposurePayload
 			if err := json.NewDecoder(r.Body).Decode(&payload); err == nil {
 				mu.Lock()

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -45,7 +45,7 @@ const (
 
 // ProviderConfig contains configuration options for the Datadog OpenFeature provider
 type ProviderConfig struct {
-	// ExposureFlushInterval is the interval at which exposure events are flushed to the agent
+	// ExposureFlushInterval is the interval at which exposure events are flushed through EVP.
 	// Default: 1 second
 	ExposureFlushInterval time.Duration
 

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -148,6 +148,9 @@ func newDatadogProvider(config ProviderConfig) *DatadogProvider {
 
 func newDatadogProviderWithSource(config ProviderConfig, source internalffe.Source) *DatadogProvider {
 	evp := newEVPClient()
+	if source == internalffe.SourceAgentless {
+		evp = newAgentlessEVPClient(internalffe.ResolveSettings(internalconfig.Get()))
+	}
 
 	// Create exposure writer
 	writer := newExposureWriterWithEVP(config, evp)


### PR DESCRIPTION
## Motivation

[FFL-1485](https://linear.app/datadoghq/issue/FFL-1485)

Go agentless Feature Flags must deliver exposure and flagevaluation events when the local Agent EVP proxy is unavailable.

```mermaid
flowchart LR
  SDK["Go agentless Feature Flags"] --> Signals["Exposures + flag evaluations"]
  Signals --> Receiver["Local Agent or sidecar"]
  Receiver -->|"Compatible EVP route"| Intake["Event Platform intake"]
  Receiver -.->|"Unavailable or unsupported"| Gap["No delivery path"]
```

## Changes

```mermaid
flowchart LR
  FirstSend["First event send"] --> Discover["Lazy /info discovery via sync.Once"]
  Discover -->|"v4 advertised"| V4["/evp_proxy/v4"]
  Discover -->|"v2 only"| V2["/evp_proxy/v2"]
  Discover -->|"Failure or no compatible route"| Direct["Direct intake + DD-API-KEY"]
  V4 --> Intake["Event Platform intake"]
  V2 --> Intake
  Direct --> Intake
```

- Use one EVP client for `/api/v2/exposures` and `/api/v2/flagevaluation`.
- Discover Agent EVP support lazily on the first event send and cache the selected route.
- Prefer `/evp_proxy/v4`, then `/evp_proxy/v2`, then authenticated direct intake.
- Validate `DD_SITE` as bounded ASCII DNS labels before constructing the direct intake host.
- Refuse direct-intake redirects before they can forward `DD-API-KEY`.
- Document the Agent address settings used for Agentless EVP discovery and delivery.
- Add proxy-aware direct HTTPS delivery and focused route, header, site-validation, redirect, failure, and concurrency coverage.

## Decisions

- Agent requests send `X-Datadog-EVP-Subdomain`; direct requests send `DD-API-KEY`.
- Direct intake uses `https://event-platform-intake.<site>:443`.
- Direct-intake redirects are returned as errors and never followed.
- HTTP 403/404/405 and definitive pre-send connection failures replay the current batch directly.
- Ambiguous transport failures switch future batches only; HTTP 429 and 5xx remain on the Agent route.
- Direct intake is terminal, and Remote Configuration remains Agent-only.

## Validation

Local SDK validation:

- `go test ./openfeature`
- `go test -race ./openfeature`
- `./bin/golangci-lint run ./openfeature` (0 issues)
- `gofmt` and `git diff --check`

The Go system tests are defined and enabled in [DataDog/system-tests#7589](https://github.com/DataDog/system-tests/pull/7589).

Ran the system-test stack against the locally built Go branch artifact in these scenarios:

- `FEATURE_FLAGGING_AND_EXPERIMENTATION`: exposure and flag-evaluation egress
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT`: exposure and flag-evaluation egress
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS`: exposure and flag-evaluation egress

In each topology, both egress tests completed successfully. They verified the selected route, direct-intake host, response status and API-key header where applicable, aggregate evaluation counts, and zero events on the unused route.
