### PR TITLE
refactor(contrib/database/sql): prepare OpenTelemetry semantics

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/DataDog/dd-trace-go/contrib/database/sql/v2/internal"
+
 	"github.com/DataDog/dd-trace-go/v2/appsec/events"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -244,9 +246,10 @@ func (tc *TracedConn) ResetSession(ctx context.Context) error {
 
 // traceParams stores all information related to tracing the driver.Conn
 type traceParams struct {
-	cfg        *config
-	driverName string
-	meta       map[string]string
+	cfg            *config
+	driverName     string
+	connectionInfo internal.ConnectionInfo
+	datadogTags    map[string]string
 }
 
 type contextKey int
@@ -295,7 +298,7 @@ func (tc *TracedConn) injectComments(ctx context.Context, query string, mode tra
 		spanCtx = span.Context()
 	}
 
-	carrier := tracer.SQLCommentCarrier{Query: query, Mode: mode, DBServiceName: tc.cfg.serviceName, PeerDBHostname: tc.meta[ext.TargetHost], PeerDBName: tc.meta[ext.DBName], PeerService: tc.providedPeerService(ctx)}
+	carrier := tracer.SQLCommentCarrier{Query: query, Mode: mode, DBServiceName: tc.cfg.serviceName, PeerDBHostname: tc.connectionInfo.Host, PeerDBName: tc.connectionInfo.Namespace, PeerService: tc.providedPeerService(ctx)}
 	if err := carrier.Inject(spanCtx); err != nil {
 		// this should never happen
 		instr.Logger().Warn("contrib/database/sql: failed to inject query comments: %s", err.Error())
@@ -361,7 +364,7 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 
 	span.SetTag("sql.query_type", string(qtype))
 	span.SetTag(ext.ResourceName, resource)
-	for k, v := range tp.meta {
+	for k, v := range tp.datadogTags {
 		span.SetTag(k, v)
 	}
 	if meta, ok := ctx.Value(spanTagsKey).(map[string]string); ok {

--- a/contrib/database/sql/internal/dsn.go
+++ b/contrib/database/sql/internal/dsn.go
@@ -23,65 +23,82 @@ func init() {
 	instr = instrumentation.Load(instrumentation.PackageDatabaseSQL)
 }
 
-// ParseDSN parses various supported DSN types into a map of key/value pairs which can be used as valid tags.
-func ParseDSN(driverName, dsn string) (meta map[string]string, err error) {
-	meta = make(map[string]string)
-	switch driverName {
-	case "mysql":
-		meta, err = parseMySQLDSN(dsn)
-		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for mysql: %v", sanitizeError(err))
-			return
-		}
-	case "postgres", "pgx":
-		meta, err = parsePostgresDSN(dsn)
-		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for postgres: %v", sanitizeError(err))
-			return
-		}
-	case "sqlserver":
-		meta, err = parseSQLServerDSN(dsn)
-		if err != nil {
-			instr.Logger().Debug("Error parsing DSN for sqlserver: %v", sanitizeError(err))
-			return
-		}
-	default:
-		// Try to parse the DSN and see if the scheme contains a known driver name.
-		u, e := parseSafe(dsn)
-		if e != nil {
-			// dsn is not a valid URL, so just ignore
-			instr.Logger().Debug("Error parsing driver name from DSN: %v", e)
-			return
-		}
-		if driverName != u.Scheme {
-			// In some cases the driver is registered under a non-official name.
-			// For example, "Test" may be the registered name with a DSN of "postgres://postgres:postgres@127.0.0.1:5432/fakepreparedb"
-			// for the purposes of testing/mocking.
-			// In these cases, we try to parse the DSN based upon the DSN itself, instead of the registered driver name
-			return ParseDSN(u.Scheme, dsn)
-		}
-	}
-	return reduceKeys(meta), nil
+// ConnectionInfo contains non-sensitive connection facts parsed from a DSN.
+type ConnectionInfo struct {
+	System          string
+	User            string
+	ApplicationName string
+	Namespace       string
+	Host            string
+	Port            string
+	InstanceName    string
 }
 
-// reduceKeys takes a map containing parsed DSN information and returns a new
-// map containing only the keys relevant as tracing tags, if any.
-func reduceKeys(meta map[string]string) map[string]string {
-	var keysOfInterest = map[string]string{
-		"user":                             ext.DBUser,
-		"application_name":                 ext.DBApplication,
-		"dbname":                           ext.DBName,
-		"host":                             ext.TargetHost,
-		"port":                             ext.TargetPort,
-		ext.MicrosoftSQLServerInstanceName: ext.MicrosoftSQLServerInstanceName,
+// DatadogTags returns connection facts using Datadog span tag names.
+func (c ConnectionInfo) DatadogTags() map[string]string {
+	values := map[string]string{
+		ext.DBUser:                         c.User,
+		ext.DBApplication:                  c.ApplicationName,
+		ext.DBName:                         c.Namespace,
+		ext.TargetHost:                     c.Host,
+		ext.TargetPort:                     c.Port,
+		ext.MicrosoftSQLServerInstanceName: c.InstanceName,
 	}
-	m := make(map[string]string)
-	for k, v := range meta {
-		if nk, ok := keysOfInterest[k]; ok {
-			m[nk] = v
+	tags := make(map[string]string, len(values))
+	for key, value := range values {
+		if value != "" {
+			tags[key] = value
 		}
 	}
-	return m
+	return tags
+}
+
+// ParseDSN parses supported DSN forms into non-sensitive connection facts.
+func ParseDSN(driverName, dsn string) (ConnectionInfo, error) {
+	var (
+		meta   map[string]string
+		err    error
+		system string
+	)
+	switch driverName {
+	case "mysql":
+		system = "mysql"
+		meta, err = parseMySQLDSN(dsn)
+	case "postgres", "postgresql", "pgx":
+		system = "postgresql"
+		meta, err = parsePostgresDSN(dsn)
+	case "sqlserver", "mssql", "azuresql":
+		system = "sqlserver"
+		meta, err = parseSQLServerDSN(dsn)
+	default:
+		// Driver aliases can still expose a recognized product through a URL DSN.
+		u, parseErr := parseSafe(dsn)
+		if parseErr != nil {
+			instr.Logger().Debug("Error parsing driver name from DSN: %v", parseErr)
+			return ConnectionInfo{}, nil
+		}
+		if driverName != u.Scheme {
+			return ParseDSN(u.Scheme, dsn)
+		}
+		return ConnectionInfo{}, nil
+	}
+	if err != nil {
+		instr.Logger().Debug("Error parsing DSN for %s: %v", system, sanitizeError(err))
+		return ConnectionInfo{}, err
+	}
+	return connectionInfo(system, meta), nil
+}
+
+func connectionInfo(system string, meta map[string]string) ConnectionInfo {
+	return ConnectionInfo{
+		System:          system,
+		User:            meta["user"],
+		ApplicationName: meta["application_name"],
+		Namespace:       meta["dbname"],
+		Host:            meta["host"],
+		Port:            meta["port"],
+		InstanceName:    meta[ext.MicrosoftSQLServerInstanceName],
+	}
 }
 
 // parseMySQLDSN parses a mysql-type dsn into a map.

--- a/contrib/database/sql/internal/dsn_test.go
+++ b/contrib/database/sql/internal/dsn_test.go
@@ -20,11 +20,13 @@ func TestParseDSN(t *testing.T) {
 	for _, tt := range []struct {
 		driverName string
 		dsn        string
+		system     string
 		expected   map[string]string
 	}{
 		{
 			driverName: "postgres",
 			dsn:        "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full",
+			system:     "postgresql",
 			expected: map[string]string{
 				ext.DBUser:     "bob",
 				ext.TargetHost: "1.2.3.4",
@@ -35,6 +37,7 @@ func TestParseDSN(t *testing.T) {
 		{
 			driverName: "mysql",
 			dsn:        "bob:secret@tcp(1.2.3.4:5432)/mydb",
+			system:     "mysql",
 			expected: map[string]string{
 				ext.DBName:     "mydb",
 				ext.DBUser:     "bob",
@@ -45,6 +48,7 @@ func TestParseDSN(t *testing.T) {
 		{
 			driverName: "postgres",
 			dsn:        "connect_timeout=0 binary_parameters=no password=zMWmQz26GORmgVVKEbEl dbname=dogdatastaging application_name=trace-api port=5433 sslmode=disable host=master-db-master-active.postgres.service.consul user=dog",
+			system:     "postgresql",
 			expected: map[string]string{
 				ext.TargetPort:    "5433",
 				ext.TargetHost:    "master-db-master-active.postgres.service.consul",
@@ -56,6 +60,7 @@ func TestParseDSN(t *testing.T) {
 		{
 			driverName: "sqlserver",
 			dsn:        "sqlserver://bob:secret@1.2.3.4:1433?database=mydb",
+			system:     "sqlserver",
 			expected: map[string]string{
 				ext.DBUser:     "bob",
 				ext.TargetHost: "1.2.3.4",
@@ -66,6 +71,7 @@ func TestParseDSN(t *testing.T) {
 		{
 			driverName: "sqlserver",
 			dsn:        "sqlserver://alice:secret@localhost/SQLExpress?database=mydb",
+			system:     "sqlserver",
 			expected: map[string]string{
 				ext.DBUser:                         "alice",
 				ext.TargetHost:                     "localhost",
@@ -74,9 +80,10 @@ func TestParseDSN(t *testing.T) {
 			},
 		},
 	} {
-		m, err := ParseDSN(tt.driverName, tt.dsn)
+		info, err := ParseDSN(tt.driverName, tt.dsn)
 		assert.Equal(nil, err)
-		assert.Equal(tt.expected, m)
+		assert.Equal(tt.system, info.System)
+		assert.Equal(tt.expected, info.DatadogTags())
 	}
 }
 

--- a/contrib/database/sql/option.go
+++ b/contrib/database/sql/option.go
@@ -29,6 +29,7 @@ type config struct {
 	dsn                string
 	ignoreQueryTypes   map[QueryType]struct{}
 	childSpansOnly     bool
+	otelSemantics      bool
 	errCheck           func(err error) bool
 	tags               map[string]interface{}
 	dbmPropagationMode tracer.DBMPropagationMode
@@ -144,6 +145,7 @@ type registerConfig = config
 
 func defaults(cfg *config, driverName string, rc *registerConfig) {
 	cfg.analyticsRate = instr.AnalyticsRate(false)
+	cfg.otelSemantics = instr.OTelSemanticsEnabled()
 	mode := env.Get("DD_DBM_PROPAGATION_MODE")
 	if mode == "" {
 		mode = env.Get("DD_TRACE_SQL_COMMENT_INJECTION_MODE")

--- a/contrib/database/sql/sql.go
+++ b/contrib/database/sql/sql.go
@@ -171,7 +171,8 @@ func (t *tracedConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		cfg:        t.cfg,
 	}
 	if dsn != "" {
-		tp.meta, _ = sqlinternal.ParseDSN(t.driverName, dsn)
+		tp.connectionInfo, _ = sqlinternal.ParseDSN(t.driverName, dsn)
+		tp.datadogTags = tp.connectionInfo.DatadogTags()
 	}
 	start := time.Now()
 	ctx, end := startTraceTask(ctx, string(QueryTypeConnect))

--- a/ddtrace/ext/db.go
+++ b/ddtrace/ext/db.go
@@ -20,6 +20,12 @@ const (
 	DBStatement = "db.statement"
 	// DBSystem indicates the database management system (DBMS) product being used.
 	DBSystem = "db.system"
+	// DBSystemName indicates the database management system product being used under OpenTelemetry semantics.
+	DBSystemName = "db.system.name"
+	// DBNamespace indicates the database name under OpenTelemetry semantics.
+	DBNamespace = "db.namespace"
+	// DBResponseStatusCode indicates a database response code under OpenTelemetry semantics.
+	DBResponseStatusCode = "db.response.status_code"
 	// DBClientConnectionPoolName indicates the name of the database connection pool,
 	// unique within the instrumented application.
 	DBClientConnectionPoolName = "db.client.connection.pool.name"
@@ -31,6 +37,10 @@ const (
 	DBSystemMySQL              = "mysql"
 	DBSystemPostgreSQL         = "postgresql"
 	DBSystemMicrosoftSQLServer = "mssql"
+	// DBSystemNameMicrosoftSQLServer is the OpenTelemetry db.system.name value for Microsoft SQL Server.
+	DBSystemNameMicrosoftSQLServer = "microsoft.sql_server"
+	// DBSystemSQLite indicates SQLite.
+	DBSystemSQLite = "sqlite"
 	// DBSystemOtherSQL is used for other SQL databases not listed above.
 	DBSystemOtherSQL      = "other_sql"
 	DBSystemElasticsearch = "elasticsearch"

--- a/ddtrace/opentelemetry/span_test.go
+++ b/ddtrace/opentelemetry/span_test.go
@@ -24,11 +24,13 @@ import (
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	otlpcommon "go.opentelemetry.io/proto/otlp/common/v1"
 	otlptrace "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 )
@@ -93,6 +95,75 @@ func waitForPayload(payloads chan traces) (traces, error) {
 	}
 }
 
+type otlpPayload struct {
+	traces *otlptrace.TracesData
+	err    error
+}
+
+func mockOTLPTracerProvider(t *testing.T, opts ...tracer.StartOption) (*TracerProvider, <-chan otlpPayload, func()) {
+	payloads := make(chan otlpPayload, 1)
+	collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/traces" {
+			err := fmt.Errorf("unexpected OTLP request: %s %s", r.Method, r.URL.Path)
+			payloads <- otlpPayload{err: err}
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			payloads <- otlpPayload{err: err}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var data otlptrace.TracesData
+		if err := proto.Unmarshal(body, &data); err != nil {
+			payloads <- otlpPayload{err: err}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		payloads <- otlpPayload{traces: &data}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector.URL+"/v1/traces")
+
+	tp := NewTracerProvider(opts...)
+	otel.SetTracerProvider(tp)
+	return tp, payloads, func() {
+		if err := tp.Shutdown(); err != nil {
+			t.Fatalf("Tracer Provider shutdown failure: %v", err)
+		}
+		collector.Close()
+	}
+}
+
+func waitForOTLPPayload(payloads <-chan otlpPayload) (*otlptrace.TracesData, error) {
+	select {
+	case payload := <-payloads:
+		return payload.traces, payload.err
+	case <-time.After(10 * time.Second):
+		return nil, errors.New("timed out waiting for OTLP traces")
+	}
+}
+
+func spansFromOTLPPayload(payload *otlptrace.TracesData) []*otlptrace.Span {
+	var spans []*otlptrace.Span
+	for _, resourceSpans := range payload.ResourceSpans {
+		for _, scopeSpans := range resourceSpans.ScopeSpans {
+			spans = append(spans, scopeSpans.Spans...)
+		}
+	}
+	return spans
+}
+
+func findOTLPAttribute(span *otlptrace.Span, key string) (*otlpcommon.AnyValue, bool) {
+	for _, attribute := range span.Attributes {
+		if attribute.Key == key {
+			return attribute.Value, true
+		}
+	}
+	return nil, false
+}
+
 func TestSpanResourceNameDefault(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
@@ -137,16 +208,14 @@ func TestSpanSetName(t *testing.T) {
 }
 
 // TestSpanSetNameUpdatesResourceOtelSemantics verifies that under OTel semantics SetName
-// updates the resource (the OTLP span name) — e.g. otelhttp renames "GET" to "GET /users/{id}".
+// determines the exported OTLP span name, as when otelhttp renames "GET" to "GET /users/{id}".
 func TestSpanSetNameUpdatesResourceOtelSemantics(t *testing.T) {
-	assert := assert.New(t)
 	// The flag is resolved when the provider is created; reload on cleanup so it
 	// doesn't leak (LIFO order runs this after t.Setenv restores the env).
 	t.Cleanup(func() { internalconfig.CreateNew() })
 	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
-	internalconfig.CreateNew()
 
-	_, payloads, cleanup := mockTracerProvider(t)
+	_, payloads, cleanup := mockOTLPTracerProvider(t)
 	tr := otel.Tracer("")
 	defer cleanup()
 
@@ -157,16 +226,11 @@ func TestSpanSetNameUpdatesResourceOtelSemantics(t *testing.T) {
 	sp.End()
 
 	tracer.Flush()
-	traces, err := waitForPayload(payloads)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	p := traces[0]
-	// Resource follows the rename. Under OTel semantics the operation-name logic is
-	// skipped entirely (no remap, no computed default), so the operation name is left
-	// as it was set at Start and the span attributes pass through unchanged.
-	assert.Equal("GET /users/{id}", p[0]["resource"])
-	assert.Equal("GET", p[0]["name"])
+	payload, err := waitForOTLPPayload(payloads)
+	require.NoError(t, err)
+	spans := spansFromOTLPPayload(payload)
+	require.Len(t, spans, 1)
+	assert.Equal(t, "GET /users/{id}", spans[0].Name)
 }
 
 func TestSpanLink(t *testing.T) {
@@ -1016,15 +1080,12 @@ func TestToReservedAttributesOtelSemantics(t *testing.T) {
 // TestRemapStatusCodeOtelSemantics verifies that under OTel semantics the bridge keeps
 // http.response.status_code instead of remapping it to the legacy http.status_code tag.
 func TestRemapStatusCodeOtelSemantics(t *testing.T) {
-	assert := assert.New(t)
-
 	// Reload global config on cleanup so the flag doesn't leak; LIFO order runs this
 	// after t.Setenv restores the env.
 	t.Cleanup(func() { internalconfig.CreateNew() })
 	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
-	internalconfig.CreateNew()
 
-	_, payloads, cleanup := mockTracerProvider(t, tracer.WithEnv("test_env"), tracer.WithService("test_serv"))
+	_, payloads, cleanup := mockOTLPTracerProvider(t, tracer.WithEnv("test_env"), tracer.WithService("test_serv"))
 	tr := otel.Tracer("")
 	defer cleanup()
 
@@ -1034,16 +1095,18 @@ func TestRemapStatusCodeOtelSemantics(t *testing.T) {
 	sp.End()
 
 	tracer.Flush()
-	traces, err := waitForPayload(payloads)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	p := traces[0]
-	meta := fmt.Sprintf("%v", p[0]["meta"])
-	metrics := fmt.Sprintf("%v", p[0]["metrics"])
-	// No legacy string remap; OTel key retained as a numeric tag.
-	assert.NotContains(meta, "http.status_code")
-	assert.Contains(metrics, "http.response.status_code:200")
+	payload, err := waitForOTLPPayload(payloads)
+	require.NoError(t, err)
+	spans := spansFromOTLPPayload(payload)
+	require.Len(t, spans, 1)
+
+	statusCode, found := findOTLPAttribute(spans[0], "http.response.status_code")
+	require.True(t, found)
+	integer, ok := statusCode.Value.(*otlpcommon.AnyValue_IntValue)
+	require.True(t, ok, "http.response.status_code must be an OTLP integer")
+	assert.Equal(t, int64(200), integer.IntValue)
+	_, found = findOTLPAttribute(spans[0], "http.status_code")
+	assert.False(t, found)
 }
 
 // TestSpanEndErrorTypeOtelSemantics verifies that finishing an error-status span under
@@ -1051,16 +1114,13 @@ func TestRemapStatusCodeOtelSemantics(t *testing.T) {
 // error.handling_stack: an instrumentation-set error.type survives, and when none is set
 // no reflect-type value is injected. (The non-semantics path is covered by TestSpanEnd.)
 func TestSpanEndErrorTypeOtelSemantics(t *testing.T) {
-	// finish an error-status span under semantics, optionally with an
-	// instrumentation-set error.type, and return the exported span.
-	run := func(t *testing.T, instrumentationErrorType string) map[string]any {
-		// Reload global config on cleanup so the flag doesn't leak; LIFO order runs this
-		// after t.Setenv restores the env.
+	// Finish an error-status span under semantics, optionally with an
+	// instrumentation-set error.type, and return the exported OTLP span.
+	run := func(t *testing.T, instrumentationErrorType string) *otlptrace.Span {
 		t.Cleanup(func() { internalconfig.CreateNew() })
 		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
-		internalconfig.CreateNew()
 
-		_, payloads, cleanup := mockTracerProvider(t)
+		_, payloads, cleanup := mockOTLPTracerProvider(t)
 		tr := otel.Tracer("")
 		defer cleanup()
 
@@ -1072,30 +1132,30 @@ func TestSpanEndErrorTypeOtelSemantics(t *testing.T) {
 		sp.End()
 
 		tracer.Flush()
-		traces, err := waitForPayload(payloads)
-		if err != nil {
-			t.Fatal(err.Error())
-		}
-		return traces[0][0]
+		payload, err := waitForOTLPPayload(payloads)
+		require.NoError(t, err)
+		spans := spansFromOTLPPayload(payload)
+		require.Len(t, spans, 1)
+		return spans[0]
 	}
 
 	t.Run("preserves instrumentation error.type", func(t *testing.T) {
-		assert := assert.New(t)
 		span := run(t, "*net.OpError")
-		assert.Equal(1.0, span["error"]) // span still flagged errored
-		meta := fmt.Sprintf("%v", span["meta"])
-		assert.Contains(meta, ext.ErrorType+":*net.OpError") // instrumentation value survives
-		assert.NotContains(meta, "*errors.errorString")      // WithError was skipped
-		assert.NotContains(meta, ext.ErrorHandlingStack)     // no DD stack injected
+		assert.Equal(t, otlptrace.Status_STATUS_CODE_ERROR, span.Status.Code)
+		errorType, found := findOTLPAttribute(span, ext.ErrorType)
+		require.True(t, found)
+		assert.Equal(t, "*net.OpError", errorType.GetStringValue())
+		_, found = findOTLPAttribute(span, ext.ErrorHandlingStack)
+		assert.False(t, found)
 	})
 
 	t.Run("injects no error.type when instrumentation sets none", func(t *testing.T) {
-		assert := assert.New(t)
 		span := run(t, "")
-		assert.Equal(1.0, span["error"]) // still errored via the error flag / OTLP status
-		meta := fmt.Sprintf("%v", span["meta"])
-		assert.NotContains(meta, ext.ErrorType) // no reflect-type value injected
-		assert.NotContains(meta, ext.ErrorHandlingStack)
+		assert.Equal(t, otlptrace.Status_STATUS_CODE_ERROR, span.Status.Code)
+		_, found := findOTLPAttribute(span, ext.ErrorType)
+		assert.False(t, found)
+		_, found = findOTLPAttribute(span, ext.ErrorHandlingStack)
+		assert.False(t, found)
 	})
 }
 

--- a/ddtrace/tracer/doc.go
+++ b/ddtrace/tracer/doc.go
@@ -165,6 +165,13 @@
 // or the environment variable DD_TRACE_STATS_ADDITIONAL_TAGS (comma-separated).
 // This feature requires DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED=true.
 //
+// # OpenTelemetry Semantic Conventions
+//
+// DD_TRACE_OTEL_SEMANTICS_ENABLED=true enables OpenTelemetry semantic
+// conventions, forces trace export through OTLP, and overrides
+// DD_TRACE_SPAN_ATTRIBUTE_SCHEMA to v0 and DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED
+// to false.
+//
 // # Trace Protocol
 //
 // Client-side stats computation is independent of the Datadog trace protocol

--- a/ddtrace/tracer/option.go
+++ b/ddtrace/tracer/option.go
@@ -224,7 +224,7 @@ func newConfig(opts ...StartOption) (*config, error) {
 			return c, fmt.Errorf("unable to look up hostname: %s", err.Error())
 		}
 	}
-	namingschema.LoadFromEnv()
+	namingschema.LoadFromConfig(c.internalConfig)
 
 	for _, fn := range opts {
 		if fn == nil {

--- a/ddtrace/tracer/option_test.go
+++ b/ddtrace/tracer/option_test.go
@@ -403,6 +403,43 @@ func TestLoadAgentFeatures(t *testing.T) {
 	})
 }
 
+func TestAgentOptionsUpdateDerivedOTLPTraceURL(t *testing.T) {
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+	tests := []struct {
+		name string
+		opt  StartOption
+		want string
+	}{
+		{
+			name: "WithAgentAddr",
+			opt:  WithAgentAddr("agent.example:8126"),
+			want: "http://agent.example:4318/v1/traces",
+		},
+		{
+			name: "WithAgentURL",
+			opt:  WithAgentURL("https://agent.example:8126"),
+			want: "http://agent.example:4318/v1/traces",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := newTestConfig(tt.opt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.internalConfig.OTLPTraceURL())
+		})
+	}
+}
+
+func TestAgentOptionsPreserveExplicitOTLPTraceURL(t *testing.T) {
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector.example:4317/custom")
+
+	cfg, err := newTestConfig(WithAgentAddr("agent.example:8126"))
+	require.NoError(t, err)
+	assert.Equal(t, "https://collector.example:4317/custom", cfg.internalConfig.OTLPTraceURL())
+}
+
 // clearIntegreationsForTests clears the state of all integrations
 func clearIntegrationsForTests() {
 	for name, state := range contribIntegrations {
@@ -1031,6 +1068,14 @@ func TestTracerOptionsDefaults(t *testing.T) {
 			WithPeerServiceMapping("old2", "new2")(c)
 			assert.Equal(t, c.internalConfig.PeerServiceDefaultsEnabled(), true)
 			assert.Equal(t, c.internalConfig.PeerServiceMappings(), map[string]string{"old": "new", "old2": "new2"})
+		})
+
+		t.Run("OpenTelemetry semantics overrides option", func(t *testing.T) {
+			t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+			c, err := newTestConfig(WithAgentTimeout(2), WithPeerServiceDefaults(true))
+			assert.NoError(t, err)
+			assert.False(t, c.internalConfig.PeerServiceDefaultsEnabled())
+			assert.True(t, c.internalConfig.OTLPExportMode())
 		})
 	})
 

--- a/ddtrace/tracer/spancontext_test.go
+++ b/ddtrace/tracer/spancontext_test.go
@@ -649,6 +649,32 @@ func TestSpanFinishPriority(t *testing.T) {
 	assert.Fail("span not found")
 }
 
+func TestSpanDoesNotDerivePeerServiceWithOTelSemantics(t *testing.T) {
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+	t.Run("defaults remain disabled", func(t *testing.T) {
+		tracer, err := newUnstartedTracer(
+			withNoopInfoHTTPClient(),
+			withNoopStats(),
+			WithPeerServiceDefaults(true),
+		)
+		require.NoError(t, err)
+		assert.False(t, tracer.config.internalConfig.PeerServiceDefaultsEnabled())
+		setGlobalTracer(tracer)
+		t.Cleanup(func() { setGlobalTracer(&NoopTracer{}) })
+
+		span := tracer.StartSpan("HTTP",
+			Tag(ext.SpanKind, ext.SpanKindClient),
+			Tag("server.address", "example.com"),
+			Tag("out.host", "legacy.example.com"),
+		)
+		span.Finish()
+
+		assert.False(t, span.meta.Has(ext.PeerService))
+		assert.False(t, span.meta.Has(keyPeerServiceSource))
+	})
+}
+
 func TestSpanPeerService(t *testing.T) {
 	testCases := []struct {
 		name                        string

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -535,6 +535,7 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 	// and log-to-stdout are selected ahead of OTLP, and those writers do not serialize
 	// native span events, so they must keep events string-tagged.
 	var otlpExportMode bool
+	var supportsOTLPSpanMetrics bool
 	ps := newPrioritySampler()
 	var dfltSampler defaultSampler = ps
 	if c.internalConfig.CIVisibilityEnabled() {
@@ -545,8 +546,10 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 		dfltSampler = newOtelParentBasedAlwaysOnSampler()
 		writer = newOTLPTraceWriter(c)
 		otlpExportMode = true
+		supportsOTLPSpanMetrics = true
 	} else {
 		writer = newAgentTraceWriter(c, ps, statsd)
+		supportsOTLPSpanMetrics = true
 	}
 	rulesSampler := newRulesSampler(c.internalConfig.TraceSamplingRules(), c.internalConfig.SpanSamplingRules(), c.internalConfig.GlobalSampleRate(), c.internalConfig.TraceRateLimitPerSecond())
 	var dataStreamsProcessor *datastreams.Processor
@@ -561,11 +564,17 @@ func newUnstartedTracer(opts ...StartOption) (t *tracer, err error) {
 			c.internalConfig.SetLogDirectory("", telemetry.OriginCalculated)
 		}
 	}
+	useOTLPSpanMetrics := c.internalConfig.OTLPSpanMetricsEnabled()
+	skipStats := c.internalConfig.OTLPExportMode()
+	if c.internalConfig.OTelSemanticsEnabled() {
+		useOTLPSpanMetrics = useOTLPSpanMetrics && supportsOTLPSpanMetrics
+		skipStats = otlpExportMode
+	}
 	var sc statsConcentrator
-	if c.internalConfig.OTLPSpanMetricsEnabled() {
+	if useOTLPSpanMetrics {
 		// OTLP span metrics: SDK computes and exports stats; agent /v0.6/stats path unused.
 		sc = newOTLPMetricsConcentrator(c, statsd)
-	} else if c.internalConfig.OTLPExportMode() {
+	} else if skipStats {
 		sc = &noopConcentrator{}
 	} else {
 		sc = newConcentrator(c, defaultStatsBucketSize, statsd)

--- a/ddtrace/tracer/tracer_test.go
+++ b/ddtrace/tracer/tracer_test.go
@@ -1478,6 +1478,119 @@ func TestOTLPExportMode(t *testing.T) {
 	})
 }
 
+func TestOTLPSpanMetricsUseOTLPSenderWithAgentTraceWriter(t *testing.T) {
+	tr, err := newUnstartedTracer(func(c *config) {
+		c.internalConfig.SetOTLPSpanMetricsEnabled(true, internalconfig.OriginCode)
+	})
+	require.NoError(t, err)
+	defer tr.Stop()
+
+	assert.IsType(t, &agentTraceWriter{}, tr.traceWriter)
+	conc, ok := tr.stats.(*concentrator)
+	require.True(t, ok)
+	assert.IsType(t, &otlpStatsSender{}, conc.sender)
+}
+
+func TestOTLPStatsSelectionUsesEffectiveTraceWriterWithOTelSemantics(t *testing.T) {
+	tests := []struct {
+		name          string
+		spanMetrics   bool
+		configure     func(*config)
+		wantTraceType traceWriter
+	}{
+		{
+			name:          "log writer without span metrics",
+			configure:     func(c *config) { c.internalConfig.SetLogToStdout(true, internalconfig.OriginCode) },
+			wantTraceType: &logTraceWriter{},
+		},
+		{
+			name:          "log writer with span metrics",
+			spanMetrics:   true,
+			configure:     func(c *config) { c.internalConfig.SetLogToStdout(true, internalconfig.OriginCode) },
+			wantTraceType: &logTraceWriter{},
+		},
+		{
+			name:          "CI Visibility writer without span metrics",
+			configure:     func(c *config) { c.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode) },
+			wantTraceType: &ciVisibilityTraceWriter{},
+		},
+		{
+			name:          "CI Visibility writer with span metrics",
+			spanMetrics:   true,
+			configure:     func(c *config) { c.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode) },
+			wantTraceType: &ciVisibilityTraceWriter{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := newUnstartedTracer(func(c *config) {
+				c.internalConfig.SetOTelSemanticsEnabled(true, internalconfig.OriginCode)
+				c.internalConfig.SetOTLPSpanMetricsEnabled(tt.spanMetrics, internalconfig.OriginCode)
+				tt.configure(c)
+			})
+			require.NoError(t, err)
+			defer tr.Stop()
+
+			assert.IsType(t, tt.wantTraceType, tr.traceWriter)
+			conc, ok := tr.stats.(*concentrator)
+			require.True(t, ok, "non-OTLP writers must use the native stats concentrator")
+			assert.IsType(t, &ddStatsSender{}, conc.sender)
+		})
+	}
+}
+
+func TestOTLPStatsSelectionPreservesLegacyConfigurationBehavior(t *testing.T) {
+	tests := []struct {
+		name          string
+		spanMetrics   bool
+		configure     func(*config)
+		wantTraceType traceWriter
+	}{
+		{
+			name:          "log writer without span metrics",
+			configure:     func(c *config) { c.internalConfig.SetLogToStdout(true, internalconfig.OriginCode) },
+			wantTraceType: &logTraceWriter{},
+		},
+		{
+			name:          "log writer with span metrics",
+			spanMetrics:   true,
+			configure:     func(c *config) { c.internalConfig.SetLogToStdout(true, internalconfig.OriginCode) },
+			wantTraceType: &logTraceWriter{},
+		},
+		{
+			name:          "CI Visibility writer without span metrics",
+			configure:     func(c *config) { c.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode) },
+			wantTraceType: &ciVisibilityTraceWriter{},
+		},
+		{
+			name:          "CI Visibility writer with span metrics",
+			spanMetrics:   true,
+			configure:     func(c *config) { c.internalConfig.SetCIVisibilityEnabled(true, internalconfig.OriginCode) },
+			wantTraceType: &ciVisibilityTraceWriter{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, err := newUnstartedTracer(func(c *config) {
+				c.internalConfig.SetOTLPExportMode(true, internalconfig.OriginCode)
+				c.internalConfig.SetOTLPSpanMetricsEnabled(tt.spanMetrics, internalconfig.OriginCode)
+				tt.configure(c)
+			})
+			require.NoError(t, err)
+			defer tr.Stop()
+
+			assert.IsType(t, tt.wantTraceType, tr.traceWriter)
+			if tt.spanMetrics {
+				conc, ok := tr.stats.(*concentrator)
+				require.True(t, ok)
+				assert.IsType(t, &otlpStatsSender{}, conc.sender)
+			} else {
+				assert.IsType(t, &noopConcentrator{}, tr.stats)
+			}
+		})
+	}
+}
+
 func TestOTLPExportModeStatsSkipped(t *testing.T) {
 	srv := newTestOTLPServer()
 	defer srv.Close()

--- a/instrumentation/instrumentation.go
+++ b/instrumentation/instrumentation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/namingschema"
 	"github.com/DataDog/dd-trace-go/v2/internal/normalizer"
@@ -212,6 +213,13 @@ func (i *Instrumentation) AnalyticsRate(defaultGlobal bool) float64 {
 
 func (i *Instrumentation) GlobalAnalyticsRate() float64 {
 	return globalconfig.AnalyticsRate()
+}
+
+// OTelSemanticsEnabled `true` changes observability data to be emitted
+// according to OpenTelemetry semantic conventions. Datadog conventions
+// are used when `false`.
+func (i *Instrumentation) OTelSemanticsEnabled() bool {
+	return internalconfig.Get().OTelSemanticsEnabled()
 }
 
 func (i *Instrumentation) AppSecEnabled() bool {

--- a/instrumentation/instrumentation_test.go
+++ b/instrumentation/instrumentation_test.go
@@ -15,8 +15,17 @@ import (
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/stacktrace"
 )
+
+func TestInstrumentationReportsOTelSemanticsEnabled(t *testing.T) {
+	t.Cleanup(func() { internalconfig.CreateNew() })
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	internalconfig.CreateNew()
+
+	require.True(t, new(Instrumentation).OTelSemanticsEnabled())
+}
 
 func TestInstrumentationStackTrace(t *testing.T) {
 	instr := &Instrumentation{}

--- a/instrumentation/internal/namingschema/namingschema.go
+++ b/instrumentation/internal/namingschema/namingschema.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -41,19 +42,21 @@ func init() {
 
 func LoadFromEnv() {
 	schemaVersionStr := env.Get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA")
-	if v, ok := parseVersionString(schemaVersionStr); ok {
-		setVersion(v)
-	} else {
-		setVersion(VersionV0)
+	if v, ok := parseVersionString(schemaVersionStr); !ok {
 		log.Warn("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=%s is not a valid value, setting to default of v%d", schemaVersionStr, v)
 	}
+	LoadFromConfig(internalconfig.Get())
+}
+
+func LoadFromConfig(cfg *internalconfig.Config) {
+	setVersion(Version(cfg.SpanAttributeSchemaVersion()))
 	// Allow DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=v0 users to disable default integration (contrib AKA v0) service names.
 	// These default service names are always disabled for v1 onwards.
 	removeFakeServiceNames = internal.BoolEnv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", false)
 }
 
 func ReloadConfig() {
-	LoadFromEnv()
+	LoadFromConfig(internalconfig.CreateNew())
 	globalconfig.SetServiceName(env.Get("DD_SERVICE"))
 }
 

--- a/instrumentation/internal/namingschema/namingschema_test.go
+++ b/instrumentation/internal/namingschema/namingschema_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package namingschema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
+func TestReloadConfigSynchronizesNamingSchemaWithEffectiveConfig(t *testing.T) {
+	t.Cleanup(ReloadConfig)
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v0")
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "false")
+
+	assertSchema := func(want Version) {
+		t.Helper()
+		ReloadConfig()
+		assert.Equal(t, want, GetVersion())
+		assert.Equal(t, int(want), internalconfig.Get().SpanAttributeSchemaVersion())
+	}
+
+	assertSchema(VersionV0)
+
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+	assertSchema(VersionV1)
+
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	assertSchema(VersionV0)
+
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "false")
+	assertSchema(VersionV1)
+}
+
+func TestLoadFromEnvPreservesInvalidSchemaWarning(t *testing.T) {
+	t.Cleanup(ReloadConfig)
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "invalid")
+	tp := new(log.RecordLogger)
+	defer log.UseLogger(tp)()
+	internalconfig.CreateNew()
+
+	LoadFromEnv()
+
+	assert.Equal(t, VersionV0, GetVersion())
+	const warning = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=invalid is not a valid value, setting to default of v0"
+	assert.Equal(t, 1, strings.Count(strings.Join(tp.Logs(), "\n"), warning))
+}
+
+func TestLoadFromEnvUsesEffectiveSpanAttributeSchema(t *testing.T) {
+	t.Cleanup(func() {
+		internalconfig.CreateNew()
+		LoadFromEnv()
+	})
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	internalconfig.CreateNew()
+
+	LoadFromEnv()
+
+	assert.Equal(t, VersionV0, GetVersion())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/samplingrules"
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry"
+	telemetrylog "github.com/DataDog/dd-trace-go/v2/internal/telemetry/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 )
 
@@ -216,11 +217,14 @@ type Config struct {
 	otlpExportMetricsMode bool
 	// otlpEndpoint is the resolved OTEL_EXPORTER_OTLP_ENDPOINT base URL; always non-empty.
 	otlpEndpoint string
-	// otelSemanticsEnabled makes OTLP-exported spans match the pure OTel SDK
-	// by omitting Datadog-specific attributes. Set via DD_TRACE_OTEL_SEMANTICS_ENABLED.
+	// otelSemanticsEnabled enables OpenTelemetry semantic conventions and
+	// their required global configuration overrides. Set via DD_TRACE_OTEL_SEMANTICS_ENABLED.
 	otelSemanticsEnabled bool
-	// otlpTraceURL is the OTLP collector endpoint for traces
+	// otlpTraceURL is the OTLP collector endpoint for traces.
 	otlpTraceURL string
+	// otlpTraceURLDerivedFromAgent reports whether otlpTraceURL should follow
+	// programmatic changes to agentURL.
+	otlpTraceURLDerivedFromAgent bool
 	// otlpHeaders holds the resolved OTLP trace headers from
 	// OTEL_EXPORTER_OTLP_TRACES_HEADERS plus Content-Type: application/x-protobuf.
 	otlpHeaders map[string]string
@@ -400,7 +404,8 @@ func loadConfig() *Config {
 	cfg.sendRetries = p.GetIntWithValidator("DD_TRACE_SEND_RETRIES", 0, validateSendRetries)
 	cfg.logsOTelEnabled = p.GetBool("DD_LOGS_OTEL_ENABLED", false)
 	otelSemantics, otelSemanticsOrigin := p.GetBoolWithOrigin("DD_TRACE_OTEL_SEMANTICS_ENABLED", false)
-	cfg.SetOTelSemanticsEnabled(otelSemantics, otelSemanticsOrigin)
+	cfg.otelSemanticsEnabled = otelSemantics
+	configtelemetry.Report("DD_TRACE_OTEL_SEMANTICS_ENABLED", otelSemantics, otelSemanticsOrigin)
 	if v := p.GetString("OTEL_LOGS_EXPORTER", ""); v != "" {
 		log.Warn("OTEL_LOGS_EXPORTER is not supported")
 	}
@@ -411,7 +416,9 @@ func loadConfig() *Config {
 	if p.IsSet("DD_TRACE_AGENT_PROTOCOL_VERSION") {
 		cfg.otlpExportMode = false
 	}
-	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""))
+	otlpTracesEndpoint := p.GetString("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	cfg.otlpTraceURL = resolveOTLPTraceURL(cfg.agentURL, otlpTracesEndpoint)
+	cfg.otlpTraceURLDerivedFromAgent = otlpTracesEndpoint == "" || cfg.otlpTraceURL != otlpTracesEndpoint
 	cfg.otlpHeaders = buildOTLPHeaders(p.GetMap("OTEL_EXPORTER_OTLP_TRACES_HEADERS", nil, internal.OtelTagsDelimeter))
 	v, origin := p.GetBoolWithOrigin("OTEL_TRACES_SPAN_METRICS_ENABLED", false)
 	if origin != telemetry.OriginDefault {
@@ -491,6 +498,7 @@ func loadConfig() *Config {
 	if cfg.spanAttributeSchemaVersion >= 1 {
 		cfg.peerServiceDefaultsEnabled = true
 	}
+	cfg.applyOTelSemanticsOverrides()
 
 	cfg.maxTagsHeaderLen = resolveMaxTagsHeaderLen(p.GetInt("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", DefaultMaxTagsHeaderLen))
 
@@ -563,6 +571,14 @@ func Get() *Config {
 	return instance
 }
 
+// New returns a new configuration loaded from the current configuration sources without
+// replacing the global configuration instance.
+func New() *Config {
+	mu.Lock()
+	defer mu.Unlock()
+	return loadConfig()
+}
+
 // CreateNew returns a new global configuration instance.
 // This function should be used when we need to create a new configuration instance.
 // It build a new configuration instance and override the existing one
@@ -610,6 +626,9 @@ func (c *Config) SetAgentURL(u *url.URL, origin telemetry.Origin, product ...Pro
 		return
 	}
 	c.agentURL = u
+	if c.otelSemanticsEnabled && c.otlpTraceURLDerivedFromAgent {
+		c.otlpTraceURL = resolveOTLPTraceURL(u, "")
+	}
 	if u != nil {
 		configtelemetry.Report("DD_TRACE_AGENT_URL", u.String(), origin)
 	}
@@ -1419,6 +1438,11 @@ func (c *Config) PeerServiceDefaultsEnabled() bool {
 func (c *Config) SetPeerServiceDefaultsEnabled(enabled bool, origin telemetry.Origin) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.otelSemanticsEnabled && enabled {
+		telemetrylog.Warn("Enabling DD_TRACE_OTEL_SEMANTICS_ENABLED overrode DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED to false")
+		configtelemetry.Report("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", false, telemetry.OriginCalculated)
+		return
+	}
 	c.peerServiceDefaultsEnabled = enabled
 	configtelemetry.Report("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", enabled, origin)
 }
@@ -1580,6 +1604,28 @@ func (c *Config) SetOTelSemanticsEnabled(enabled bool, origin telemetry.Origin, 
 	}
 	c.otelSemanticsEnabled = enabled
 	configtelemetry.Report("DD_TRACE_OTEL_SEMANTICS_ENABLED", enabled, origin)
+	c.applyOTelSemanticsOverrides()
+}
+
+// applyOTelSemanticsOverrides applies settings required by OpenTelemetry
+// semantic conventions after their raw values have been resolved.
+// The caller must hold c.mu after configuration initialization.
+func (c *Config) applyOTelSemanticsOverrides() {
+	if !c.otelSemanticsEnabled {
+		return
+	}
+	c.otlpExportMode = true
+	configtelemetry.Report("OTEL_TRACES_EXPORTER", "otlp", telemetry.OriginCalculated)
+	if c.spanAttributeSchemaVersion != 0 {
+		c.spanAttributeSchemaVersion = 0
+		telemetrylog.Warn("Enabling DD_TRACE_OTEL_SEMANTICS_ENABLED overrode DD_TRACE_SPAN_ATTRIBUTE_SCHEMA to v0")
+		configtelemetry.Report("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v0", telemetry.OriginCalculated)
+	}
+	if c.peerServiceDefaultsEnabled {
+		c.peerServiceDefaultsEnabled = false
+		telemetrylog.Warn("Enabling DD_TRACE_OTEL_SEMANTICS_ENABLED overrode DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED to false")
+		configtelemetry.Report("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", false, telemetry.OriginCalculated)
+	}
 }
 
 // RequestedTraceProtocol returns the Datadog trace protocol version to use for
@@ -1683,6 +1729,10 @@ func (c *Config) SetOTLPExportMode(v bool, origin telemetry.Origin, product ...P
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.checkProductConflict("OTEL_TRACES_EXPORTER", origin, v, product...) {
+		return
+	}
+	if c.otelSemanticsEnabled && !v {
+		configtelemetry.Report("OTEL_TRACES_EXPORTER", "otlp", telemetry.OriginCalculated)
 		return
 	}
 	c.otlpExportMode = v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,22 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/telemetry/telemetrytest"
 )
 
+func TestNew(t *testing.T) {
+	resetGlobalState()
+	defer resetGlobalState()
+
+	global := Get()
+	require.False(t, global.Debug())
+
+	t.Setenv("DD_TRACE_DEBUG", "true")
+	fresh := New()
+
+	assert.NotSame(t, global, fresh)
+	assert.True(t, fresh.Debug())
+	assert.Same(t, global, Get())
+	assert.False(t, Get().Debug())
+}
+
 func TestGet(t *testing.T) {
 	t.Run("returns non-nil config", func(t *testing.T) {
 		resetGlobalState()
@@ -632,6 +648,29 @@ func TestOTLPTraceURLResolution(t *testing.T) {
 
 		assert.Equal(t, "http://custom-agent:4318/v1/traces", cfg.OTLPTraceURL())
 	})
+
+	t.Run("independent OTLP export does not follow programmatic agent URL", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		t.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+
+		cfg := Get()
+		original := cfg.OTLPTraceURL()
+		cfg.SetAgentURL(&url.URL{Scheme: "http", Host: "custom-agent:8126"}, OriginCode)
+
+		assert.Equal(t, original, cfg.OTLPTraceURL())
+	})
+
+	t.Run("semantic OTLP export follows programmatic agent URL", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+		cfg := Get()
+		cfg.SetAgentURL(&url.URL{Scheme: "http", Host: "custom-agent:8126"}, OriginCode)
+
+		assert.Equal(t, "http://custom-agent:4318/v1/traces", cfg.OTLPTraceURL())
+	})
 }
 
 func TestOTLPHeaders(t *testing.T) {
@@ -782,6 +821,117 @@ func TestOTLPExportMode(t *testing.T) {
 
 		cfg.SetOTLPExportMode(false, telemetry.OriginCode)
 		assert.False(t, cfg.OTLPExportMode())
+	})
+}
+
+func TestInvalidSpanAttributeSchemaFallsBackWithoutSharedWarning(t *testing.T) {
+	resetGlobalState()
+	defer resetGlobalState()
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "invalid")
+	tp := new(log.RecordLogger)
+	defer log.UseLogger(tp)()
+
+	cfg := Get()
+	assert.Equal(t, 0, cfg.SpanAttributeSchemaVersion())
+	const warning = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=invalid is not a valid value, setting to default of v0"
+	assert.NotContains(t, strings.Join(tp.Logs(), "\n"), warning)
+}
+
+func TestOTelSemanticsEnforcesConfigurationOverrides(t *testing.T) {
+	const (
+		schemaOverrideLog = "Enabling DD_TRACE_OTEL_SEMANTICS_ENABLED overrode DD_TRACE_SPAN_ATTRIBUTE_SCHEMA to v0"
+		peerOverrideLog   = "Enabling DD_TRACE_OTEL_SEMANTICS_ENABLED overrode DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED to false"
+	)
+
+	t.Run("forces OTLP export", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		rec := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(rec)()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+		cfg := Get()
+		assert.True(t, cfg.OTLPExportMode())
+		assert.True(t, slices.ContainsFunc(rec.Configuration, func(c telemetry.Configuration) bool {
+			return c.Name == "OTEL_TRACES_EXPORTER" && c.Value == "otlp" && c.Origin == telemetry.OriginCalculated
+		}))
+		cfg.SetOTLPExportMode(false, telemetry.OriginCode)
+		assert.True(t, cfg.OTLPExportMode())
+	})
+
+	t.Run("wins over Datadog trace protocol", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+		t.Setenv("DD_TRACE_AGENT_PROTOCOL_VERSION", "0.4")
+
+		cfg := Get()
+		assert.True(t, cfg.OTLPExportMode())
+		assert.Equal(t, TraceProtocolV04, cfg.RequestedTraceProtocol())
+	})
+
+	t.Run("calculates conflicting schema and peer service defaults", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		rec := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(rec)()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+		t.Setenv("DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED", "true")
+
+		cfg := Get()
+		assert.Equal(t, 0, cfg.SpanAttributeSchemaVersion())
+		assert.False(t, cfg.PeerServiceDefaultsEnabled())
+		assert.True(t, slices.ContainsFunc(rec.Configuration, func(c telemetry.Configuration) bool {
+			return c.Name == "DD_TRACE_OTEL_SEMANTICS_ENABLED" && c.Value == true && c.Origin == telemetry.OriginEnvVar
+		}))
+		assert.Contains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: schemaOverrideLog})
+		assert.Contains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: peerOverrideLog})
+		assert.True(t, slices.ContainsFunc(rec.Configuration, func(c telemetry.Configuration) bool {
+			return c.Name == "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA" && c.Value == "v0" && c.Origin == telemetry.OriginCalculated
+		}))
+		assert.True(t, slices.ContainsFunc(rec.Configuration, func(c telemetry.Configuration) bool {
+			return c.Name == "DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED" && c.Value == false && c.Origin == telemetry.OriginCalculated
+		}))
+	})
+
+	t.Run("schema v1 implication also calculates peer defaults false", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		rec := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(rec)()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+
+		cfg := Get()
+		assert.Equal(t, 0, cfg.SpanAttributeSchemaVersion())
+		assert.False(t, cfg.PeerServiceDefaultsEnabled())
+		assert.Contains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: schemaOverrideLog})
+		assert.Contains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: peerOverrideLog})
+	})
+
+	t.Run("does not log non-conflicting defaults", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		rec := new(telemetrytest.RecordClient)
+		defer telemetry.MockClient(rec)()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+		cfg := Get()
+		assert.Equal(t, 0, cfg.SpanAttributeSchemaVersion())
+		assert.False(t, cfg.PeerServiceDefaultsEnabled())
+		assert.NotContains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: schemaOverrideLog})
+		assert.NotContains(t, rec.Logs, telemetrytest.LogLine{Level: telemetry.LogWarn, Text: peerOverrideLog})
+	})
+
+	t.Run("programmatic peer defaults cannot re-enable", func(t *testing.T) {
+		resetGlobalState()
+		defer resetGlobalState()
+		t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+
+		cfg := Get()
+		cfg.SetPeerServiceDefaultsEnabled(true, telemetry.OriginCode)
+		assert.False(t, cfg.PeerServiceDefaultsEnabled())
 	})
 }
 

--- a/internal/namingschema/namingschema.go
+++ b/internal/namingschema/namingschema.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/globalconfig"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -40,12 +41,16 @@ var (
 
 func LoadFromEnv() {
 	schemaVersionStr := env.Get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA")
-	if v, ok := parseVersionStr(schemaVersionStr); ok {
-		setVersion(v)
-	} else {
-		setVersion(SchemaV0)
+	if v, ok := parseVersionStr(schemaVersionStr); !ok {
 		log.Warn("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=%s is not a valid value, setting to default of v%d", schemaVersionStr, v)
 	}
+	LoadFromConfig(internalconfig.Get())
+}
+
+// LoadFromConfig loads the naming schema from cfg and the remaining naming
+// options from the environment.
+func LoadFromConfig(cfg *internalconfig.Config) {
+	setVersion(Version(cfg.SpanAttributeSchemaVersion()))
 	// Allow DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=v0 users to disable default integration (contrib AKA v0) service names.
 	// These default service names are always disabled for v1 onwards.
 	SetRemoveIntegrationServiceNames(internal.BoolEnv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", false))
@@ -53,7 +58,7 @@ func LoadFromEnv() {
 
 // ReloadConfig is used to reload the configuration in tests.
 func ReloadConfig() {
-	LoadFromEnv()
+	LoadFromConfig(internalconfig.New())
 	globalconfig.SetServiceName(env.Get("DD_SERVICE"))
 }
 

--- a/internal/namingschema/namingschema_test.go
+++ b/internal/namingschema/namingschema_test.go
@@ -6,13 +6,49 @@
 package namingschema
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
 )
+
+func TestReloadConfigRefreshesNamingSchemaWithoutReplacingGlobalConfig(t *testing.T) {
+	t.Cleanup(func() {
+		internalconfig.CreateNew()
+		ReloadConfig()
+	})
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v0")
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "false")
+	globalConfig := internalconfig.CreateNew()
+	globalConfig.SetEnv("programmatic-env", internalconfig.OriginCode)
+
+	assertSchema := func(want Version) {
+		t.Helper()
+		ReloadConfig()
+		assert.Equal(t, want, GetVersion())
+		assert.Same(t, globalConfig, internalconfig.Get())
+		assert.Equal(t, "programmatic-env", internalconfig.Get().Env())
+		assert.Equal(t, int(SchemaV0), internalconfig.Get().SpanAttributeSchemaVersion())
+	}
+
+	assertSchema(SchemaV0)
+
+	t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
+	assertSchema(SchemaV1)
+
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true")
+	assertSchema(SchemaV0)
+
+	t.Setenv("DD_TRACE_OTEL_SEMANTICS_ENABLED", "false")
+	assertSchema(SchemaV1)
+}
 
 func TestNamingSchema(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
+		internalconfig.CreateNew()
 		LoadFromEnv()
 
 		cfg := GetConfig()
@@ -25,6 +61,7 @@ func TestNamingSchema(t *testing.T) {
 		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "v1")
 		t.Setenv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", "true")
 
+		internalconfig.CreateNew()
 		LoadFromEnv()
 
 		cfg := GetConfig()
@@ -34,6 +71,7 @@ func TestNamingSchema(t *testing.T) {
 	})
 
 	t.Run("options", func(t *testing.T) {
+		internalconfig.CreateNew()
 		LoadFromEnv()
 		SetRemoveIntegrationServiceNames(true)
 
@@ -46,12 +84,18 @@ func TestNamingSchema(t *testing.T) {
 	t.Run("fallback to v0", func(t *testing.T) {
 		t.Setenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", "invalid")
 		t.Setenv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", "true")
+		tp := new(log.RecordLogger)
+		defer log.UseLogger(tp)()
 
+		internalconfig.CreateNew()
 		LoadFromEnv()
 
 		cfg := GetConfig()
 		assert.EqualValues(t, 0, cfg.NamingSchemaVersion)
 		assert.Equal(t, true, cfg.RemoveIntegrationServiceNames)
 		assert.Equal(t, "", cfg.DDService)
+		const warning = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA=invalid is not a valid value, setting to default of v0"
+		assert.Equal(t, 1, strings.Count(strings.Join(tp.Logs(), "\n"), warning))
 	})
+
 }


### PR DESCRIPTION
### What does this PR do?

Part 1 of a stacked implementation for OpenTelemetry `database/sql` span semantics, based on the shared semantics configuration from #5219. The database stack remains separate from the HTTP client and server stacks, while reusing their common configuration accessor. It separates metadata plumbing from span shaping and driver error handling so each behavior can be reviewed independently.

This PR caches the shared OpenTelemetry semantics setting in `database/sql` configuration and separates parsed connection facts from Datadog tag names. It also defines shared database semantic-convention constants for later stack layers.

Datadog span output remains unchanged in this layer. DBM propagation now reads the same parsed host and namespace facts directly instead of reading them back from emitted tag keys.

### Motivation

[APMAPI-2128](https://datadoghq.atlassian.net/browse/APMAPI-2128) requires opt-in OpenTelemetry database client semantics while preserving current output when the setting is disabled. Keeping connection facts independent from output keys lets later layers emit either Datadog or OpenTelemetry names without duplicating DSN parsing or breaking DBM propagation.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.


[APMAPI-2128]: https://datadoghq.atlassian.net/browse/APMAPI-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ