### PR TITLE
test(contrib/database/sql): validate OpenTelemetry semantics

### DIFF
--- a/contrib/database/sql/conn.go
+++ b/contrib/database/sql/conn.go
@@ -338,7 +338,6 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 	if _, exists := tracer.SpanFromContext(ctx); tp.cfg.childSpansOnly && !exists {
 		return
 	}
-	dbSystem, _ := normalizeDBSystem(tp.driverName)
 	var otelInfo internal.OTelConnectionInfo
 	if tp.cfg.otelSemantics {
 		otelInfo = tp.connectionInfo.OTelSemantics(tp.driverName)
@@ -352,6 +351,7 @@ func (tp *traceParams) tryTrace(ctx context.Context, qtype QueryType, query stri
 		tracer.Tag(ext.SpanKind, ext.SpanKindClient),
 	)
 	if !tp.cfg.otelSemantics {
+		dbSystem, _ := normalizeDBSystem(tp.driverName)
 		opts = append(opts, tracer.Tag(ext.DBSystem, dbSystem))
 	}
 	if tp.cfg.tags != nil {

--- a/contrib/database/sql/conn_test.go
+++ b/contrib/database/sql/conn_test.go
@@ -158,6 +158,154 @@ func TestTryTraceOTelSpecialErrors(t *testing.T) {
 	})
 }
 
+func TestTryTraceOTelOperationMatrix(t *testing.T) {
+	tests := []struct {
+		name         string
+		queryType    QueryType
+		query        string
+		wantResource string
+	}{
+		{name: "query", queryType: QueryTypeQuery, query: "SELECT * FROM customer", wantResource: "orders"},
+		{name: "exec", queryType: QueryTypeExec, query: "DELETE FROM customer", wantResource: "orders"},
+		{name: "prepare", queryType: QueryTypePrepare, query: "SELECT * FROM customer WHERE id = ?", wantResource: "orders"},
+		{name: "connect", queryType: QueryTypeConnect, wantResource: "Connect orders"},
+		{name: "ping", queryType: QueryTypePing, wantResource: "Ping orders"},
+		{name: "begin", queryType: QueryTypeBegin, wantResource: "Begin orders"},
+		{name: "commit", queryType: QueryTypeCommit, wantResource: "Commit orders"},
+		{name: "rollback", queryType: QueryTypeRollback, wantResource: "Rollback orders"},
+		{name: "close", queryType: QueryTypeClose, wantResource: "Close orders"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			tp := newTestTraceParams(true)
+			tp.tryTrace(context.Background(), tt.queryType, tt.query, time.Now(), nil)
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			span := spans[0]
+			assert.Equal(t, tt.wantResource, span.Tag(ext.ResourceName))
+			assert.Equal(t, ext.DBSystemMySQL, span.Tag(ext.DBSystemName))
+			assert.Equal(t, ext.SpanKindClient, span.Tag(ext.SpanKind))
+			assert.Equal(t, "orders", span.Tag(ext.DBNamespace))
+			assert.Equal(t, "db.example.com", span.Tag(ext.ServerAddress))
+			assert.Equal(t, float64(3307), span.Tag(ext.ServerPort))
+			assert.Nil(t, span.Tag(ext.DBSystem))
+			assert.Nil(t, span.Tag(ext.DBName))
+			assert.Nil(t, span.Tag(ext.TargetHost))
+			assert.Nil(t, span.Tag(ext.TargetPort))
+			assert.Nil(t, span.Tag(ext.ErrorType))
+			assert.Nil(t, span.Tag(ext.DBResponseStatusCode))
+			assert.Nil(t, span.Tag("db.query.text"))
+			if tt.query == "" {
+				assert.Nil(t, span.Tag(ext.DBStatement))
+			} else {
+				assert.Equal(t, tt.query, span.Tag(ext.DBStatement))
+				assert.NotContains(t, tt.wantResource, tt.query)
+			}
+		})
+	}
+}
+
+func TestTryTraceOTelFiltering(t *testing.T) {
+	t.Run("ignored operation", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		tp := newTestTraceParams(true)
+		tp.cfg.ignoreQueryTypes = map[QueryType]struct{}{QueryTypeQuery: {}}
+		tp.tryTrace(context.Background(), QueryTypeQuery, "SELECT 1", time.Now(), nil)
+		assert.Empty(t, mt.FinishedSpans())
+	})
+	t.Run("child only without parent", func(t *testing.T) {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+		tp := newTestTraceParams(true)
+		tp.cfg.childSpansOnly = true
+		tp.tryTrace(context.Background(), QueryTypeQuery, "SELECT 1", time.Now(), nil)
+		assert.Empty(t, mt.FinishedSpans())
+	})
+}
+
+func TestTryTraceDatadogSemanticsSnapshot(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	tp := newTestTraceParams(false)
+	tp.cfg.tags = map[string]any{"custom": "value"}
+	const query = "SELECT * FROM customer"
+	tp.tryTrace(context.Background(), QueryTypeQuery, query, time.Now(), nil)
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	tags := spans[0].Tags()
+	// Exclude tracer-wide metadata so this snapshot covers every field owned by the integration.
+	for _, key := range []string{"_dd.base_service", "_dd.p.tid", "_dd.profiling.enabled", "_dd.tags.process", "_dd.top_level", "language"} {
+		delete(tags, key)
+	}
+	assert.Equal(t, map[string]any{
+		ext.SpanName:     "mysql.query",
+		ext.ServiceName:  "mysql.db",
+		ext.ResourceName: query,
+		ext.SpanType:     ext.SpanTypeSQL,
+		ext.Component:    string(componentName),
+		ext.SpanKind:     ext.SpanKindClient,
+		ext.DBSystem:     ext.DBSystemMySQL,
+		ext.DBName:       "orders",
+		ext.DBUser:       "alice",
+		ext.TargetHost:   "db.example.com",
+		ext.TargetPort:   "3307",
+		"custom":         "value",
+		"sql.query_type": string(QueryTypeQuery),
+	}, tags)
+}
+
+func newTestTraceParams(otelSemantics bool) *traceParams {
+	connectionInfo := internal.ConnectionInfo{
+		System:    "mysql",
+		User:      "alice",
+		Namespace: "orders",
+		Host:      "db.example.com",
+		Port:      "3307",
+	}
+	return &traceParams{
+		driverName: "mysql",
+		cfg: &config{
+			serviceName:   "mysql.db",
+			spanName:      "mysql.query",
+			analyticsRate: math.NaN(),
+			otelSemantics: otelSemantics,
+		},
+		connectionInfo: connectionInfo,
+		datadogTags:    connectionInfo.DatadogTags(),
+	}
+}
+
+func BenchmarkTryTraceSemantics(b *testing.B) {
+	for _, queryType := range []QueryType{QueryTypeQuery, QueryTypeExec} {
+		for _, enabled := range []bool{false, true} {
+			name := string(queryType) + "/Datadog"
+			if enabled {
+				name = string(queryType) + "/OpenTelemetry"
+			}
+			b.Run(name, func(b *testing.B) {
+				mt := mocktracer.Start()
+				defer mt.Stop()
+				tp := newTestTraceParams(enabled)
+				ctx := context.Background()
+				start := time.Now()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					tp.tryTrace(ctx, queryType, "SELECT * FROM customer", start, nil)
+					mt.Reset()
+				}
+			})
+		}
+	}
+}
+
 func TestWithSpanTags(t *testing.T) {
 	type sqlRegister struct {
 		name   string

--- a/ddtrace/tracer/span_to_otlp_test.go
+++ b/ddtrace/tracer/span_to_otlp_test.go
@@ -275,6 +275,42 @@ func TestConvertSpanAttributesOtelSemantics(t *testing.T) {
 	assert.Equal(t, "GET", m["http.request.method"])
 }
 
+func TestConvertDatabaseSpanOTelSemantics(t *testing.T) {
+	s := newSpan("mysql.query", "mysql.db", "orders", 100, 200, 0)
+	s.start = 1000
+	s.duration = 100
+	s.meta = tinternal.NewSpanMetaFromMap(map[string]string{
+		ext.SpanKind:      ext.SpanKindClient,
+		ext.DBSystemName:  ext.DBSystemMySQL,
+		ext.DBNamespace:   "orders",
+		ext.ServerAddress: "db.example.com",
+		ext.DBStatement:   "SELECT * FROM customer",
+		ext.DBUser:        "alice",
+		ext.Component:     "database/sql",
+		"sql.query_type":  "Query",
+	})
+	s.metrics[ext.ServerPort] = 3307
+
+	otlp := convertSpan(s, "mysql.db", true)
+	require.NotNil(t, otlp)
+	assert.Equal(t, "orders", otlp.Name)
+	assert.Equal(t, otlptrace.Span_SPAN_KIND_CLIENT, otlp.Kind)
+
+	attrs := keyValuesToMap(otlp.Attributes)
+	assert.Equal(t, ext.DBSystemMySQL, attrs[ext.DBSystemName])
+	assert.Equal(t, "orders", attrs[ext.DBNamespace])
+	assert.Equal(t, "db.example.com", attrs[ext.ServerAddress])
+	assert.Equal(t, int64(3307), attrs[ext.ServerPort])
+	assert.Equal(t, "SELECT * FROM customer", attrs[ext.DBStatement])
+	assert.Equal(t, "alice", attrs[ext.DBUser])
+	assert.Equal(t, "database/sql", attrs[ext.Component])
+	assert.Equal(t, "Query", attrs["sql.query_type"])
+	for _, key := range []string{ext.DBSystem, ext.DBName, ext.TargetHost, ext.TargetPort, "db.query.text"} {
+		assert.NotContains(t, attrs, key)
+	}
+	assert.NotContains(t, otlp.Name, "SELECT")
+}
+
 func TestConvertSpanAttributesWithMetaStruct(t *testing.T) {
 	s := newBasicSpan("op")
 	s.meta = tinternal.NewSpanMetaFromMap(map[string]string{"tag": "val"})


### PR DESCRIPTION
### What does this PR do?

Part 4 of the OpenTelemetry `database/sql` semantics stack, building on #5277. The stack keeps shared metadata, span shaping, error semantics, and validation independently reviewable.

This final layer adds capture-path coverage for query, exec, prepare, connect, ping, begin, commit, rollback, and close spans. It verifies low-cardinality names, required OpenTelemetry attributes, retained Datadog-only attributes, replaced Datadog equivalents, ignored operations, child-only behavior, and a complete snapshot of integration-owned output when OpenTelemetry semantics are disabled.

OTLP coverage verifies that the final database attributes survive export, `server.port` remains an integer, and the exported span name contains no SQL. Query and exec benchmarks compare OpenTelemetry semantics with existing Datadog semantics. The enabled path also avoids computing Datadog system normalization that it does not use.

### Motivation

[APMAPI-2128](https://datadoghq.atlassian.net/browse/APMAPI-2128) requires compatibility and export validation in addition to capture-time semantic changes. These tests protect the disabled behavior and exercise every operation through the shared span-creation path without adding production behavior beyond the feature gate.

### Testing

- `go test ./instrumentation ./ddtrace/ext ./ddtrace/tracer`
- `go test -race ./ddtrace/tracer`
- `go vet ./ddtrace/tracer ./ddtrace/ext ./instrumentation`
- `cd contrib/database/sql && go test ./...`
- `cd contrib/database/sql && INTEGRATION=1 go test ./internal`
- `cd contrib/database/sql && go test -race ./internal`
- `cd contrib/database/sql && go vet ./...`
- `bin/golangci-lint run --new-from-rev apmapi-2121-otel-semantics-config ./ddtrace/tracer ./ddtrace/ext ./instrumentation`
- `cd contrib/database/sql && ../../../bin/golangci-lint run -c ../../../.golangci.yml -D gocritic --new-from-rev apmapi-2121-otel-semantics-config ./...`
- `make generate`
- `make lint/misc`
- focused span tests and query/exec benchmarks through a local unit-only `TestMain` bypass, removed before commit

The benchmark matrix reports the same allocation count for enabled and disabled paths. Full `INTEGRATION=1 go test .` still requires the repository's MySQL, PostgreSQL, and SQL Server services, which were not available locally.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [x] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [x] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.


[APMAPI-2128]: https://datadoghq.atlassian.net/browse/APMAPI-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ