### PR TITLE
fix(contrib/valyala/fasthttp): obfuscate query string in http.url tag

### DIFF
--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
 	appsechttpsec "github.com/DataDog/dd-trace-go/v2/instrumentation/appsec/httpsec"
+	instrhttptrace "github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace"
 )
 
 var instr *instrumentation.Instrumentation
@@ -79,7 +80,7 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 		tracer.Tag(ext.SpanKind, ext.SpanKindServer),
 		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.Tag(ext.HTTPMethod, string(fctx.Method())),
-		tracer.Tag(ext.HTTPURL, string(fctx.URI().FullURI())),
+		tracer.Tag(ext.HTTPURL, httpURLTag(fctx)),
 		tracer.Tag(ext.HTTPUserAgent, string(fctx.UserAgent())),
 		tracer.Measured(),
 	}
@@ -88,4 +89,16 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 	}
 	opts = appsechttpsec.AppendSecurityTestingHeaderTagsFromBytes(opts, fctx.Request.Header.VisitAll)
 	return opts
+}
+
+// httpURLTag builds the http.url span tag from the request URI's scheme, host, and path, appending the query
+// string only after running it through the same obfuscation net/http-based integrations use. Unlike
+// fctx.URI().FullURI(), this never leaks a raw, unobfuscated query string.
+func httpURLTag(fctx *fasthttp.RequestCtx) string {
+	uri := fctx.URI()
+	url := string(uri.Scheme()) + "://" + string(uri.Host()) + string(uri.PathOriginal())
+	if query := instrhttptrace.ObfuscateQueryString(string(uri.QueryString())); query != "" {
+		url += "?" + query
+	}
+	return url
 }

--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -91,9 +91,8 @@ func defaultSpanOptions(fctx *fasthttp.RequestCtx) []tracer.StartSpanOption {
 	return opts
 }
 
-// httpURLTag builds the http.url span tag from the request URI's scheme, host, and path, appending the query
-// string only after running it through the same obfuscation net/http-based integrations use. Unlike
-// fctx.URI().FullURI(), this never leaks a raw, unobfuscated query string.
+// httpURLTag builds the http.url span tag. It obfuscates the query string because
+// fctx.URI().FullURI() returns it verbatim.
 func httpURLTag(fctx *fasthttp.RequestCtx) string {
 	uri := fctx.URI()
 	url := string(uri.Scheme()) + "://" + string(uri.Host()) + string(uri.PathOriginal())

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/instrumentation"
+	instrhttptrace "github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace"
 )
 
 const errMsg = "This is an error!"
@@ -133,6 +134,89 @@ func TestTrace200(t *testing.T) {
 	assert.Equal(string(instrumentation.PackageValyalaFastHTTP), span.Tag(ext.Component))
 	assert.Equal(string(instrumentation.PackageValyalaFastHTTP), span.Integration())
 	assert.Equal(ext.SpanKindServer, span.Tag(ext.SpanKind))
+}
+
+// Test that the http.url span tag redacts sensitive query string parameters instead of
+// leaking them verbatim (APMSP-3529).
+func TestHTTPURLQueryStringObfuscation(t *testing.T) {
+	addr := startServer(t)
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret&safe=1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Tag(ext.HTTPURL).(string)
+	assert.Contains(url, "safe=1")
+	assert.Contains(url, "<redacted>")
+	assert.NotContains(url, "supersecret")
+}
+
+func TestHTTPURLQueryStringDisabled(t *testing.T) {
+	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "true")
+	instrhttptrace.ResetCfg()
+	t.Cleanup(instrhttptrace.ResetCfg)
+
+	addr := startServer(t)
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(addr+"/any", spans[0].Tag(ext.HTTPURL))
+}
+
+func TestHTTPURLQueryStringCustomRegexp(t *testing.T) {
+	t.Setenv("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP", `myparam=\w+`)
+	instrhttptrace.ResetCfg()
+	t.Cleanup(instrhttptrace.ResetCfg)
+
+	addr := startServer(t)
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	resp, err := (&http.Client{}).Get(addr + "/any?myparam=shouldberedacted&other=1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Tag(ext.HTTPURL).(string)
+	assert.Contains(url, "other=1")
+	assert.Contains(url, "<redacted>")
+	assert.NotContains(url, "shouldberedacted")
+}
+
+func TestHTTPURLQueryStringAllowlist(t *testing.T) {
+	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST_SERVER", "safe")
+	instrhttptrace.ResetCfg()
+	t.Cleanup(instrhttptrace.ResetCfg)
+
+	addr := startServer(t)
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	resp, err := (&http.Client{}).Get(addr + "/any?safe=1&password=hunter2")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	url, _ := spans[0].Tag(ext.HTTPURL).(string)
+	assert.Contains(url, "safe=1")
+	assert.NotContains(url, "hunter2")
+	assert.NotContains(url, "password")
 }
 
 // Test that HTTP Status codes >= 500 are treated as error spans

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -7,6 +7,7 @@ package fasthttp
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -157,9 +158,9 @@ func TestHTTPURLQueryStringObfuscation(t *testing.T) {
 }
 
 func TestHTTPURLQueryStringDisabled(t *testing.T) {
+	t.Cleanup(instrhttptrace.ResetCfg)
 	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "true")
 	instrhttptrace.ResetCfg()
-	t.Cleanup(instrhttptrace.ResetCfg)
 
 	addr := startServer(t)
 	assert := assert.New(t)
@@ -176,9 +177,9 @@ func TestHTTPURLQueryStringDisabled(t *testing.T) {
 }
 
 func TestHTTPURLQueryStringCustomRegexp(t *testing.T) {
+	t.Cleanup(instrhttptrace.ResetCfg)
 	t.Setenv("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP", `myparam=\w+`)
 	instrhttptrace.ResetCfg()
-	t.Cleanup(instrhttptrace.ResetCfg)
 
 	addr := startServer(t)
 	assert := assert.New(t)
@@ -198,9 +199,9 @@ func TestHTTPURLQueryStringCustomRegexp(t *testing.T) {
 }
 
 func TestHTTPURLQueryStringAllowlist(t *testing.T) {
+	t.Cleanup(instrhttptrace.ResetCfg)
 	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST_SERVER", "safe")
 	instrhttptrace.ResetCfg()
-	t.Cleanup(instrhttptrace.ResetCfg)
 
 	addr := startServer(t)
 	assert := assert.New(t)
@@ -217,6 +218,31 @@ func TestHTTPURLQueryStringAllowlist(t *testing.T) {
 	assert.Contains(url, "safe=1")
 	assert.NotContains(url, "hunter2")
 	assert.NotContains(url, "password")
+}
+
+// Test that the http.url span tag preserves the raw, as-received wire-form path
+// (no dot-segment collapsing, no %2F decoding) rather than a normalized one. A
+// regular net/http.Client would normalize a path like "/a/b/../c" before it ever
+// reaches the wire, so this dials the server directly and writes the request
+// line by hand to control the exact bytes sent.
+func TestHTTPURLPreservesRawPath(t *testing.T) {
+	addr := startServer(t)
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	rawAddr := strings.TrimPrefix(addr, "http://")
+	conn, err := net.Dial("tcp", rawAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("GET /a/b/../c HTTP/1.1\r\nHost: " + rawAddr + "\r\nConnection: close\r\n\r\n"))
+	require.NoError(t, err)
+	_, _ = io.ReadAll(conn) // drain the response so the span finishes before we inspect it
+
+	spans := mt.FinishedSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(addr+"/a/b/../c", spans[0].Tag(ext.HTTPURL))
 }
 
 // Test that HTTP Status codes >= 500 are treated as error spans

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -139,85 +139,87 @@ func TestTrace200(t *testing.T) {
 
 // Test that the http.url span tag redacts sensitive query string parameters instead of
 // leaking them verbatim (APMSP-3529).
-func TestHTTPURLQueryStringObfuscation(t *testing.T) {
-	addr := startServer(t)
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+func TestHTTPURLQueryString(t *testing.T) {
+	t.Run("obfuscation", func(t *testing.T) {
+		addr := startServer(t)
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
 
-	resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret&safe=1")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+		resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret&safe=1")
+		require.NoError(t, err)
+		defer resp.Body.Close()
 
-	spans := mt.FinishedSpans()
-	require.Len(t, spans, 1)
-	url, _ := spans[0].Tag(ext.HTTPURL).(string)
-	assert.Contains(url, "safe=1")
-	assert.Contains(url, "<redacted>")
-	assert.NotContains(url, "supersecret")
-}
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 1)
+		url, _ := spans[0].Tag(ext.HTTPURL).(string)
+		assert.Contains(url, "safe=1")
+		assert.Contains(url, "<redacted>")
+		assert.NotContains(url, "supersecret")
+	})
 
-func TestHTTPURLQueryStringDisabled(t *testing.T) {
-	t.Cleanup(instrhttptrace.ResetCfg)
-	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "true")
-	instrhttptrace.ResetCfg()
+	t.Run("disabled", func(t *testing.T) {
+		t.Cleanup(instrhttptrace.ResetCfg)
+		t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED", "true")
+		instrhttptrace.ResetCfg()
 
-	addr := startServer(t)
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+		addr := startServer(t)
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
 
-	resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+		resp, err := (&http.Client{}).Get(addr + "/any?token=supersecret")
+		require.NoError(t, err)
+		defer resp.Body.Close()
 
-	spans := mt.FinishedSpans()
-	require.Len(t, spans, 1)
-	assert.Equal(addr+"/any", spans[0].Tag(ext.HTTPURL))
-}
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 1)
+		assert.Equal(addr+"/any", spans[0].Tag(ext.HTTPURL))
+	})
 
-func TestHTTPURLQueryStringCustomRegexp(t *testing.T) {
-	t.Cleanup(instrhttptrace.ResetCfg)
-	t.Setenv("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP", `myparam=\w+`)
-	instrhttptrace.ResetCfg()
+	t.Run("custom regexp", func(t *testing.T) {
+		t.Cleanup(instrhttptrace.ResetCfg)
+		t.Setenv("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP", `myparam=\w+`)
+		instrhttptrace.ResetCfg()
 
-	addr := startServer(t)
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+		addr := startServer(t)
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
 
-	resp, err := (&http.Client{}).Get(addr + "/any?myparam=shouldberedacted&other=1")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+		resp, err := (&http.Client{}).Get(addr + "/any?myparam=shouldberedacted&other=1")
+		require.NoError(t, err)
+		defer resp.Body.Close()
 
-	spans := mt.FinishedSpans()
-	require.Len(t, spans, 1)
-	url, _ := spans[0].Tag(ext.HTTPURL).(string)
-	assert.Contains(url, "other=1")
-	assert.Contains(url, "<redacted>")
-	assert.NotContains(url, "shouldberedacted")
-}
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 1)
+		url, _ := spans[0].Tag(ext.HTTPURL).(string)
+		assert.Contains(url, "other=1")
+		assert.Contains(url, "<redacted>")
+		assert.NotContains(url, "shouldberedacted")
+	})
 
-func TestHTTPURLQueryStringAllowlist(t *testing.T) {
-	t.Cleanup(instrhttptrace.ResetCfg)
-	t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST_SERVER", "safe")
-	instrhttptrace.ResetCfg()
+	t.Run("allowlist", func(t *testing.T) {
+		t.Cleanup(instrhttptrace.ResetCfg)
+		t.Setenv("DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST_SERVER", "safe")
+		instrhttptrace.ResetCfg()
 
-	addr := startServer(t)
-	assert := assert.New(t)
-	mt := mocktracer.Start()
-	defer mt.Stop()
+		addr := startServer(t)
+		assert := assert.New(t)
+		mt := mocktracer.Start()
+		defer mt.Stop()
 
-	resp, err := (&http.Client{}).Get(addr + "/any?safe=1&password=hunter2")
-	require.NoError(t, err)
-	defer resp.Body.Close()
+		resp, err := (&http.Client{}).Get(addr + "/any?safe=1&password=hunter2")
+		require.NoError(t, err)
+		defer resp.Body.Close()
 
-	spans := mt.FinishedSpans()
-	require.Len(t, spans, 1)
-	url, _ := spans[0].Tag(ext.HTTPURL).(string)
-	assert.Contains(url, "safe=1")
-	assert.NotContains(url, "hunter2")
-	assert.NotContains(url, "password")
+		spans := mt.FinishedSpans()
+		require.Len(t, spans, 1)
+		url, _ := spans[0].Tag(ext.HTTPURL).(string)
+		assert.Contains(url, "safe=1")
+		assert.NotContains(url, "hunter2")
+		assert.NotContains(url, "password")
+	})
 }
 
 // Test that the http.url span tag preserves the raw, as-received wire-form path

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -223,20 +223,10 @@ func URLFromClientRequest(r *http.Request, queryString bool) string {
 // Use this for server-side integrations whose request type is not a *http.Request (e.g. fasthttp) and therefore
 // cannot call URLFromRequest directly.
 func ObfuscateQueryString(rawQuery string) string {
-	return obfuscateQueryStringForTag(rawQuery, false)
-}
-
-// ObfuscateClientQueryString is the client-side counterpart of ObfuscateQueryString: it consults
-// DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST[_CLIENT] instead of the server-side allowlist.
-func ObfuscateClientQueryString(rawQuery string) string {
-	return obfuscateQueryStringForTag(rawQuery, true)
-}
-
-func obfuscateQueryStringForTag(rawQuery string, isClient bool) string {
 	if !cfg.queryString || rawQuery == "" {
 		return ""
 	}
-	return obfuscateQueryString(rawQuery, isClient)
+	return obfuscateQueryString(rawQuery, false)
 }
 
 func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
@@ -272,8 +262,7 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 // obfuscateQueryString applies allowlist filtering or regexp-based obfuscation to rawQuery, in the priority
 // order used for the http.url span tag: an explicit allowlist (getQueryStringAllowlist) takes precedence over
 // the default obfuscator, which takes precedence over a custom DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP. It is
-// the single obfuscation code path shared by urlFromRequest and the exported ObfuscateQueryString /
-// ObfuscateClientQueryString.
+// the single obfuscation code path shared by urlFromRequest and the exported ObfuscateQueryString.
 func obfuscateQueryString(rawQuery string, isClient bool) string {
 	if allowlist := cfg.getQueryStringAllowlist(isClient); allowlist != nil {
 		// When an allowlist is configured, only keep the specified parameter keys.

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -215,6 +215,30 @@ func URLFromClientRequest(r *http.Request, queryString bool) string {
 	return urlFromRequest(r, queryString, true)
 }
 
+// ObfuscateQueryString returns rawQuery obfuscated using the same server-side rules as URLFromRequest: it honors
+// DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED, DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST[_SERVER], the default
+// obfuscator, and DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, in that order of precedence. It returns "" when query
+// string collection is disabled or rawQuery is empty.
+//
+// Use this for server-side integrations whose request type is not a *http.Request (e.g. fasthttp) and therefore
+// cannot call URLFromRequest directly.
+func ObfuscateQueryString(rawQuery string) string {
+	return obfuscateQueryStringForTag(rawQuery, false)
+}
+
+// ObfuscateClientQueryString is the client-side counterpart of ObfuscateQueryString: it consults
+// DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST[_CLIENT] instead of the server-side allowlist.
+func ObfuscateClientQueryString(rawQuery string) string {
+	return obfuscateQueryStringForTag(rawQuery, true)
+}
+
+func obfuscateQueryStringForTag(rawQuery string, isClient bool) string {
+	if !cfg.queryString || rawQuery == "" {
+		return ""
+	}
+	return obfuscateQueryString(rawQuery, isClient)
+}
+
 func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 	// Quoting net/http comments about net.Request.URL on server requests:
 	// "For most requests, fields other than Path and RawQuery will be
@@ -235,18 +259,7 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 	}
 	// Collect the query string if we are allowed to report it and obfuscate it if possible/allowed
 	if queryString && r.URL.RawQuery != "" {
-		query := r.URL.RawQuery
-		allowlist := cfg.getQueryStringAllowlist(isClient)
-		if allowlist != nil {
-			// When an allowlist is configured, only keep the specified parameter keys.
-			// This avoids running the expensive obfuscation regex entirely.
-			query = filterQueryStringByAllowlist(query, allowlist)
-		} else if cfg.useDefaultObfuscator {
-			query = obfuscateQueryStringDefault(query)
-		} else if cfg.queryStringRegexp != nil {
-			query = cfg.queryStringRegexp.ReplaceAllLiteralString(query, "<redacted>")
-		}
-		if query != "" {
+		if query := obfuscateQueryString(r.URL.RawQuery, isClient); query != "" {
 			url = url + "?" + query
 		}
 	}
@@ -254,6 +267,26 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 		url = url + "#" + frag
 	}
 	return url
+}
+
+// obfuscateQueryString applies allowlist filtering or regexp-based obfuscation to rawQuery, in the priority
+// order used for the http.url span tag: an explicit allowlist (getQueryStringAllowlist) takes precedence over
+// the default obfuscator, which takes precedence over a custom DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP. It is
+// the single obfuscation code path shared by urlFromRequest and the exported ObfuscateQueryString /
+// ObfuscateClientQueryString.
+func obfuscateQueryString(rawQuery string, isClient bool) string {
+	if allowlist := cfg.getQueryStringAllowlist(isClient); allowlist != nil {
+		// When an allowlist is configured, only keep the specified parameter keys.
+		// This avoids running the expensive obfuscation regex entirely.
+		return filterQueryStringByAllowlist(rawQuery, allowlist)
+	}
+	if cfg.useDefaultObfuscator {
+		return obfuscateQueryStringDefault(rawQuery)
+	}
+	if cfg.queryStringRegexp != nil {
+		return cfg.queryStringRegexp.ReplaceAllLiteralString(rawQuery, "<redacted>")
+	}
+	return rawQuery
 }
 
 // filterQueryStringByAllowlist parses a raw query string and returns only the key=value

--- a/instrumentation/httptrace/httptrace.go
+++ b/instrumentation/httptrace/httptrace.go
@@ -215,18 +215,54 @@ func URLFromClientRequest(r *http.Request, queryString bool) string {
 	return urlFromRequest(r, queryString, true)
 }
 
-// ObfuscateQueryString returns rawQuery obfuscated using the same server-side rules as URLFromRequest: it honors
-// DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED, DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST[_SERVER], the default
-// obfuscator, and DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, in that order of precedence. It returns "" when query
-// string collection is disabled or rawQuery is empty.
-//
-// Use this for server-side integrations whose request type is not a *http.Request (e.g. fasthttp) and therefore
-// cannot call URLFromRequest directly.
-func ObfuscateQueryString(rawQuery string) string {
-	if !cfg.queryString || rawQuery == "" {
+// obfuscateQueryStringConfig holds the settings for one call to ObfuscateQueryString.
+type obfuscateQueryStringConfig struct {
+	isClient bool
+	// checkCollection reports whether the call consults DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED before
+	// obfuscating. URLFromRequest and URLFromClientRequest make that decision themselves through their
+	// queryString argument, so they disable this check.
+	checkCollection bool
+}
+
+// An ObfuscateQueryStringOption customizes ObfuscateQueryString.
+type ObfuscateQueryStringOption func(*obfuscateQueryStringConfig)
+
+// withClientAllowlist selects the client allowlist (DD_TRACE_HTTP_URL_QUERY_STRING_ALLOWLIST_CLIENT)
+// instead of the server one.
+func withClientAllowlist(c *obfuscateQueryStringConfig) {
+	c.isClient = true
+}
+
+// skipCollectionCheck makes the call ignore DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED.
+func skipCollectionCheck(c *obfuscateQueryStringConfig) {
+	c.checkCollection = false
+}
+
+// ObfuscateQueryString returns rawQuery with sensitive query parameters obfuscated, following the same rules
+// as URLFromRequest. It returns "" when query string collection is disabled or rawQuery is empty. Use it for
+// integrations whose request type is not a *http.Request, such as fasthttp.
+func ObfuscateQueryString(rawQuery string, opts ...ObfuscateQueryStringOption) string {
+	config := obfuscateQueryStringConfig{checkCollection: true}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&config)
+		}
+	}
+	if rawQuery == "" || (config.checkCollection && !cfg.queryString) {
 		return ""
 	}
-	return obfuscateQueryString(rawQuery, false)
+	if allowlist := cfg.getQueryStringAllowlist(config.isClient); allowlist != nil {
+		// When an allowlist is configured, only keep the specified parameter keys.
+		// This avoids running the expensive obfuscation regex entirely.
+		return filterQueryStringByAllowlist(rawQuery, allowlist)
+	}
+	if cfg.useDefaultObfuscator {
+		return obfuscateQueryStringDefault(rawQuery)
+	}
+	if cfg.queryStringRegexp != nil {
+		return cfg.queryStringRegexp.ReplaceAllLiteralString(rawQuery, "<redacted>")
+	}
+	return rawQuery
 }
 
 func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
@@ -249,7 +285,11 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 	}
 	// Collect the query string if we are allowed to report it and obfuscate it if possible/allowed
 	if queryString && r.URL.RawQuery != "" {
-		if query := obfuscateQueryString(r.URL.RawQuery, isClient); query != "" {
+		opts := []ObfuscateQueryStringOption{skipCollectionCheck}
+		if isClient {
+			opts = append(opts, withClientAllowlist)
+		}
+		if query := ObfuscateQueryString(r.URL.RawQuery, opts...); query != "" {
 			url = url + "?" + query
 		}
 	}
@@ -257,25 +297,6 @@ func urlFromRequest(r *http.Request, queryString bool, isClient bool) string {
 		url = url + "#" + frag
 	}
 	return url
-}
-
-// obfuscateQueryString applies allowlist filtering or regexp-based obfuscation to rawQuery, in the priority
-// order used for the http.url span tag: an explicit allowlist (getQueryStringAllowlist) takes precedence over
-// the default obfuscator, which takes precedence over a custom DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP. It is
-// the single obfuscation code path shared by urlFromRequest and the exported ObfuscateQueryString.
-func obfuscateQueryString(rawQuery string, isClient bool) string {
-	if allowlist := cfg.getQueryStringAllowlist(isClient); allowlist != nil {
-		// When an allowlist is configured, only keep the specified parameter keys.
-		// This avoids running the expensive obfuscation regex entirely.
-		return filterQueryStringByAllowlist(rawQuery, allowlist)
-	}
-	if cfg.useDefaultObfuscator {
-		return obfuscateQueryStringDefault(rawQuery)
-	}
-	if cfg.queryStringRegexp != nil {
-		return cfg.queryStringRegexp.ReplaceAllLiteralString(rawQuery, "<redacted>")
-	}
-	return rawQuery
 }
 
 // filterQueryStringByAllowlist parses a raw query string and returns only the key=value

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -582,6 +582,48 @@ func TestURLTagWithAllowlist(t *testing.T) {
 	}
 }
 
+func TestObfuscateQueryStringExported(t *testing.T) {
+	oldCfg := cfg
+	defer func() { cfg = oldCfg }()
+
+	t.Run("default obfuscator", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = true
+		cfg.useDefaultObfuscator = true
+		require.Equal(t, "<redacted>", ObfuscateQueryString("token=value"))
+	})
+	t.Run("query string disabled", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = false
+		cfg.useDefaultObfuscator = true
+		require.Equal(t, "", ObfuscateQueryString("token=value"))
+	})
+	t.Run("empty raw query", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = true
+		require.Equal(t, "", ObfuscateQueryString(""))
+	})
+	t.Run("custom regexp", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = true
+		cfg.useDefaultObfuscator = false
+		cfg.queryStringRegexp = regexp.MustCompile(`secret=\w+`)
+		require.Equal(t, "<redacted>", ObfuscateQueryString("secret=abc"))
+	})
+	t.Run("server allowlist", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = true
+		cfg.serverQueryStringAllowlist = map[string]struct{}{"p1": {}}
+		require.Equal(t, "p1=a", ObfuscateQueryString("p1=a&secret=abc"))
+	})
+	t.Run("client allowlist via ObfuscateClientQueryString", func(t *testing.T) {
+		cfg = oldCfg
+		cfg.queryString = true
+		cfg.clientQueryStringAllowlist = map[string]struct{}{"p1": {}}
+		require.Equal(t, "p1=a", ObfuscateClientQueryString("p1=a&secret=abc"))
+	})
+}
+
 func TestURLTagWithClientServerAllowlist(t *testing.T) {
 	makeRequest := func(query string) *http.Request {
 		return &http.Request{

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -616,12 +616,6 @@ func TestObfuscateQueryStringExported(t *testing.T) {
 		cfg.serverQueryStringAllowlist = map[string]struct{}{"p1": {}}
 		require.Equal(t, "p1=a", ObfuscateQueryString("p1=a&secret=abc"))
 	})
-	t.Run("client allowlist via ObfuscateClientQueryString", func(t *testing.T) {
-		cfg = oldCfg
-		cfg.queryString = true
-		cfg.clientQueryStringAllowlist = map[string]struct{}{"p1": {}}
-		require.Equal(t, "p1=a", ObfuscateClientQueryString("p1=a&secret=abc"))
-	})
 }
 
 func TestURLTagWithClientServerAllowlist(t *testing.T) {

--- a/instrumentation/httptrace/httptrace_test.go
+++ b/instrumentation/httptrace/httptrace_test.go
@@ -582,7 +582,7 @@ func TestURLTagWithAllowlist(t *testing.T) {
 	}
 }
 
-func TestObfuscateQueryStringExported(t *testing.T) {
+func TestObfuscateQueryString(t *testing.T) {
 	oldCfg := cfg
 	defer func() { cfg = oldCfg }()
 


### PR DESCRIPTION
## What does this PR do?

The `contrib/valyala/fasthttp` integration set the `http.url` span tag from `fctx.URI().FullURI()` — the full, raw request URI, including its query string — bypassing the query-string obfuscation logic that every other net/http-based server integration (`net/http`, `gorilla/mux`, `go-chi`, `gin`, `echo`, ...) routes through via `instrumentation/httptrace.URLFromRequest`.

Secrets passed as query parameters (e.g. `?api_key=`, `?token=`, `?password=`) were sent to the Agent and indexed in APM verbatim, for any route served by a fasthttp server instrumented with dd-trace-go (manually via `fasthttptrace.WrapHandler`, or automatically via Orchestrion's `fasthttp.Server.Serve` hook). The standard mitigations (`DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED`, `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`) had no effect on this integration.

`contrib/gofiber/fiber.v2` also wraps fasthttp under the hood but only tags `ext.HTTPURL` with the path (no query string), so it was not affected and needs no change.

## Why?

- `instrumentation/httptrace`'s obfuscation logic (allowlist filtering, default obfuscator, custom regexp) was entirely unexported, and only usable via `URLFromRequest`/`URLFromClientRequest`, both of which take a `*http.Request`. fasthttp's `*fasthttp.RequestCtx` isn't one, so the fasthttp integration couldn't reuse it and built the tag from `FullURI()` directly instead.
- Rather than reimplementing obfuscation in the fasthttp package (risking drift from the canonical behavior), this exposes the existing shared logic as a small public function, `ObfuscateQueryString`, for integrations whose request type isn't a `*http.Request`. `urlFromRequest` itself is refactored to delegate to the same underlying helper, so there is exactly one obfuscation code path shared by both callers.
- The fasthttp integration now builds `http.url` from `scheme://host+path` (using `PathOriginal()`, the as-received wire form — the closest fasthttp equivalent of `url.URL.EscapedPath()`) plus the query string run through `ObfuscateQueryString`, so it now honors `DD_TRACE_HTTP_URL_QUERY_STRING_DISABLED`, `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`, and the allowlist env vars like every other server integration. As a side effect, using `PathOriginal()` instead of the old `FullURI()`-derived path means `http.url` now reports the raw wire path (no dot-segment collapsing, no `%2F` decoding) instead of a normalized one — consistent with how `url.URL.EscapedPath()` behaves for the other server integrations, but a change from this integration's own prior behavior.

## Reviewer notes

- No `go.mod`/`go.sum` changes: `contrib/valyala/fasthttp` already requires and locally replaces the root `v2` module that contains `instrumentation/httptrace`.
- Tests added in both packages: `instrumentation/httptrace/httptrace_test.go` covers the new exported function directly (default obfuscator, disabled, empty input, custom regexp, allowlist); `contrib/valyala/fasthttp/fasthttp_test.go` adds end-to-end tests against a real fasthttp server covering the same cases, mirroring the existing `t.Setenv` + `ResetCfg()` pattern used in other contrib tests (e.g. `go-chi`).
- `TestTrace200`'s existing assertion on the no-query-string case is unchanged — the new URL-building logic reduces to the same `scheme://host+path` output when there's no query string.

