### PR TITLE
ci(system-tests): run APIM weblog scenarios

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -251,10 +251,6 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: apim-callout-image-linux-amd64
             image_name: apim-callout
-          - weblog-variant: apim
-            scenario: APPSEC_BLOCKING_FULL_DENYLIST
-            image_artifact: apim-callout-image-linux-amd64
-            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -251,6 +251,10 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: apim-callout-image-linux-amd64
             image_name: apim-callout
+          - weblog-variant: apim
+            scenario: APPSEC_BLOCKING_FULL_DENYLIST
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -124,6 +124,7 @@ jobs:
       - build-weblog-images
       - build-service-extensions-callout
       - build-haproxy
+      - build-apim-callout
     strategy:
       matrix:
         weblog-variant:
@@ -242,6 +243,14 @@ jobs:
             scenario: APPSEC_BLOCKING
             image_artifact: haproxy-spoa-image-linux-amd64
             image_name: haproxy-spoa
+          - weblog-variant: apim
+            scenario: DEFAULT
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
+          - weblog-variant: apim
+            scenario: APPSEC_BLOCKING
+            image_artifact: apim-callout-image-linux-amd64
+            image_name: apim-callout
       fail-fast: false
     env:
       SYSTEM_TESTS_WEBLOG: ${{ matrix.weblog-variant }}
@@ -304,7 +313,7 @@ jobs:
         run: npm install -g @datadog/datadog-ci
 
       - name: Download pre-built weblog image
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: weblog-image-${{ matrix.weblog-variant }}
@@ -314,21 +323,21 @@ jobs:
         run: ls -la binaries
 
       - name: Build weblog
-        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' }}
+        if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.image_artifact }}
 
       - name: Load ${{ matrix.weblog-variant }} image
-        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy') }}
+        if: ${{ github.ref != 'refs/heads/main'  && (matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim') }}
         run: docker load -i ${{ matrix.image_artifact }}.tar
       
       - name: Set ${{ matrix.image_name }} image name
-        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' }}
+        if: ${{ matrix.weblog-variant == 'envoy' || matrix.weblog-variant == 'haproxy' || matrix.weblog-variant == 'apim' }}
         run: echo "ghcr.io/datadog/dd-trace-go/${{ matrix.image_name }}:dev" > binaries/golang-${{ matrix.image_name }}-image
 
       - name: Build runner


### PR DESCRIPTION
## What does this PR do?

Runs the APIM proxy integration in the Go system-tests workflow for `DEFAULT` and `APPSEC_BLOCKING`.

The workflow now:

- waits for the existing `build-apim-callout` job
- downloads and loads its `linux/amd64` image artifact on pull requests
- writes the `binaries/golang-apim-callout-image` pointer used by system-tests
- skips the normal weblog download/build path, matching Envoy and HAProxy

This complements DataDog/system-tests#7567, which enables the validated proxy test declarations.

`APPSEC_BLOCKING_FULL_DENYLIST` is intentionally deferred because the scenario also selects user-blocking tests whose `/users` endpoint is not implemented by proxy weblogs.

## Motivation

The APIM callout image was already built by CI, but no system-test matrix lane consumed it. As a result, dd-trace-go changes to the APIM contrib were not exercised end to end before merge.

## Additional Notes

Validated with `make lint/action`. Both APIM lanes ran in GitHub Actions and passed.