### PR TITLE
fix(profiler): remove trace ID labels from the CPU profile

### DIFF
--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -30,14 +30,14 @@ import (
 func Enabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return status.Enabled()
+	return activeAppSec != nil && activeAppSec.started
 }
 
 // RASPEnabled returns true when DD_APPSEC_RASP_ENABLED=true or is unset. Granted that AppSec is enabled.
 func RASPEnabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return status.Enabled() && activeAppSec.cfg.RASP
+	return activeAppSec != nil && activeAppSec.started && activeAppSec.cfg.RASP
 }
 
 // Start AppSec when enabled is enabled by both using the appsec build tag and
@@ -154,7 +154,6 @@ func setActiveAppSec(a *appsec) {
 		activeAppSec.stop()
 	}
 	activeAppSec = a
-	status.SetEnabled(a != nil && a.started)
 }
 
 type appsec struct {
@@ -192,8 +191,8 @@ func (a *appsec) start() error {
 	a.enableRCBlocking()
 	a.enableRASP()
 
+	status.MarkEnabled()
 	a.started = true
-	status.SetEnabled(true) // TODO: right?
 	log.Info("appsec: up and running")
 
 	// TODO: log the config like the APM tracer does but we first need to define
@@ -209,7 +208,6 @@ func (a *appsec) stop() {
 	}
 
 	a.started = false
-	status.SetEnabled(false) // TODO: right?
 	registerAppsecStopTelemetry()
 	// Disable RC blocking first so that the following is guaranteed not to be concurrent anymore.
 	a.disableRCBlocking()

--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -17,6 +17,7 @@ import (
 	globalinternal "github.com/DataDog/dd-trace-go/v2/internal"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/appsec/listener"
+	"github.com/DataDog/dd-trace-go/v2/internal/appsec/status"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
 	"github.com/DataDog/dd-trace-go/v2/internal/remoteconfig"
@@ -29,14 +30,14 @@ import (
 func Enabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return activeAppSec != nil && activeAppSec.started
+	return status.Enabled()
 }
 
 // RASPEnabled returns true when DD_APPSEC_RASP_ENABLED=true or is unset. Granted that AppSec is enabled.
 func RASPEnabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return activeAppSec != nil && activeAppSec.started && activeAppSec.cfg.RASP
+	return status.Enabled() && activeAppSec.cfg.RASP
 }
 
 // Start AppSec when enabled is enabled by both using the appsec build tag and
@@ -153,6 +154,7 @@ func setActiveAppSec(a *appsec) {
 		activeAppSec.stop()
 	}
 	activeAppSec = a
+	status.SetEnabled(a != nil && a.started)
 }
 
 type appsec struct {
@@ -191,6 +193,7 @@ func (a *appsec) start() error {
 	a.enableRASP()
 
 	a.started = true
+	status.SetEnabled(true) // TODO: right?
 	log.Info("appsec: up and running")
 
 	// TODO: log the config like the APM tracer does but we first need to define
@@ -204,7 +207,9 @@ func (a *appsec) stop() {
 	if !a.started {
 		return
 	}
+
 	a.started = false
+	status.SetEnabled(false) // TODO: right?
 	registerAppsecStopTelemetry()
 	// Disable RC blocking first so that the following is guaranteed not to be concurrent anymore.
 	a.disableRCBlocking()

--- a/internal/appsec/status/status.go
+++ b/internal/appsec/status/status.go
@@ -3,21 +3,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026 Datadog, Inc.
 
-// Package status exposes the status of appsec, i.e. whether or
-// not it is currently enabled. This exists so that other dd-trace-go packages
-// can query this status without depending on all of appsec.
+// Package status exposes whether AppSec has ever been enabled. This allows the
+// profiler to conservatively determine whether CPU profiles may contain AppSec
+// goroutine pprof labels without depending on the full AppSec implementation.
+// The monotonic signal intentionally favors simplicity over coordinating an
+// exact status across AppSec lifecycle transitions.
 package status
 
 import "sync/atomic"
 
-var enabled atomic.Bool
+var everEnabled atomic.Bool
 
-// Enabled reports whether appsec is enabled.
-func Enabled() bool {
-	return enabled.Load()
+// EverEnabled reports whether AppSec has been enabled at least once during the
+// lifetime of the process. Once true, it remains true even if AppSec stops or
+// is remotely deactivated because goroutine pprof labels added while it was
+// enabled may still be present.
+func EverEnabled() bool {
+	return everEnabled.Load()
 }
 
-// SetEnabled sets whether appsec is enabled.
-func SetEnabled(value bool) {
-	enabled.Store(value)
+// MarkEnabled records that AppSec has been enabled.
+func MarkEnabled() {
+	everEnabled.Store(true)
 }

--- a/internal/appsec/status/status.go
+++ b/internal/appsec/status/status.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+// Package status exposes the status of appsec, i.e. whether or
+// not it is currently enabled. This exists so that other dd-trace-go packages
+// can query this status without depending on all of appsec.
+package status
+
+import "sync/atomic"
+
+var enabled atomic.Bool
+
+// Enabled reports whether appsec is enabled.
+func Enabled() bool {
+	return enabled.Load()
+}
+
+// SetEnabled sets whether appsec is enabled.
+func SetEnabled(value bool) {
+	enabled.Store(value)
+}

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -124,18 +124,7 @@ var profileTypes = map[ProfileType]profileType{
 			c.Reset(&buf)
 			var writeErr error
 			if stripLabels {
-				r, err := gzip.NewReader(bytes.NewReader(outBuf.Bytes()))
-				if err != nil {
-					writeErr = err
-				} else {
-					profile, err := io.ReadAll(r)
-					_ = r.Close()
-					if err != nil {
-						writeErr = err
-					} else {
-						writeErr = stripPPROFLabels(profile, c)
-					}
-				}
+				writeErr = stripPPROFLabels(outBuf.Bytes(), c)
 			} else {
 				_, writeErr = outBuf.WriteTo(c)
 			}

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -119,6 +119,19 @@ var profileTypes = map[ProfileType]profileType{
 			stripLabels := appsecEnabled()
 			c := p.compressors[CPUProfile]
 			if stripLabels {
+				if p.stripCPUCompressor == nil {
+					_, outputCompression := compressionStrategy(CPUProfile, false, p.cfg.compressionConfig)
+					var err error
+					p.stripCPUCompressor, err = p.compressionBuilder.Build(noCompression, outputCompression)
+					if err != nil {
+						return nil, err
+					}
+					// Drop the old compressor, which we won't use again.
+					// This is safe because we arrange for CPU profiling to stop
+					// after all other profilers, meaning we won't race with any
+					// other access to p.compressors
+					delete(p.compressors, CPUProfile)
+				}
 				c = p.stripCPUCompressor
 			}
 			c.Reset(&buf)

--- a/profiler/profile.go
+++ b/profiler/profile.go
@@ -116,9 +116,29 @@ var profileTypes = map[ProfileType]profileType{
 			p.pendingProfiles.Wait()
 			pprof.StopCPUProfile()
 
+			stripLabels := appsecEnabled()
 			c := p.compressors[CPUProfile]
+			if stripLabels {
+				c = p.stripCPUCompressor
+			}
 			c.Reset(&buf)
-			_, writeErr := outBuf.WriteTo(c)
+			var writeErr error
+			if stripLabels {
+				r, err := gzip.NewReader(bytes.NewReader(outBuf.Bytes()))
+				if err != nil {
+					writeErr = err
+				} else {
+					profile, err := io.ReadAll(r)
+					_ = r.Close()
+					if err != nil {
+						writeErr = err
+					} else {
+						writeErr = stripPPROFLabels(profile, c)
+					}
+				}
+			} else {
+				_, writeErr = outBuf.WriteTo(c)
+			}
 			closeErr := c.Close()
 			return buf.Bytes(), cmp.Or(writeErr, closeErr)
 		},

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -118,10 +118,14 @@ type profiler struct {
 	met         *metrics       // metric collector state
 	deltas      map[ProfileType]*fastDeltaProfiler
 	compressors map[ProfileType]compressor
-	// stripCPUCompressor is used if we are stripping unwanted labels from
-	// CPU profiles, in which case we need to have an uncompressed profile
-	// in memory and can't just pass it straight through for compression.
+	// stripCPUCompressor is used when we want to strip labels from CPU
+	// profiles, in which case we need the decompressed profile in memory
+	// and can't pass straight through to recompression. Initialized lazily.
 	stripCPUCompressor compressor
+	// compressionBuilder is retained so that stripCPUCompressor can share a
+	// zstd encoder with the other compressors which are initialized when
+	// the profiler is started.
+	compressionBuilder compressionPipelineBuilder
 	seq                uint64         // seq is the value of the profile_seq tag
 	pendingProfiles    sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
 
@@ -263,22 +267,14 @@ func newProfiler(opts ...Option) (*profiler, error) {
 	if p.cfg.traceConfig.Enabled {
 		types = append(types, executionTrace)
 	}
-	var pipelineBuilder compressionPipelineBuilder
 	for _, pt := range types {
 		isDelta := p.cfg.deltaProfiles && len(profileTypes[pt].DeltaValues) > 0
 		in, out := compressionStrategy(pt, isDelta, p.cfg.compressionConfig)
-		compressor, err := pipelineBuilder.Build(in, out)
+		compressor, err := p.compressionBuilder.Build(in, out)
 		if err != nil {
 			return nil, err
 		}
 		p.compressors[pt] = compressor
-
-		if pt == CPUProfile {
-			p.stripCPUCompressor, err = pipelineBuilder.Build(noCompression, out)
-			if err != nil {
-				return nil, err
-			}
-		}
 
 		if isDelta {
 			p.deltas[pt] = newFastDeltaProfiler(compressor, profileTypes[pt].DeltaValues...)

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -45,8 +45,8 @@ var (
 	containerID    atomic.Pointer[string]
 	entityID       atomic.Pointer[string]
 
-	// appsecEnabled is a hook for testing
-	appsecEnabled = appsecstatus.Enabled
+	// appsecEnabled is a hook for testing.
+	appsecEnabled = appsecstatus.EverEnabled
 
 	// errProfilerStopped is a sentinel for suppressing errors if we are
 	// about to stop the profiler

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/internal"
+	appsecstatus "github.com/DataDog/dd-trace-go/v2/internal/appsec/status"
 	internalconfig "github.com/DataDog/dd-trace-go/v2/internal/config"
 	"github.com/DataDog/dd-trace-go/v2/internal/env"
 	"github.com/DataDog/dd-trace-go/v2/internal/log"
@@ -43,6 +44,9 @@ var (
 	activeProfiler *profiler
 	containerID    atomic.Pointer[string]
 	entityID       atomic.Pointer[string]
+
+	// appsecEnabled is a hook for testing
+	appsecEnabled = appsecstatus.Enabled
 
 	// errProfilerStopped is a sentinel for suppressing errors if we are
 	// about to stop the profiler
@@ -106,16 +110,20 @@ func Stop() {
 // profiler collects and sends preset profiles to the Datadog API at a given frequency
 // using a given configuration.
 type profiler struct {
-	cfg             *config        // profile configuration
-	out             chan batch     // upload queue
-	exit            chan struct{}  // exit signals the profiler to stop; it is closed after stopping
-	stopOnce        sync.Once      // stopOnce ensures the profiler is stopped exactly once.
-	wg              sync.WaitGroup // wg waits for all goroutines to exit when stopping.
-	met             *metrics       // metric collector state
-	deltas          map[ProfileType]*fastDeltaProfiler
-	compressors     map[ProfileType]compressor
-	seq             uint64         // seq is the value of the profile_seq tag
-	pendingProfiles sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
+	cfg         *config        // profile configuration
+	out         chan batch     // upload queue
+	exit        chan struct{}  // exit signals the profiler to stop; it is closed after stopping
+	stopOnce    sync.Once      // stopOnce ensures the profiler is stopped exactly once.
+	wg          sync.WaitGroup // wg waits for all goroutines to exit when stopping.
+	met         *metrics       // metric collector state
+	deltas      map[ProfileType]*fastDeltaProfiler
+	compressors map[ProfileType]compressor
+	// stripCPUCompressor is used if we are stripping unwanted labels from
+	// CPU profiles, in which case we need to have an uncompressed profile
+	// in memory and can't just pass it straight through for compression.
+	stripCPUCompressor compressor
+	seq                uint64         // seq is the value of the profile_seq tag
+	pendingProfiles    sync.WaitGroup // signal that profile collection is done, for stopping CPU profiling
 
 	// lastTrace is the last time an execution trace was collected
 	lastTrace time.Time
@@ -264,6 +272,13 @@ func newProfiler(opts ...Option) (*profiler, error) {
 			return nil, err
 		}
 		p.compressors[pt] = compressor
+
+		if pt == CPUProfile {
+			p.stripCPUCompressor, err = pipelineBuilder.Build(noCompression, out)
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		if isDelta {
 			p.deltas[pt] = newFastDeltaProfiler(compressor, profileTypes[pt].DeltaValues...)

--- a/profiler/profiler_test.go
+++ b/profiler/profiler_test.go
@@ -551,6 +551,33 @@ func TestEnabledFalse(t *testing.T) {
 	}
 }
 
+func TestCPUProfileAppsecEnabled(t *testing.T) {
+	originalAppSecEnabled := appsecEnabled
+	t.Cleanup(func() { appsecEnabled = originalAppSecEnabled })
+	// This is here so pprofile can parse the profile. We could also
+	// decompress it ourselves from zstd first and then give the data to
+	// pprofile.
+	t.Setenv("DD_PROFILING_DEBUG_COMPRESSION_SETTINGS", "gzip")
+
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("appsec-enabled=%t", enabled), func(t *testing.T) {
+			appsecEnabled = func() bool { return enabled }
+			profile := startTestProfiler(t, 1,
+				WithPeriod(10*time.Millisecond),
+				WithProfileTypes(CPUProfile),
+			).ReceiveProfile(t)
+
+			// Label stripping logic should still leave us with a
+			// valid profile.
+			// TODO: do some work so there are actually samples?
+			// Gives us more assurance that the profile is still
+			// valid, or at least parseable.
+			_, err := pprofile.ParseData(profile.attachments["cpu.pprof"])
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestExecutionTraceCPUProfileRate(t *testing.T) {
 	// cpuProfileRate is picked randomly so we can check for it in the trace
 	// data to reduce the chance that it occurs in the trace data for some other

--- a/profiler/strip_labels.go
+++ b/profiler/strip_labels.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package profiler
+
+import (
+	"errors"
+	"io"
+	"math"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+)
+
+// stripPPROFLabels removes unwanted labels from samples in the pprof-encoded
+// profile in data and writes the resulting profile to w.
+func stripPPROFLabels(data []byte, w io.Writer) error {
+	decoder := pproflite.NewDecoder(data)
+	skippedKeyStringIndices := make(map[int64]struct{})
+	var n int64
+	if err := decoder.FieldEach(func(field pproflite.Field) error {
+		if name := string(field.(*pproflite.StringTable).Value); name == traceprof.TraceID {
+			skippedKeyStringIndices[n] = struct{}{}
+		}
+		n++
+		return nil
+	}, pproflite.StringTableDecoder); err != nil {
+		return err
+	}
+
+	if n > math.MaxUint32 {
+		// It is extremely unlikely to have 4 billion strings in a
+		// profile, but limiting to 32 bits' worth lets us use smaller
+		// indices.
+		return errors.New("too many strings in profile")
+	}
+
+	// indices is zero for unreferenced strings and otherwise stores its new
+	// index (plus one, to distinguish between index 0 and an unreferenced
+	// string)
+	indices := make([]uint32, n)
+	if len(indices) > 0 {
+		indices[0] = 1 // The empty string is always the first string
+	}
+	mark := func(index int64) { indices[index] = 1 }
+	isStrippedLabel := func(label pproflite.Label) bool {
+		_, ok := skippedKeyStringIndices[label.Key]
+		return ok
+	}
+
+	// First find strings used by all fields that will remain in the profile.
+	if err := decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.SampleType:
+			mark(field.ValueType.Type)
+			mark(field.ValueType.Unit)
+		case *pproflite.Sample:
+			for _, label := range field.Label {
+				if isStrippedLabel(label) {
+					continue
+				}
+				mark(label.Key)
+				mark(label.Str)
+				mark(label.NumUnit)
+			}
+		case *pproflite.Mapping:
+			mark(field.Filename)
+			mark(field.BuildID)
+		case *pproflite.Function:
+			mark(field.Name)
+			mark(field.SystemName)
+			mark(field.FileName)
+		case *pproflite.DropFrames:
+			mark(field.Value)
+		case *pproflite.KeepFrames:
+			mark(field.Value)
+		case *pproflite.PeriodType:
+			mark(field.ValueType.Type)
+			mark(field.ValueType.Unit)
+		case *pproflite.Comment:
+			mark(field.Value)
+		case *pproflite.DefaultSampleType:
+			mark(field.Value)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var next uint32
+	for i, index := range indices {
+		if index != 0 {
+			next++
+			indices[i] = next
+		}
+	}
+	// translate maps a string table reference to its new location.
+	translate := func(index *int64) { *index = int64(indices[*index] - 1) }
+
+	encoder := pproflite.NewEncoder(w)
+	stringIndex := 0
+	return decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.StringTable:
+			keep := indices[stringIndex] != 0
+			stringIndex++
+			if !keep {
+				return nil
+			}
+		case *pproflite.SampleType:
+			translate(&field.ValueType.Type)
+			translate(&field.ValueType.Unit)
+		case *pproflite.Sample:
+			labels := field.Label[:0]
+			for _, label := range field.Label {
+				if isStrippedLabel(label) {
+					continue
+				}
+				translate(&label.Key)
+				translate(&label.Str)
+				translate(&label.NumUnit)
+				labels = append(labels, label)
+			}
+			field.Label = labels
+		case *pproflite.Mapping:
+			translate(&field.Filename)
+			translate(&field.BuildID)
+		case *pproflite.Function:
+			translate(&field.Name)
+			translate(&field.SystemName)
+			translate(&field.FileName)
+		case *pproflite.DropFrames:
+			translate(&field.Value)
+		case *pproflite.KeepFrames:
+			translate(&field.Value)
+		case *pproflite.PeriodType:
+			translate(&field.ValueType.Type)
+			translate(&field.ValueType.Unit)
+		case *pproflite.Comment:
+			translate(&field.Value)
+		case *pproflite.DefaultSampleType:
+			translate(&field.Value)
+		}
+		return encoder.Encode(field)
+	})
+}

--- a/profiler/strip_labels.go
+++ b/profiler/strip_labels.go
@@ -6,17 +6,33 @@
 package profiler
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
 	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
 )
 
-// stripPPROFLabels removes unwanted labels from samples in the pprof-encoded
-// profile in data and writes the resulting profile to w.
+// stripPPROFLabels removes unwanted labels from samples in the gzip-compressed
+// pprof profile in data and writes the resulting profile to w.
 func stripPPROFLabels(data []byte, w io.Writer) error {
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	data, readErr := io.ReadAll(r)
+	closeErr := r.Close()
+	if readErr != nil {
+		return readErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+
 	decoder := pproflite.NewDecoder(data)
 	skippedKeyStringIndices := make(map[int64]struct{})
 	var n int64

--- a/profiler/strip_labels_test.go
+++ b/profiler/strip_labels_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License, Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026 Datadog, Inc.
+
+package profiler
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/traceprof"
+	"github.com/DataDog/dd-trace-go/v2/profiler/internal/pproflite"
+
+	pprofile "github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkStripTracerLabels(b *testing.B) {
+	path := os.Getenv("STRIP_TRACER_LABELS_PROFILE")
+	if path == "" {
+		b.Skip("set STRIP_TRACER_LABELS_PROFILE to a raw CPU profile path")
+	}
+	profile, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Logf("input size: %d bytes", len(profile))
+	buf := new(bytes.Buffer)
+	stripPPROFLabels(profile, buf)
+	b.Logf("output size: %d bytes", buf.Len())
+
+	b.SetBytes(int64(len(profile)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := stripPPROFLabels(profile, io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestStripTracerLabels(t *testing.T) {
+	// Include a value used outside a tracer label to verify that only unreferenced
+	// string table entries are removed.
+	strings := []string{"", "samples", "count", traceprof.SpanID, "123", traceprof.TraceID, "456", traceprof.TraceEndpoint, "/users", "custom", "kept"}
+	var input bytes.Buffer
+	encoder := pproflite.NewEncoder(&input)
+	for _, value := range strings {
+		require.NoError(t, encoder.Encode(&pproflite.StringTable{Value: []byte(value)}))
+	}
+	require.NoError(t, encoder.Encode(&pproflite.SampleType{ValueType: pproflite.ValueType{Type: 1, Unit: 2}}))
+	require.NoError(t, encoder.Encode(&pproflite.Sample{Value: []int64{1}, Label: []pproflite.Label{
+		{Key: 3, Str: 4},
+		{Key: 5, Str: 6},
+		{Key: 7, Str: 8},
+		{Key: 9, Str: 10},
+	}}))
+
+	var output bytes.Buffer
+	require.NoError(t, stripPPROFLabels(input.Bytes(), &output))
+
+	// Make sure we produced a valid profile.
+	_, err := pprofile.ParseData(output.Bytes())
+	require.NoError(t, err)
+
+	var gotLabels []pproflite.Label
+	var gotStrings []string
+	decoder := pproflite.NewDecoder(output.Bytes())
+	require.NoError(t, decoder.FieldEach(func(field pproflite.Field) error {
+		switch field := field.(type) {
+		case *pproflite.Sample:
+			gotLabels = append(gotLabels, field.Label...)
+		case *pproflite.StringTable:
+			gotStrings = append(gotStrings, string(field.Value))
+		}
+		return nil
+	}))
+
+	require.Len(t, gotLabels, 3)
+	require.Equal(t, traceprof.SpanID, gotStrings[gotLabels[0].Key])
+	require.Equal(t, "123", gotStrings[gotLabels[0].Str])
+	require.Equal(t, traceprof.TraceEndpoint, gotStrings[gotLabels[1].Key])
+	require.Equal(t, "/users", gotStrings[gotLabels[1].Str])
+	require.Equal(t, "custom", gotStrings[gotLabels[2].Key])
+	require.Equal(t, "kept", gotStrings[gotLabels[2].Str])
+	require.NotContains(t, gotStrings, traceprof.TraceID)
+	require.NotContains(t, gotStrings, "456")
+}

--- a/profiler/strip_labels_test.go
+++ b/profiler/strip_labels_test.go
@@ -7,6 +7,7 @@ package profiler
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"os"
 	"testing"
@@ -60,11 +61,17 @@ func TestStripTracerLabels(t *testing.T) {
 		{Key: 9, Str: 10},
 	}}))
 
+	var compressed bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressed)
+	_, err := gzipWriter.Write(input.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+
 	var output bytes.Buffer
-	require.NoError(t, stripPPROFLabels(input.Bytes(), &output))
+	require.NoError(t, stripPPROFLabels(compressed.Bytes(), &output))
 
 	// Make sure we produced a valid profile.
-	_, err := pprofile.ParseData(output.Bytes())
+	_, err = pprofile.ParseData(output.Bytes())
 	require.NoError(t, err)
 
 	var gotLabels []pproflite.Label

--- a/profiler/telemetry.go
+++ b/profiler/telemetry.go
@@ -64,5 +64,6 @@ func telemetryConfiguration(c *config) []telemetry.Configuration {
 		{Name: "num_custom_profiler_label_keys", Value: len(c.customProfilerLabels)},
 		{Name: "flush_on_exit", Value: c.flushOnExit},
 		{Name: "debug_compression_settings", Value: c.compressionConfig},
+		{Name: "appsec_enabled", Value: appsecEnabled()},
 	}
 }


### PR DESCRIPTION
When appsec is enabled, the tracer creates trace ID goroutine labels so
that the Datadog agent can correlate security-related runtime events
with APM traces via eBPF. These goroutine labels end up in the CPU
profile, making them ~10% larger on average. This size increase leads to
more bandwidth usage, which costs us and our customers money.

We have no use for these labels in the profiling product. Thus, it's
safe to remove the labels from the profile before uploading them. This
costs about ~10ms of CPU time per MiB of data, and requires having the
CPU profile buffered in memory where it wasn't before.

We only do this stripping if appsec is enabled, since the labels are
only added on the tracer side when appsec is enabled. This does increase
our complexity a bit in the profiler. To avoid taking a full dependency
on appsec, which would break the build of the profiler on 32-bit
platforms, introduce an appsec status package to track whether appsec is
enabled.

With a ~2.3MiB CPU profile of a Datadog production service, I get this output
from the included benchmark:

```
BenchmarkStripTracerLabels
    strip_labels_test.go:31: input size: 2378731 bytes
    strip_labels_test.go:34: output size: 2093234 bytes
BenchmarkStripTracerLabels-10                 44          25415905 ns/op          93.59 MB/s      109458 B/op         33 allocs/op
PASS
ok      github.com/DataDog/dd-trace-go/v2/profiler      1.661s
```

Based on #5114