### PR TITLE
feat(contrib/database/sql): support OpenTelemetry span semantics

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -339,6 +339,10 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 		return
 	}
 	dbSystem, _ := normalizeDBSystem(tp.driverName)
+	var otelInfo internal.OTelConnectionInfo
+	if tp.cfg.otelSemantics {
+		otelInfo = tp.connectionInfo.OTelSemantics(tp.driverName)
+	}
 	opts := options.Expand(spanOpts, 0, 6+len(tp.cfg.tags)+1)
 	opts = append(opts,
 		instrumentation.ServiceNameWithSource(tp.cfg.serviceName, tp.cfg.serviceSource),
@@ -346,8 +350,10 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 		tracer.StartTime(startTime),
 		tracer.Tag(ext.Component, componentName),
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
-		tracer.Tag(ext.DBSystem, dbSystem),
 	)
+	if !tp.cfg.otelSemantics {
+		opts = append(opts, tracer.Tag(ext.DBSystem, dbSystem))
+	}
 	if tp.cfg.tags != nil {
 		for key, tag := range tp.cfg.tags {
 			opts = append(opts, tracer.Tag(key, tag))
@@ -357,20 +363,50 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 		opts = append(opts, tracer.Tag(ext.EventSampleRate, tp.cfg.analyticsRate))
 	}
 	span, _ := tracer.StartSpanFromContext(ctx, tp.cfg.spanName, opts...)
-	resource := string(qtype)
-	if query != "" {
-		resource = query
-	}
-
 	span.SetTag("sql.query_type", string(qtype))
-	span.SetTag(ext.ResourceName, resource)
-	for k, v := range tp.datadogTags {
-		span.SetTag(k, v)
+	if tp.cfg.otelSemantics {
+		operation := ""
+		if query == "" {
+			operation = string(qtype)
+		}
+		span.SetTag(ext.ResourceName, otelInfo.SpanName(operation))
+		if query != "" {
+			span.SetTag(ext.DBStatement, query)
+		}
+		if otelInfo.Namespace != "" {
+			span.SetTag(ext.DBNamespace, otelInfo.Namespace)
+		}
+		if otelInfo.ServerAddress != "" {
+			span.SetTag(ext.ServerAddress, otelInfo.ServerAddress)
+		}
+		if otelInfo.ServerPort != 0 {
+			span.SetTag(ext.ServerPort, otelInfo.ServerPort)
+		}
+		for k, v := range tp.datadogTags {
+			switch k {
+			case ext.DBName, ext.TargetHost, ext.TargetPort:
+				continue
+			}
+			span.SetTag(k, v)
+		}
+	} else {
+		resource := string(qtype)
+		if query != "" {
+			resource = query
+		}
+		span.SetTag(ext.ResourceName, resource)
+		for k, v := range tp.datadogTags {
+			span.SetTag(k, v)
+		}
 	}
 	if meta, ok := ctx.Value(spanTagsKey).(map[string]string); ok {
 		for k, v := range meta {
 			span.SetTag(k, v)
 		}
+	}
+	if tp.cfg.otelSemantics {
+		// db.system.name is required and must not be overridden by custom or context tags.
+		span.SetTag(ext.DBSystemName, otelInfo.SystemName)
 	}
 	if err != nil && !events.IsSecurityError(err) && (tp.cfg.errCheck == nil || tp.cfg.errCheck(err)) {
 		span.SetTag(ext.Error, err)

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -10,8 +10,12 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"log"
+	"math"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/contrib/database/sql/v2/internal"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
@@ -21,6 +25,55 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTryTraceOTelSemantics(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	tp := &traceParams{
+		driverName: "mysql",
+		cfg: &config{
+			serviceName:   "mysql.db",
+			spanName:      "mysql.query",
+			analyticsRate: math.NaN(),
+			otelSemantics: true,
+			tags: map[string]any{
+				"custom":         "connection",
+				ext.DBSystemName: "invalid",
+			},
+		},
+		connectionInfo: internal.ConnectionInfo{
+			System:    "mysql",
+			User:      "alice",
+			Namespace: "orders",
+			Host:      "db.example.com",
+			Port:      "3307",
+		},
+	}
+	tp.datadogTags = tp.connectionInfo.DatadogTags()
+	ctx := WithSpanTags(context.Background(), map[string]string{
+		"custom":         "operation",
+		ext.DBSystemName: "also-invalid",
+	})
+	const query = "SELECT * FROM customer"
+	tp.tryTrace(ctx, QueryTypeQuery, query, time.Now(), nil)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, "orders", span.Tag(ext.ResourceName))
+	assert.Equal(t, query, span.Tag(ext.DBStatement))
+	assert.Equal(t, ext.DBSystemMySQL, span.Tag(ext.DBSystemName))
+	assert.Equal(t, "orders", span.Tag(ext.DBNamespace))
+	assert.Equal(t, "db.example.com", span.Tag(ext.ServerAddress))
+	assert.Equal(t, float64(3307), span.Tag(ext.ServerPort))
+	assert.Equal(t, "alice", span.Tag(ext.DBUser))
+	assert.Equal(t, "operation", span.Tag("custom"))
+	assert.Nil(t, span.Tag(ext.DBSystem))
+	assert.Nil(t, span.Tag(ext.DBName))
+	assert.Nil(t, span.Tag(ext.TargetHost))
+	assert.Nil(t, span.Tag(ext.TargetPort))
+}
 
 func TestWithSpanTags(t *testing.T) {
 	type sqlRegister struct {

--- a/contrib/database/sql/internal/semantics.go
+++ b/contrib/database/sql/internal/semantics.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package internal
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+)
+
+// OTelConnectionInfo contains connection attributes used by OpenTelemetry database semantics.
+type OTelConnectionInfo struct {
+	SystemName    string
+	Namespace     string
+	ServerAddress string
+	ServerPort    int
+}
+
+// OTelSemantics returns OpenTelemetry database connection attributes for a driver and parsed DSN.
+func (c ConnectionInfo) OTelSemantics(driverName string) OTelConnectionInfo {
+	system := otelDBSystem(c.System, driverName)
+	info := OTelConnectionInfo{
+		SystemName: system,
+		Namespace:  c.Namespace,
+	}
+	if system == ext.DBSystemSQLite {
+		return info
+	}
+	info.ServerAddress = c.Host
+	if info.ServerAddress == "" || c.Port == "" || c.Port == defaultPort(system) {
+		return info
+	}
+	port, err := strconv.ParseUint(c.Port, 10, 16)
+	if err == nil && port > 0 && defaultPort(system) != "" {
+		info.ServerPort = int(port)
+	}
+	return info
+}
+
+// SpanName returns a low-cardinality database span name. Operation may be empty when no reliable
+// database operation is available.
+func (c OTelConnectionInfo) SpanName(operation string) string {
+	target := c.Namespace
+	if target == "" {
+		target = c.ServerAddress
+		if target != "" && c.ServerPort != 0 {
+			target = net.JoinHostPort(target, strconv.Itoa(c.ServerPort))
+		}
+	}
+	if target == "" {
+		target = c.SystemName
+	}
+	if operation == "" {
+		return target
+	}
+	return operation + " " + target
+}
+
+func otelDBSystem(parsedSystem, driverName string) string {
+	system := parsedSystem
+	if system == "" {
+		system = strings.ToLower(driverName)
+	}
+	switch system {
+	case "mysql":
+		return ext.DBSystemMySQL
+	case "postgres", "postgresql", "pgx":
+		return ext.DBSystemPostgreSQL
+	case "sqlserver", "mssql", "azuresql":
+		return ext.DBSystemNameMicrosoftSQLServer
+	case "sqlite", "sqlite3":
+		return ext.DBSystemSQLite
+	default:
+		return ext.DBSystemOtherSQL
+	}
+}
+
+func defaultPort(system string) string {
+	switch system {
+	case ext.DBSystemMySQL:
+		return "3306"
+	case ext.DBSystemPostgreSQL:
+		return "5432"
+	case ext.DBSystemNameMicrosoftSQLServer:
+		return "1433"
+	default:
+		return ""
+	}
+}

--- a/contrib/database/sql/internal/semantics_test.go
+++ b/contrib/database/sql/internal/semantics_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+)
+
+func TestOTelSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		driverName string
+		connection ConnectionInfo
+		want       OTelConnectionInfo
+	}{
+		{
+			name:       "mysql default port",
+			driverName: "mysql",
+			connection: ConnectionInfo{System: "mysql", Namespace: "orders", Host: "db.example.com", Port: "3306"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemMySQL, Namespace: "orders", ServerAddress: "db.example.com"},
+		},
+		{
+			name:       "postgres non-default port",
+			driverName: "custom-postgres-alias",
+			connection: ConnectionInfo{System: "postgresql", Host: "2001:db8::1", Port: "6432"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemPostgreSQL, ServerAddress: "2001:db8::1", ServerPort: 6432},
+		},
+		{
+			name:       "SQL Server alias",
+			driverName: "azuresql",
+			connection: ConnectionInfo{Host: "db.example.com", Port: "1434"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemNameMicrosoftSQLServer, ServerAddress: "db.example.com", ServerPort: 1434},
+		},
+		{
+			name:       "SQLite has no server",
+			driverName: "sqlite3",
+			connection: ConnectionInfo{Namespace: "local.db", Host: "ignored", Port: "1234"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemSQLite, Namespace: "local.db"},
+		},
+		{
+			name:       "unknown driver",
+			driverName: "custom",
+			connection: ConnectionInfo{Host: "db.example.com", Port: "1234"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemOtherSQL, ServerAddress: "db.example.com"},
+		},
+		{
+			name:       "port requires address",
+			driverName: "mysql",
+			connection: ConnectionInfo{Port: "3307"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemMySQL},
+		},
+		{
+			name:       "invalid port",
+			driverName: "postgres",
+			connection: ConnectionInfo{Host: "db.example.com", Port: "invalid"},
+			want:       OTelConnectionInfo{SystemName: ext.DBSystemPostgreSQL, ServerAddress: "db.example.com"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.connection.OTelSemantics(test.driverName))
+		})
+	}
+}
+
+func TestOTelSpanName(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      OTelConnectionInfo
+		operation string
+		want      string
+	}{
+		{name: "namespace", info: OTelConnectionInfo{SystemName: "mysql", Namespace: "orders", ServerAddress: "host", ServerPort: 3307}, want: "orders"},
+		{name: "operation and namespace", info: OTelConnectionInfo{SystemName: "mysql", Namespace: "orders"}, operation: "Ping", want: "Ping orders"},
+		{name: "IPv4 server", info: OTelConnectionInfo{SystemName: "postgresql", ServerAddress: "127.0.0.1", ServerPort: 6432}, want: "127.0.0.1:6432"},
+		{name: "IPv6 server", info: OTelConnectionInfo{SystemName: "postgresql", ServerAddress: "2001:db8::1", ServerPort: 6432}, want: "[2001:db8::1]:6432"},
+		{name: "address without port", info: OTelConnectionInfo{SystemName: "postgresql", ServerAddress: "db.example.com"}, want: "db.example.com"},
+		{name: "system fallback", info: OTelConnectionInfo{SystemName: "other_sql"}, want: "other_sql"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.info.SpanName(test.operation))
+		})
+	}
+}

--- a/ddtrace/ext/tags.go
+++ b/ddtrace/ext/tags.go
@@ -8,6 +8,12 @@
 package ext
 
 const (
+	// ServerAddress identifies the server address under OpenTelemetry semantics.
+	ServerAddress = "server.address"
+
+	// ServerPort identifies the server port under OpenTelemetry semantics.
+	ServerPort = "server.port"
+
 	// TargetHost sets the target host address.
 	// Legacy: Kept for backwards compatibility. Use NetworkDestinationName for hostname
 	// and NetworkDestinationIP for IP addresses


### PR DESCRIPTION
### What does this PR do?

Part 2 of the OpenTelemetry `database/sql` semantics stack, building on #5274.

When OpenTelemetry semantics are enabled, SQL spans now:

- use `db.system.name` with exact identifiers for MySQL, PostgreSQL, Microsoft SQL Server, SQLite, and unknown SQL databases;
- replace parsed `db.name`, `out.host`, and `out.port` with `db.namespace`, `server.address`, and conditional integer `server.port`;
- omit known default ports;
- use low-cardinality span names based on namespace, server target, or database system instead of raw SQL;
- retain the full query under `db.statement` and preserve Datadog-only connection metadata;
- protect required `db.system.name` from custom and context tag collisions.

Datadog semantics remain on the existing path when the setting is disabled. Driver error enrichment is intentionally left to the next stack layer.

### Motivation

[APMAPI-2128](https://datadoghq.atlassian.net/browse/APMAPI-2128) adds opt-in OpenTelemetry database client semantics while preserving existing output by default. This layer isolates capture-time span shaping from driver-specific error handling, keeping both changes reviewable.

### Testing

- `go test ./instrumentation ./ddtrace/ext`
- `cd contrib/database/sql && go test ./...`
- `cd contrib/database/sql && INTEGRATION=1 go test ./internal`

The focused integration-package test compiles in the package suite. Running it locally with `INTEGRATION=1` requires the repository's MySQL, PostgreSQL, and SQL Server test services; local MySQL was unavailable.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.


[APMAPI-2128]: https://datadoghq.atlassian.net/browse/APMAPI-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ