### PR TITLE
fix(ddtrace/tracer): clear span-context snapshot on ContextWithSpan(ctx, nil)

### DIFF
--- a/ddtrace/tracer/context.go
+++ b/ddtrace/tracer/context.go
@@ -21,10 +21,17 @@ import (
 // some other way" (notably Orchestrion's GLS fallback, which resolves an
 // active span even from context.Background()). Only the former should
 // override an explicit ChildOf option; see StartSpanFromContext.
+// ContextWithSpan(ctx, nil) clears this snapshot too, not just
+// internal.ActiveSpanKey, so detaching from an ambient span also detaches
+// from any snapshot inherited from an ancestor context.
 type activeSpanContextKey struct{}
 
 // ContextWithSpan returns a copy of the given context which includes the span s.
 // If ctx is nil, a new background context is created to avoid panicking.
+// Passing a nil span detaches ctx from any ambient span, including one
+// inherited from an ancestor context, so a subsequent [StartSpanFromContext]
+// starts a new root span — unless the caller also passes an explicit parent
+// (e.g. ChildOf) to that call, which is honored as usual.
 func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 	if ctx == nil {
 		log.Warn("ContextWithSpan: received nil context, falling back to context.Background()")
@@ -53,6 +60,14 @@ func ContextWithSpan(ctx context.Context, s *Span) context.Context {
 		// underlying trace from being finished or flushed; callers must ensure
 		// the parent's trace lifetime exceeds child span creation.
 		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, s.Context())
+	} else if sc, ok := ctx.Value(activeSpanContextKey{}).(*SpanContext); ok && sc != nil {
+		// Shadow a snapshot inherited from an ancestor context, otherwise
+		// StartSpanFromContext would keep re-parenting onto it even though
+		// ActiveSpanKey was just cleared above. Only an ancestor that actually
+		// holds a snapshot needs shadowing: ContextWithSpan(ctx, nil) is on the
+		// hot path whenever the tracer is disabled (StartSpan returns nil), so
+		// paying an allocation to shadow nothing would be wasted on every span.
+		newCtx = context.WithValue(newCtx, activeSpanContextKey{}, (*SpanContext)(nil))
 	}
 	return contextWithPropagatedLLMSpan(newCtx, s)
 }

--- a/ddtrace/tracer/context_test.go
+++ b/ddtrace/tracer/context_test.go
@@ -209,3 +209,102 @@ func TestStartSpanFromNilContext(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(child, ctxSpan)
 }
+
+// TestStartSpanFromContextDetachRegression guards against a regression introduced between
+// v2.9.1-rc.3 and v2.10.0-rc.4: ContextWithSpan(ctx, nil) is the way to detach from an
+// ambient span while preserving ctx's cancellation/deadline. For a while it only cleared
+// internal.ActiveSpanKey and left behind any activeSpanContextKey{} snapshot that a prior
+// StartSpanFromContext call had already written into an ancestor of ctx. StartSpanFromContext
+// consults that snapshot before falling back to SpanFromContext, so a "detached" context kept
+// silently chaining onto the old parent's trace.
+func TestStartSpanFromContextDetachRegression(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	// Start a "parent" span the way a long-lived handler would, and get back a
+	// context carrying it.
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+
+	// Sanity check: without detaching, a child does inherit the parent's trace.
+	child, _ := StartSpanFromContext(parentCtx, "child")
+	defer child.Finish()
+	assert.Equal(t, parent.traceID, child.traceID)
+	assert.Equal(t, parent.spanID, child.parentID)
+
+	// Detach: pass a nil span to keep ctx's cancellation/deadline but drop the
+	// ambient span.
+	detachedCtx := ContextWithSpan(parentCtx, nil)
+
+	// SpanFromContext correctly reports no active span on the detached context.
+	_, ok := SpanFromContext(detachedCtx)
+	assert.False(t, ok, "detached context must not report an active span")
+
+	// StartSpanFromContext must treat detachedCtx as having no parent and start a
+	// fresh root span (new trace, no parentID), not inherit the stale
+	// activeSpanContextKey{} snapshot left behind by the parent's own
+	// StartSpanFromContext call.
+	grandchild, _ := StartSpanFromContext(detachedCtx, "grandchild-should-be-root")
+	defer grandchild.Finish()
+
+	assert.NotEqual(t, parent.traceID, grandchild.traceID,
+		"span started from a detached context must not inherit the old trace ID")
+	assert.Zero(t, grandchild.parentID,
+		"span started from a detached context must not have a parentID")
+}
+
+// TestStartSpanFromContextDetachWithExplicitParent guards the qualifier on
+// ContextWithSpan's root-span promise: detaching only suppresses the ambient
+// parent. A caller that also passes an explicit parent (e.g. ChildOf) to the
+// subsequent StartSpanFromContext call still gets that parent, not a root span.
+func TestStartSpanFromContextDetachWithExplicitParent(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+	detachedCtx := ContextWithSpan(parentCtx, nil)
+
+	explicitParent, _ := StartSpanFromContext(context.Background(), "explicit-parent")
+	defer explicitParent.Finish()
+
+	child, _ := StartSpanFromContext(detachedCtx, "child", ChildOf(explicitParent.Context()))
+	defer child.Finish()
+
+	assert.Equal(t, explicitParent.traceID, child.traceID,
+		"an explicit ChildOf passed alongside a detached context must still be honored")
+	assert.Equal(t, explicitParent.spanID, child.parentID,
+		"an explicit ChildOf passed alongside a detached context must still be honored")
+	assert.NotEqual(t, parent.traceID, child.traceID,
+		"the detached ambient parent must not leak through despite the explicit ChildOf")
+}
+
+// TestContextWithSpanDoubleDetachIdempotent guards the shadow branch added
+// alongside TestStartSpanFromContextDetachRegression: shadowing an
+// already-nil snapshot must be a no-op rather than compounding into a second
+// write, so detaching an already-detached context behaves exactly like
+// detaching it once.
+func TestContextWithSpanDoubleDetachIdempotent(t *testing.T) {
+	_, _, _, stop, err := startTestTracer(t)
+	assert.NoError(t, err)
+	defer stop()
+
+	parent, parentCtx := StartSpanFromContext(context.Background(), "parent")
+	defer parent.Finish()
+
+	onceDetached := ContextWithSpan(parentCtx, nil)
+	twiceDetached := ContextWithSpan(onceDetached, nil)
+
+	_, ok := SpanFromContext(twiceDetached)
+	assert.False(t, ok, "double-detached context must not report an active span")
+
+	grandchild, _ := StartSpanFromContext(twiceDetached, "grandchild-should-be-root")
+	defer grandchild.Finish()
+
+	assert.NotEqual(t, parent.traceID, grandchild.traceID,
+		"span started from a double-detached context must not inherit the old trace ID")
+	assert.Zero(t, grandchild.parentID,
+		"span started from a double-detached context must not have a parentID")
+}


### PR DESCRIPTION
## Summary

Flagged by Codex review on #5265. My restoration of `activeSpanContextKey` there (to fix the ChildOf-precedence regression) only cleared `internal.ActiveSpanKey` when detaching via `ContextWithSpan(ctx, nil)`. It left behind any `activeSpanContextKey{}` snapshot a prior `StartSpanFromContext` call had already written into an ancestor of `ctx`, so `StartSpanFromContext` kept silently re-parenting the "detached" span onto that stale ancestor.

This is the exact class of bug `main`'s #5162 (squashed as `64eb381b7`) fixed. It's not a missing backport from #5265's own commit set — it's a gap in *my own* restoration of `activeSpanContextKey`, introduced after #5265 already merged.

## Fix

Ported #5162's fix verbatim: `ContextWithSpan(ctx, nil)` now shadows an inherited `activeSpanContextKey{}` snapshot with an explicit nil, but only when the ancestor actually holds one, so the hot "tracer disabled" path (`StartSpan` returns nil on every call) doesn't pay an allocation for nothing.

Also ported #5162's three regression tests verbatim (`TestStartSpanFromContextDetachRegression`, `TestStartSpanFromContextDetachWithExplicitParent`, `TestContextWithSpanDoubleDetachIdempotent`), since they exercise exactly this behavior without depending on #5164's later `spanCtx` perf refactor (not needed here).

## On Codex's second finding

Codex also flagged: *"When callers pass a non-nil zero-value or otherwise uninitialized `*Span`, `s.Context()` returns nil and this call panics because `context.WithValue` rejects a nil value."*

This is a false positive. `context.WithValue` only panics on a nil key or nil parent, never on a nil value, per its own stdlib source. Confirmed empirically with a zero-value `*Span` and the existing `TestContextWithSpan` cases, which already cover this exact shape and pass. Not acted on.

## Verification

- Full `ddtrace/tracer` suite green.
- `go vet ./...` and `go build ./...` clean.
- `check_copyright.go` clean.

AI Generated