### PR TITLE
refactor(ddtrace/tracer): remove unused agentTraceWriter.wait

### DIFF
--- a/ddtrace/tracer/writer.go
+++ b/ddtrace/tracer/writer.go
@@ -122,8 +122,6 @@ func (h *agentTraceWriter) stop() {
 	h.wg.Wait()
 }
 
-func (h *agentTraceWriter) wait() { h.wg.Wait() }
-
 // newPayload returns a new payload for protocol. hint, when positive,
 // pre-sizes the buffer to the previous flush cycle's actual encoded size,
 // eliminating the doubling ramp-up at the cost of one upfront allocation.


### PR DESCRIPTION
### What does this PR do?

Removes `func (h *agentTraceWriter) wait() { h.wg.Wait() }` from `ddtrace/tracer/writer.go`. It is dead code on this branch.

### Motivation

`wait()` was introduced by 28bcbb121 (`fix(ddtrace/tracer): re-evaluate agent v1.0 support at runtime`, #5167) and survived the revert in 76ef5013b (#5263).

It has never had a caller. At the introducing commit, `git grep '\.wait()'` was already empty — the tests added by that same commit (`trace_protocol_runtime_test.go`) reach for `w.wg.Wait()` directly, and `stop()` does the same rather than routing through the helper. On `release-v2.10.x`, a repo-wide `git grep 'wait()'` matches this one line and nothing else: no call sites, no interface it satisfies, nothing in the two build-tagged files in the package (`time.go`, `spancontext_deadlock_test.go`).

### Do not forward-port

**This removal is release-branch-only.** On `main`, b72f157e7 (`fix(ddtrace/tracer): guard inspectable flush against non-agent trace writers`) added

```go
type flushWaiter interface{ wait() }
```

which `tracertest.go` type-asserts against in the inspectable tracer's flush handler. `agentTraceWriter.wait()` is live on `main`. That commit is not an ancestor of `release-v2.10.x`, which is why the method is orphaned here.

### Not addressed: the `Flush()` synchrony TODO

The pre-existing TODO in `tracer.go` (in the `case done := <-t.flush:` arm) notes that `traceWriter.flush()` is not synchronous for the agent writer. Wiring `wait()` into that path to make `(*tracer).Flush()` a real barrier would be a behaviour change with its own risk profile, and the history shows `wait()` was not added for that purpose. Left as-is; that work belongs in a separate PR against `main`.

### Testing

- `go build ./ddtrace/...`, `go vet ./ddtrace/tracer/` — clean
- `go test ./ddtrace/tracer/ -run 'Writer|Protocol|Flush' -count=1` — pass

No public API surface is touched (unexported method on an unexported type).