### PR TITLE
chore(codeowners): change ownership for supported configurations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -90,8 +90,6 @@
 /.github/workflows/config-audit.yml            @DataDog/apm-sdk-capabilities-go
 /ddtrace/tracer/remote_config.go               @DataDog/apm-sdk-capabilities-go
 /ddtrace/tracer/otel_dd_mappings.go            @DataDog/apm-sdk-capabilities-go
-/internal/env/supported_configurations.gen.go  @DataDog/apm-sdk-capabilities-go
-/internal/env/supported_configurations.json    @DataDog/apm-sdk-capabilities-go
 # capabilities - telemetry
 /internal/telemetry/                 @DataDog/apm-sdk-capabilities-go
 /ddtrace/tracer/telemetry.go         @DataDog/apm-sdk-capabilities-go
@@ -109,6 +107,10 @@
 /ddtrace/tracer/propagating_tags.go  @DataDog/apm-sdk-capabilities-go
 # capabilities- OTel integration
 /ddtrace/opentelemetry/              @DataDog/apm-sdk-capabilities-go
+
+# common configuration tooling
+/internal/env/supported_configurations.gen.go  @DataDog/dd-trace-go-guild
+/internal/env/supported_configurations.json    @DataDog/dd-trace-go-guild
 
 # data streams monitoring
 /datastreams/                               @DataDog/data-streams-monitoring


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updated CODEOWNERS to democratize adding new configurations

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

This was originally added in #5001 but recently regressed in #5209

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
