### PR TITLE
fix(contrib/elastic/go-elasticsearch.v6): fall back to status text when response body is empty

### DIFF
--- a/contrib/elastic/go-elasticsearch.v6/elastictrace.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace.go
@@ -90,7 +90,10 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	} else if res.StatusCode < 200 || res.StatusCode > 299 {
 		// HTTP error
 		snip, rc, err := peek(res.Body, res.Header.Get("Content-Encoding"), int(res.ContentLength), bodyCutoff)
-		if err != nil {
+		if err != nil || snip == "" {
+			// An empty body (common for 401/403) yields an empty snippet, which
+			// would otherwise produce an error with no message. Fall back to the
+			// HTTP status text so Error Tracking shows e.g. "Unauthorized".
 			snip = http.StatusText(res.StatusCode)
 		}
 		span.SetTag(ext.Error, errors.New(snip))

--- a/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
+++ b/contrib/elastic/go-elasticsearch.v6/elastictrace_test.go
@@ -259,6 +259,32 @@ func TestRoundTripperGzipErrorResponseUncompressedRequest(t *testing.T) {
 	assert.Equal(t, errBody, span.Tag(ext.ErrorMsg))
 }
 
+// TestRoundTripperEmptyErrorBody is a regression test for #5284: a non-2xx response with an
+// empty body must not produce an error with an empty message. peek() normalizes io.EOF to nil,
+// so an empty body returns an empty snippet with no error; RoundTrip must fall back to the HTTP
+// status text (e.g. "Unauthorized") so Error Tracking shows a meaningful title.
+func TestRoundTripperEmptyErrorBody(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		// no body written
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/twitter/_search", nil)
+	require.NoError(t, err)
+
+	res, err := (&http.Client{Transport: NewRoundTripper()}).Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	span := mt.FinishedSpans()[0]
+	assert.Equal(t, http.StatusText(http.StatusUnauthorized), span.Tag(ext.ErrorMsg))
+	assert.NotEmpty(t, span.Tag(ext.ErrorMsg))
+}
+
 // TestRoundTripperGzipBodyCutoffUncompressedRequest covers the path TestRoundTripperGzipBodyCutoff
 // doesn't: a gzip-bomb response arriving on an uncompressed request. Content-Encoding is now read
 // from the response's own header, so this path decodes gzip where it previously wouldn't have; it


### PR DESCRIPTION
### What does this PR do?

In `contrib/elastic/go-elasticsearch.v6/elastictrace.go`, when a non-2xx HTTP response has an **empty body**, the span was tagged with an error carrying an empty message (`errors.New("")`). This PR falls back to `http.StatusText(res.StatusCode)` in that case, so the span records a meaningful message such as `"Unauthorized"`.

Empty bodies are common for `401`/`403` responses. `peek()` normalizes `io.EOF` to `nil`, so an empty body returns `("", rc, nil)` — success with an empty snippet. Because `err == nil`, the existing fallback to `http.StatusText()` was skipped. The condition now also triggers on an empty snippet:

```go
if err != nil || snip == "" {
    snip = http.StatusText(res.StatusCode)
}
```

Added a regression test (`TestRoundTripperEmptyErrorBody`) using `httptest`: a `401` response with an empty body now asserts the span's `ext.ErrorMsg` equals `"Unauthorized"` (previously empty). Verified the test fails without the fix and passes with it.

### Motivation

Fixes #5284. With an empty error message, Datadog Error Tracking displayed the top internal stack frame (`...stacktrace.SkipAndCaptureWithInternalFrames`) as the issue title instead of a meaningful message. This follows the exact fix suggested in the issue by @darccio.

Note: `contrib/olivere/elastic.v5/elastictrace.go` (lines 94–96) has the identical pattern and the same latent bug. It is a separate module / different client library, so it is intentionally left out of this PR to keep it scoped; happy to send a follow-up (or include it here) if preferred.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality.
- [ ] System-Tests covering this feature have been added.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [x] New code is free of linting errors (`gofmt -l` clean; `go build ./...` passes).
- [x] New code doesn't break existing tests.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [x] All generated files are up to date (no generated files affected).
- [x] No go.mod changes.
