### PR TITLE
feat(openfeature): send API key fingerprint with managed UFC requests

### DIFF
--- a/openfeature/agentless_endpoint.go
+++ b/openfeature/agentless_endpoint.go
@@ -37,7 +37,7 @@ type agentlessEndpoint struct {
 	// url is the full request URL. SENSITIVE: may embed credentials; never log.
 	url string
 	// managed reports whether this is the Datadog-hosted endpoint, the only
-	// one that receives the DD-API-KEY header.
+	// one that receives API-key credential headers.
 	managed bool
 }
 
@@ -45,7 +45,7 @@ type agentlessEndpoint struct {
 // baseURL is blank, it derives the managed Datadog-hosted endpoint from site
 // and requires apiKey. When baseURL is set, it is used verbatim (with the
 // canonical path appended only if the URL has no path of its own) and the
-// endpoint never receives the API key.
+// endpoint never receives API-key credentials.
 func buildAgentlessEndpoint(baseURL, site, env, apiKey string) (agentlessEndpoint, error) {
 	if strings.TrimSpace(baseURL) != "" {
 		return buildCustomAgentlessEndpoint(baseURL)

--- a/openfeature/agentless_source.go
+++ b/openfeature/agentless_source.go
@@ -52,12 +52,13 @@ var errResponseTooLarge = errors.New("response exceeds maximum size")
 type agentlessSource struct {
 	// endpoint is the full request URL. SENSITIVE: may embed credentials; never log.
 	endpoint string
-	// apiKey is sent as DD-API-KEY; empty unless endpoint is the managed one.
-	apiKey         string
-	pollInterval   time.Duration
-	requestTimeout time.Duration
-	httpClient     *http.Client
-	apply          func(*universalFlagsConfiguration)
+	// API-key credentials are sent only to the managed endpoint.
+	apiKey            string
+	apiKeyFingerprint string
+	pollInterval      time.Duration
+	requestTimeout    time.Duration
+	httpClient        *http.Client
+	apply             func(*universalFlagsConfiguration)
 	// retryDelay is overridden by tests to skip real waiting.
 	retryDelay func(attempt int) time.Duration
 
@@ -78,15 +79,18 @@ func newAgentlessSource(settings internalffe.Settings, apply func(*universalFlag
 	}
 
 	apiKey := ""
+	apiKeyFingerprint := ""
 	if endpoint.managed {
 		apiKey = settings.APIKey
+		apiKeyFingerprint = createAPIKeyFingerprint(apiKey)
 	}
 
 	s := &agentlessSource{
-		endpoint:       endpoint.url,
-		apiKey:         apiKey,
-		pollInterval:   settings.PollInterval,
-		requestTimeout: settings.RequestTimeout,
+		endpoint:          endpoint.url,
+		apiKey:            apiKey,
+		apiKeyFingerprint: apiKeyFingerprint,
+		pollInterval:      settings.PollInterval,
+		requestTimeout:    settings.RequestTimeout,
 		// We build our own transport rather than use http.DefaultTransport so
 		// these polls stay out of our own HTTP instrumentation and can never
 		// recurse through it (see internal/civisibility/utils/net/http.go).
@@ -97,9 +101,9 @@ func newAgentlessSource(settings internalffe.Settings, apply func(*universalFlag
 		doneCh:     make(chan struct{}),
 	}
 	// A fixed configuration endpoint has no legitimate reason to redirect.
-	// Refusing to follow redirects avoids forwarding DD-API-KEY to a
+	// Refusing to follow redirects avoids forwarding API-key credentials to a
 	// different host: Go's client only strips Authorization/Cookie headers
-	// on a cross-origin redirect, not our custom DD-API-KEY header.
+	// on a cross-origin redirect, not our custom headers.
 	s.httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
@@ -240,6 +244,7 @@ func (s *agentlessSource) pollOnce() (pollOutcome, time.Duration) {
 	}
 	if s.apiKey != "" {
 		req.Header.Set("DD-API-KEY", s.apiKey)
+		req.Header.Set(apiKeyFingerprintHeader, s.apiKeyFingerprint)
 	}
 
 	resp, err := s.httpClient.Do(req)

--- a/openfeature/agentless_source_httptest_test.go
+++ b/openfeature/agentless_source_httptest_test.go
@@ -54,6 +54,7 @@ type fakeUFCBackend struct {
 	maxInFlight     int
 	lastIfNoneMatch string
 	lastAuthPresent bool
+	lastFingerprint string
 }
 
 func newFakeUFCBackend(t *testing.T) *fakeUFCBackend {
@@ -76,6 +77,12 @@ func (b *fakeUFCBackend) status() (requestsTotal, maxInFlight int, lastIfNoneMat
 	return b.requestsTotal, b.maxInFlight, b.lastIfNoneMatch, b.lastAuthPresent
 }
 
+func (b *fakeUFCBackend) apiKeyFingerprint() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.lastFingerprint
+}
+
 func (b *fakeUFCBackend) handle(w http.ResponseWriter, r *http.Request) {
 	b.mu.Lock()
 	b.requestsTotal++
@@ -85,6 +92,7 @@ func (b *fakeUFCBackend) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	b.lastIfNoneMatch = r.Header.Get("If-None-Match")
 	b.lastAuthPresent = r.Header.Get("DD-API-KEY") != ""
+	b.lastFingerprint = r.Header.Get(apiKeyFingerprintHeader)
 	response := b.responses[0]
 	if len(b.responses) > 1 {
 		b.responses = b.responses[1:]
@@ -411,6 +419,9 @@ func TestAgentlessSource_DoesNotFollowRedirects(t *testing.T) {
 		if r.Header.Get("DD-API-KEY") != "" {
 			t.Error("the redirect target must never receive DD-API-KEY")
 		}
+		if r.Header.Get(apiKeyFingerprintHeader) != "" {
+			t.Error("the redirect target must never receive DD-API-KEY-FINGERPRINT")
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer redirectTarget.Close()
@@ -460,7 +471,7 @@ func TestSanitizeTransportError_DoesNotLeakSecrets(t *testing.T) {
 	assert.Equal(t, "connection refused", got)
 }
 
-func TestAgentlessSource_APIKeyOnlySentToManagedEndpoint(t *testing.T) {
+func TestAgentlessSource_CredentialsOnlySentToManagedEndpoint(t *testing.T) {
 	backend := newFakeUFCBackend(t)
 	backend.setResponses("valid")
 
@@ -472,6 +483,7 @@ func TestAgentlessSource_APIKeyOnlySentToManagedEndpoint(t *testing.T) {
 	}, func(*universalFlagsConfiguration) {})
 	require.NoError(t, err)
 	assert.Empty(t, src.apiKey, "a custom endpoint must never receive the API key")
+	assert.Empty(t, src.apiKeyFingerprint, "a custom endpoint must never derive an API key fingerprint")
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -480,8 +492,47 @@ func TestAgentlessSource_APIKeyOnlySentToManagedEndpoint(t *testing.T) {
 	})
 	src.start()
 
+	require.Eventually(t, func() bool {
+		requests, _, _, _ := backend.status()
+		return requests >= 1
+	}, 2*time.Second, time.Millisecond)
 	_, _, _, lastAuthPresent := backend.status()
 	assert.False(t, lastAuthPresent)
+	assert.Empty(t, backend.apiKeyFingerprint())
+}
+
+func TestAgentlessSource_ManagedEndpointCredentials(t *testing.T) {
+	const (
+		apiKey      = "system-tests-mock-api-key"
+		fingerprint = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
+	)
+
+	backend := newFakeUFCBackend(t)
+	src, err := newAgentlessSource(internalffe.Settings{
+		Site:           "datadoghq.com",
+		APIKey:         apiKey,
+		PollInterval:   time.Hour,
+		RequestTimeout: 2 * time.Second,
+	}, func(*universalFlagsConfiguration) {})
+	require.NoError(t, err)
+	assert.Equal(t, apiKey, src.apiKey)
+	assert.Equal(t, fingerprint, src.apiKeyFingerprint)
+
+	// Keep the managed-endpoint credentials while directing this test request
+	// to the local capture server.
+	src.endpoint = backend.server.URL
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		src.Stop(ctx)
+	})
+	src.start()
+
+	require.Eventually(t, func() bool {
+		requests, _, _, authenticated := backend.status()
+		return requests >= 1 && authenticated
+	}, 2*time.Second, time.Millisecond)
+	assert.Equal(t, fingerprint, backend.apiKeyFingerprint())
 }
 
 func TestAgentlessSource_Headers(t *testing.T) {

--- a/openfeature/api_key_fingerprint.go
+++ b/openfeature/api_key_fingerprint.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package openfeature
+
+import (
+	"crypto/sha256"
+	"math/big"
+)
+
+const (
+	apiKeyFingerprintPrefix = "rijn_"
+	sha256Base62Length      = 43
+	base62Alphabet          = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+// createAPIKeyFingerprint returns the canonical non-secret identifier for an
+// API key. SHA-256 is required for cross-SDK compatibility, not password
+// storage or any other security decision.
+func createAPIKeyFingerprint(apiKey string) string {
+	digest := sha256.Sum256([]byte(apiKey))
+	value := new(big.Int).SetBytes(digest[:])
+	radix := big.NewInt(62)
+	remainder := new(big.Int)
+	encoded := make([]byte, 0, sha256Base62Length)
+	for value.Sign() > 0 {
+		value.QuoRem(value, radix, remainder)
+		encoded = append(encoded, base62Alphabet[remainder.Int64()])
+	}
+	if len(encoded) == 0 {
+		encoded = append(encoded, base62Alphabet[0])
+	}
+	for len(encoded) < sha256Base62Length {
+		encoded = append(encoded, base62Alphabet[0])
+	}
+	for left, right := 0, len(encoded)-1; left < right; left, right = left+1, right-1 {
+		encoded[left], encoded[right] = encoded[right], encoded[left]
+	}
+	return apiKeyFingerprintPrefix + string(encoded)
+}

--- a/openfeature/api_key_fingerprint.go
+++ b/openfeature/api_key_fingerprint.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	apiKeyFingerprintHeader = "DD-API-KEY-FINGERPRINT"
 	apiKeyFingerprintPrefix = "rijn_"
 	sha256Base62Length      = 43
 	base62Alphabet          = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/openfeature/api_key_fingerprint_test.go
+++ b/openfeature/api_key_fingerprint_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+package openfeature
+
+import "testing"
+
+func TestCreateAPIKeyFingerprintMatchesCanonicalVectors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		apiKey string
+		want   string
+	}{
+		{name: "empty", apiKey: "", want: "rijn_RZwTDmWjELXeEmMEb0eIIegKayGGUPNsuJweEPhlXi5"},
+		{name: "leading zero padding", apiKey: "padding-171", want: "rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D"},
+		{name: "unicode", apiKey: "!@#$%^𐍈한€हИ£", want: "rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K"},
+		{name: "ascii", apiKey: "secret", want: "rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := createAPIKeyFingerprint(test.apiKey)
+			if got != test.want {
+				t.Fatalf("createAPIKeyFingerprint(%q) = %q, want %q", test.apiKey, got, test.want)
+			}
+			if len(got) != 48 {
+				t.Fatalf("len(createAPIKeyFingerprint(%q)) = %d, want 48", test.apiKey, len(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Managed agentless UFC configuration polls authenticate with `DD-API-KEY` and require the canonical non-secret API-key fingerprint used across Feature Flagging SDKs.

## Changes

- Add the canonical `rijn_` SHA-256/base62 fingerprint helper.
- Preserve fixed-width 43-character base62 encoding, including leading-zero padding.
- Attach `DD-API-KEY-FINGERPRINT` alongside `DD-API-KEY` only on managed UFC configuration requests.
- Keep custom configuration endpoints and redirect targets free of both API-key credential headers.
- Lock the algorithm with empty, padding, Unicode, and ASCII cross-SDK golden vectors.

## Decisions

- Use SHA-256 strictly for a non-secret compatibility identifier, not password storage or a security decision.
- Compute the fingerprint once when constructing the managed agentless source.
- Never derive or forward a fingerprint for a custom endpoint.

## Validation

- Focused canonical-vector, managed-header, custom-endpoint absence, and redirect absence tests passed.
- `go test ./openfeature` passed.
