### PR TITLE
feat(contrib/database/sql): add OpenTelemetry error semantics

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -410,6 +410,13 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 	}
 	if err != nil && !events.IsSecurityError(err) && (tp.cfg.errCheck == nil || tp.cfg.errCheck(err)) {
 		span.SetTag(ext.Error, err)
+		if tp.cfg.otelSemantics {
+			errorInfo := internal.OTelErrorSemantics(err, otelInfo.SystemName)
+			span.SetTag(ext.ErrorType, errorInfo.Type)
+			if errorInfo.ResponseStatusCode != "" {
+				span.SetTag(ext.DBResponseStatusCode, errorInfo.ResponseStatusCode)
+			}
+		}
 	}
 	span.Finish()
 }

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/dd-trace-go/contrib/database/sql/v2/internal"
 
+	"github.com/DataDog/dd-trace-go/v2/appsec/events"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 
@@ -73,6 +74,88 @@ func TestTryTraceOTelSemantics(t *testing.T) {
 	assert.Nil(t, span.Tag(ext.DBName))
 	assert.Nil(t, span.Tag(ext.TargetHost))
 	assert.Nil(t, span.Tag(ext.TargetPort))
+}
+
+func TestTryTraceOTelErrorSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		errCheck  func(error) bool
+		wantError bool
+	}{
+		{name: "accepted", wantError: true},
+		{name: "filtered", errCheck: func(error) bool { return false }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			var tags map[string]any
+			if tt.wantError {
+				tags = map[string]any{
+					ext.ErrorType:            "invalid",
+					ext.DBResponseStatusCode: "invalid",
+				}
+			}
+			tp := &traceParams{
+				driverName: "mysql",
+				cfg: &config{
+					serviceName:   "mysql.db",
+					spanName:      "mysql.query",
+					analyticsRate: math.NaN(),
+					otelSemantics: true,
+					errCheck:      tt.errCheck,
+					tags:          tags,
+				},
+				connectionInfo: internal.ConnectionInfo{System: "mysql"},
+			}
+			err := &mysql.MySQLError{Number: 1062, Message: "duplicate entry"}
+			tp.tryTrace(context.Background(), QueryTypeExec, "INSERT INTO customer VALUES (1)", time.Now(), err)
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			span := spans[0]
+			if tt.wantError {
+				assert.Equal(t, err.Error(), span.Tag(ext.ErrorMsg))
+				assert.Equal(t, "1062", span.Tag(ext.ErrorType))
+				assert.Equal(t, "1062", span.Tag(ext.DBResponseStatusCode))
+				return
+			}
+			assert.Nil(t, span.Tag(ext.ErrorMsg))
+			assert.Nil(t, span.Tag(ext.ErrorType))
+			assert.Nil(t, span.Tag(ext.DBResponseStatusCode))
+		})
+	}
+}
+
+func TestTryTraceOTelSpecialErrors(t *testing.T) {
+	tp := &traceParams{
+		driverName: "mysql",
+		cfg: &config{
+			serviceName:   "mysql.db",
+			spanName:      "mysql.query",
+			analyticsRate: math.NaN(),
+			otelSemantics: true,
+		},
+		connectionInfo: internal.ConnectionInfo{System: "mysql"},
+	}
+
+	t.Run("driver skip", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		tp.tryTrace(context.Background(), QueryTypeExec, "SELECT 1", time.Now(), driver.ErrSkip)
+		assert.Empty(t, mt.FinishedSpans())
+	})
+	t.Run("security error", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		tp.tryTrace(context.Background(), QueryTypeExec, "SELECT 1", time.Now(), &events.BlockingSecurityEvent{})
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 1)
+		assert.Nil(t, spans[0].Tag(ext.ErrorMsg))
+		assert.Nil(t, spans[0].Tag(ext.ErrorType))
+		assert.Nil(t, spans[0].Tag(ext.DBResponseStatusCode))
+	})
 }
 
 func TestWithSpanTags(t *testing.T) {

--- a/contrib/database/sql/internal/errors.go
+++ b/contrib/database/sql/internal/errors.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+)
+
+// OTelErrorInfo contains error attributes used by OpenTelemetry database semantics.
+type OTelErrorInfo struct {
+	Type               string
+	ResponseStatusCode string
+}
+
+// OTelErrorSemantics returns OpenTelemetry error attributes for a failed database operation.
+func OTelErrorSemantics(err error, systemName string) OTelErrorInfo {
+	if err == nil {
+		return OTelErrorInfo{}
+	}
+	if code := databaseErrorCode(err, systemName); code != "" {
+		return OTelErrorInfo{Type: code, ResponseStatusCode: code}
+	}
+	for cause := errors.Unwrap(err); cause != nil; cause = errors.Unwrap(cause) {
+		err = cause
+	}
+	return OTelErrorInfo{Type: fmt.Sprintf("%T", err)}
+}
+
+func databaseErrorCode(err error, systemName string) string {
+	switch systemName {
+	case ext.DBSystemMySQL:
+		var mysqlError *mysql.MySQLError
+		if errors.As(err, &mysqlError) {
+			return strconv.FormatUint(uint64(mysqlError.Number), 10)
+		}
+	case ext.DBSystemPostgreSQL:
+		var postgresError interface{ SQLState() string }
+		if errors.As(err, &postgresError) {
+			return postgresError.SQLState()
+		}
+	case ext.DBSystemNameMicrosoftSQLServer:
+		var sqlServerError interface{ SQLErrorNumber() int32 }
+		if errors.As(err, &sqlServerError) {
+			return strconv.FormatInt(int64(sqlServerError.SQLErrorNumber()), 10)
+		}
+	}
+	return ""
+}

--- a/contrib/database/sql/internal/errors_test.go
+++ b/contrib/database/sql/internal/errors_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016 Datadog, Inc.
+
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	mssql "github.com/denisenkom/go-mssqldb"
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+)
+
+type postgresTestError struct {
+	state string
+}
+
+func (e postgresTestError) Error() string    { return "postgres error" }
+func (e postgresTestError) SQLState() string { return e.state }
+
+type unknownTestError struct{}
+
+func (unknownTestError) Error() string { return "unknown error" }
+
+func TestOTelErrorSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		systemName string
+		want       OTelErrorInfo
+	}{
+		{
+			name:       "nil",
+			systemName: ext.DBSystemOtherSQL,
+			want:       OTelErrorInfo{},
+		},
+		{
+			name:       "MySQL vendor code",
+			err:        &mysql.MySQLError{Number: 1062, Message: "duplicate entry"},
+			systemName: ext.DBSystemMySQL,
+			want:       OTelErrorInfo{Type: "1062", ResponseStatusCode: "1062"},
+		},
+		{
+			name:       "wrapped PostgreSQL SQLSTATE",
+			err:        fmt.Errorf("query failed: %w", &pq.Error{Code: pq.ErrorCode("23505")}),
+			systemName: ext.DBSystemPostgreSQL,
+			want:       OTelErrorInfo{Type: "23505", ResponseStatusCode: "23505"},
+		},
+		{
+			name:       "wrapped SQL Server number",
+			err:        fmt.Errorf("query failed: %w", mssql.Error{Number: 2627}),
+			systemName: ext.DBSystemNameMicrosoftSQLServer,
+			want:       OTelErrorInfo{Type: "2627", ResponseStatusCode: "2627"},
+		},
+		{
+			name:       "empty PostgreSQL SQLSTATE",
+			err:        postgresTestError{},
+			systemName: ext.DBSystemPostgreSQL,
+			want:       OTelErrorInfo{Type: "internal.postgresTestError"},
+		},
+		{
+			name:       "driver mismatch",
+			err:        &mysql.MySQLError{Number: 1062, Message: "duplicate entry"},
+			systemName: ext.DBSystemOtherSQL,
+			want:       OTelErrorInfo{Type: "*mysql.MySQLError"},
+		},
+		{
+			name:       "unwraps unknown error",
+			err:        fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", unknownTestError{})),
+			systemName: ext.DBSystemOtherSQL,
+			want:       OTelErrorInfo{Type: "internal.unknownTestError"},
+		},
+		{
+			name:       "standard error",
+			err:        errors.New("failure"),
+			systemName: ext.DBSystemOtherSQL,
+			want:       OTelErrorInfo{Type: "*errors.errorString"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, OTelErrorSemantics(tt.err, tt.systemName))
+		})
+	}
+}

--- a/internal/exectracetest/go.mod
+++ b/internal/exectracetest/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/orchestrion/_integration/go.mod
+++ b/internal/orchestrion/_integration/go.mod
@@ -223,6 +223,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.23.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect

--- a/orchestrion/all/go.mod
+++ b/orchestrion/all/go.mod
@@ -147,6 +147,7 @@ require (
 	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/go-redis/redis/v7 v7.4.1 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect


### PR DESCRIPTION
### What does this PR do?

Part 3 of the OpenTelemetry `database/sql` semantics stack, building on #5275.

When OpenTelemetry semantics are enabled and the existing error policy accepts an operation failure, SQL spans now:

- preserve existing error status, message, stack, and handling-stack behavior;
- use MySQL vendor error numbers for `error.type` and `db.response.status_code`;
- use PostgreSQL SQLSTATE values exposed through `SQLState()`;
- use Microsoft SQL Server error numbers exposed through `SQLErrorNumber()`;
- inspect wrapped driver errors with `errors.As`;
- fall back to the most relevant canonical Go error type when no database response code exists.

Database response codes are applied after generic error handling so they remain authoritative. Filtered errors receive no generated error attributes. Security errors and `driver.ErrSkip` retain their existing behavior.

The generated Orchestrion aggregate module now records the MySQL driver dependency used by the error adapter.

### Motivation

[APMAPI-2128](https://datadoghq.atlassian.net/browse/APMAPI-2128) requires failed database client spans to expose stable OpenTelemetry error attributes while preserving current Datadog error filtering and AppSec behavior.

### Testing

- `go test ./ddtrace/ext ./instrumentation`
- `cd contrib/database/sql && go test ./...`
- `cd contrib/database/sql && INTEGRATION=1 go test ./internal`
- `cd contrib/database/sql && go test -race ./internal`
- `make generate`
- `cd orchestrion/all && go mod tidy -diff`

Focused helper tests use concrete MySQL, PostgreSQL, and SQL Server driver errors, including wrapped errors and unknown-type fallback. Span-level tests cover accepted errors, filtered errors, tag precedence, security errors, and `driver.ErrSkip`.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.


[APMAPI-2128]: https://datadoghq.atlassian.net/browse/APMAPI-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ