### PR TITLE
fix(profiler): keep AppSec status sticky

### DIFF
--- a/internal/appsec/appsec.go
+++ b/internal/appsec/appsec.go
@@ -29,14 +29,14 @@ import (
 func Enabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return status.Enabled()
+	return activeAppSec != nil && activeAppSec.started
 }
 
 // RASPEnabled returns true when DD_APPSEC_RASP_ENABLED=true or is unset. Granted that AppSec is enabled.
 func RASPEnabled() bool {
 	mu.RLock()
 	defer mu.RUnlock()
-	return status.Enabled() && activeAppSec.cfg.RASP
+	return activeAppSec != nil && activeAppSec.started && activeAppSec.cfg.RASP
 }
 
 // Start AppSec when enabled is enabled by both using the appsec build tag and
@@ -152,7 +152,6 @@ func setActiveAppSec(a *appsec) {
 		activeAppSec.stop()
 	}
 	activeAppSec = a
-	status.SetEnabled(a != nil && a.started)
 }
 
 type appsec struct {
@@ -190,8 +189,8 @@ func (a *appsec) start() error {
 	a.enableRCBlocking()
 	a.enableRASP()
 
+	status.MarkEnabled()
 	a.started = true
-	status.SetEnabled(true) // TODO: right?
 	log.Info("appsec: up and running")
 
 	// TODO: log the config like the APM tracer does but we first need to define
@@ -207,7 +206,6 @@ func (a *appsec) stop() {
 	}
 
 	a.started = false
-	status.SetEnabled(false) // TODO: right?
 	registerAppsecStopTelemetry()
 	// Disable RC blocking first so that the following is guaranteed not to be concurrent anymore.
 	a.disableRCBlocking()

--- a/internal/appsec/status/status.go
+++ b/internal/appsec/status/status.go
@@ -3,21 +3,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026 Datadog, Inc.
 
-// Package status exposes the status of appsec, i.e. whether or
-// not it is currently enabled. This exists so that other dd-trace-go packages
-// can query this status without depending on all of appsec.
+// Package status exposes whether AppSec has ever been enabled. This allows the
+// profiler to conservatively determine whether CPU profiles may contain AppSec
+// goroutine pprof labels without depending on the full AppSec implementation.
+// The monotonic signal intentionally favors simplicity over coordinating an
+// exact status across AppSec lifecycle transitions.
 package status
 
 import "sync/atomic"
 
-var enabled atomic.Bool
+var everEnabled atomic.Bool
 
-// Enabled reports whether appsec is enabled.
-func Enabled() bool {
-	return enabled.Load()
+// EverEnabled reports whether AppSec has been enabled at least once during the
+// lifetime of the process. Once true, it remains true even if AppSec stops or
+// is remotely deactivated because goroutine pprof labels added while it was
+// enabled may still be present.
+func EverEnabled() bool {
+	return everEnabled.Load()
 }
 
-// SetEnabled sets whether appsec is enabled.
-func SetEnabled(value bool) {
-	enabled.Store(value)
+// MarkEnabled records that AppSec has been enabled.
+func MarkEnabled() {
+	everEnabled.Store(true)
 }

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -43,8 +43,8 @@ var (
 	containerID    atomic.Pointer[string]
 	entityID       atomic.Pointer[string]
 
-	// appsecEnabled is a hook for testing
-	appsecEnabled = appsecstatus.Enabled
+	// appsecEnabled is a hook for testing.
+	appsecEnabled = appsecstatus.EverEnabled
 
 	// errProfilerStopped is a sentinel for suppressing errors if we are
 	// about to stop the profiler


### PR DESCRIPTION
### What does this PR do?

Changes the lightweight AppSec status to a sticky, process-lifetime signal indicating whether AppSec has ever been enabled.

### Motivation

This was initially motivated by the startup race discovered by agentic code review in #5295. I realized that fixing the problem is just treating the symptom of the complexity introduced by the PR. So instead I'm proposing a much simpler approach that guarantees the main property we should care about: **AppSec never adds overhead for profiling users that don't use AppSec** while keeping the implementation as simple and risk-free as possible.

### Reviewer Notes

Yes, there is an edge case now where AppSec is enabled and later disabled (e.g. via remote config). I could fix this with the provider idea below, but now any mutex contention (or deadlock!) in the appsec start/stop code could also impact profiling users. Doesn't seem to be worth it for what's mostly a cost/overhead optimization. But I don't feel very strongly about, it's an acceptable path to go down as well.

<details>
<summary>Alternative considered: querying AppSec through a provider</summary>

I considered having the lightweight status package query a provider registered by AppSec. This would avoid replicated state and return the exact current AppSec status. It could work roughly like this:

```go
// internal/appsec/status/status.go
var enabledProvider atomic.Value // stores func() bool

func RegisterEnabledProvider(provider func() bool) {
    enabledProvider.Store(provider)
}

func Enabled() bool {
    provider, _ := enabledProvider.Load().(func() bool)
    return provider != nil && provider()
}
```

AppSec would register its mutex-backed status function:

```go
// internal/appsec/appsec.go
func init() {
    appsecstatus.RegisterEnabledProvider(Enabled)
}

func Enabled() bool {
    mu.RLock()
    defer mu.RUnlock()
    return activeAppSec != nil && activeAppSec.started
}
```

The profiler could then query it without importing the full AppSec package:

```go
stripLabels := appsecstatus.Enabled()
```

I decided against this because the provider would acquire AppSec's mutex from the profiler. If AppSec has an issue, such as deadlocking while holding that mutex, profile collection could also block. Since this status is only a best-effort optimization for the profiler, that coupling is not worth the risk.

</details>

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!


