### PR TITLE
ci: point LLM validation gate at ddoghq/llm-validation-platform

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,12 +81,6 @@ linux-go-go-prof-app-parallel:
     # monitored file reads as "absent at baseline" and the gate quietly diffs against nothing.
     LLMVAL_BASE_REF: "main"
 
-"llm validation (candidate-absent)":
-  variables:
-    LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
-    LLMVAL_PLATFORM_REF: "anna.yafi/make-generic"
-    LLMVAL_BASE_REF: "main"
-
 go-go-prof-app-parallel-check-slo-breaches:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ include:
   # LLM Validation gate: reusable job shipped by the platform repo — only the local .llm-validation/ suite
   # stays in this repo. The job auto-skips when no monitored file changed; a FAIL blocks the merge.
   - project: 'ddoghq/llm-validation-platform'
-    ref: anna.yafi/make-generic
+    ref: main
     file: '/ci/llm-validation.gitlab-ci.yml'
 
 # Pin the benchmarking-platform image for the go-go-prof-app-parallel jobs
@@ -73,7 +73,7 @@ linux-go-go-prof-app-parallel:
 "llm validation":
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
-    LLMVAL_PLATFORM_REF: "anna.yafi/make-generic"
+    LLMVAL_PLATFORM_REF: "main"
     LLMVAL_BASE_REF: "main"   # must be job-level, not top-level `variables:` — see ci/README.md
 
 go-go-prof-app-parallel-check-slo-breaches:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,18 +61,31 @@ include:
     ref: 'main'
   # LLM Validation gate: reusable job shipped by the platform repo — only the local .llm-validation/ suite
   # stays in this repo. The job auto-skips when no monitored file changed; a FAIL blocks the merge.
-  - project: 'DataDog/llm-validation-platform'
-    ref: anna.yafi/instruction-presence-benchmark
+  - project: 'ddoghq/llm-validation-platform'
+    ref: anna.yafi/make-generic
     file: '/ci/llm-validation.gitlab-ci.yml'
-
-"llm validation":
-  variables:
-    LLMVAL_BASE_REF: "main"
 
 # Pin the benchmarking-platform image for the go-go-prof-app-parallel jobs
 # included from DataDog/apm-reliability/apm-sdks-benchmarks above.
 linux-go-go-prof-app-parallel:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
+
+"llm validation":
+  variables:
+    LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
+    LLMVAL_PLATFORM_REF: "anna.yafi/make-generic"
+    # LLMVAL_BASE_REF must be set here (job-level), NOT in the top-level `variables:` block above — the
+    # template gives it its own job-level default ("master"), and a job-level variable always beats a
+    # top-level one in GitLab. A top-level override here silently loses, and dd-trace-go's real default
+    # branch is `main`; `master` is a stale branch frozen in 2018, long before AGENTS.md existed, so every
+    # monitored file reads as "absent at baseline" and the gate quietly diffs against nothing.
+    LLMVAL_BASE_REF: "main"
+
+"llm validation (candidate-absent)":
+  variables:
+    LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
+    LLMVAL_PLATFORM_REF: "anna.yafi/make-generic"
+    LLMVAL_BASE_REF: "main"
 
 go-go-prof-app-parallel-check-slo-breaches:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,12 +74,7 @@ linux-go-go-prof-app-parallel:
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
     LLMVAL_PLATFORM_REF: "anna.yafi/make-generic"
-    # LLMVAL_BASE_REF must be set here (job-level), NOT in the top-level `variables:` block above — the
-    # template gives it its own job-level default ("master"), and a job-level variable always beats a
-    # top-level one in GitLab. A top-level override here silently loses, and dd-trace-go's real default
-    # branch is `main`; `master` is a stale branch frozen in 2018, long before AGENTS.md existed, so every
-    # monitored file reads as "absent at baseline" and the gate quietly diffs against nothing.
-    LLMVAL_BASE_REF: "main"
+    LLMVAL_BASE_REF: "main"   # must be job-level, not top-level `variables:` — see ci/README.md
 
 go-go-prof-app-parallel-check-slo-breaches:
   image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ include:
   # LLM Validation gate: reusable job shipped by the platform repo — only the local .llm-validation/ suite
   # stays in this repo. The job auto-skips when no monitored file changed; a FAIL blocks the merge.
   - project: 'ddoghq/llm-validation-platform'
-    ref: main
+    ref: c331696647a78672101002ba48ccebbd41b0fae8 # v0.1.3
     file: '/ci/llm-validation.gitlab-ci.yml'
 
 # Pin the benchmarking-platform image for the go-go-prof-app-parallel jobs
@@ -73,7 +73,7 @@ linux-go-go-prof-app-parallel:
 "llm validation":
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
-    LLMVAL_PLATFORM_REF: "main"
+    LLMVAL_PLATFORM_REF: "c331696647a78672101002ba48ccebbd41b0fae8"  # v0.1.3
     LLMVAL_BASE_REF: "main"   # must be job-level, not top-level `variables:` — see ci/README.md
 
 go-go-prof-app-parallel-check-slo-breaches:


### PR DESCRIPTION
### What does this PR do?
Repoints the LLM Validation gate's GitLab CI `include:` from `DataDog/llm-validation-platform` to `ddoghq/llm-validation-platform` @ `anna.yafi/make-generic`, adds matching `LLMVAL_PLATFORM_PROJECT`/`LLMVAL_PLATFORM_REF` variable overrides to the existing `"llm validation":` job, and adds a new `"llm validation (candidate-absent)":` job (same platform/ref) to `.gitlab-ci.yml`.

### Motivation
`DataDog/llm-validation-platform` was archived after its org migration to `ddoghq`, so the gate's `include:` needs to point at `ddoghq/llm-validation-platform` to keep resolving.

The new `"llm validation (candidate-absent)"` job runs the eval suite without the AGENTS.md candidate present, so its results can be compared against the existing candidate-present run. That comparison is the baseline needed to measure whether AGENTS.md content causally improves an agent's answers, rather than assuming it does.

### Reviewer's Checklist
- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

This PR only changes `.gitlab-ci.yml` (CI configuration, not tracer code), so most of the checklist above is not applicable — no Go code, unit tests, system tests, benchmarks, or go.mod changes are introduced.
