### PR TITLE
fix(contrib/valyala/fasthttp): stop leaking response body into span error tag on 5xx

### DIFF
--- a/contrib/valyala/fasthttp/fasthttp.go
+++ b/contrib/valyala/fasthttp/fasthttp.go
@@ -67,7 +67,7 @@ func wrapHandler(h fasthttp.RequestHandler, opts ...Option) fasthttp.RequestHand
 		span.SetTag(ext.ResourceName, cfg.resourceNamer(fctx))
 		status := fctx.Response.StatusCode()
 		if cfg.isStatusError(status) {
-			span.SetTag(ext.ErrorNoStackTrace, fmt.Errorf("%d: %s", status, string(fctx.Response.Body())))
+			span.SetTag(ext.ErrorNoStackTrace, fmt.Errorf("%d: %s", status, fasthttp.StatusMessage(status)))
 		}
 		span.SetTag(ext.HTTPCode, strconv.Itoa(status))
 	}

--- a/contrib/valyala/fasthttp/fasthttp_test.go
+++ b/contrib/valyala/fasthttp/fasthttp_test.go
@@ -152,8 +152,9 @@ func TestStatusError(t *testing.T) {
 	require.Len(t, spans, 1)
 	span := spans[0]
 	assert.Equal("500", span.Tag(ext.HTTPCode))
-	wantErr := fmt.Sprintf("%d: %s", 500, errMsg)
+	wantErr := fmt.Sprintf("%d: %s", 500, fasthttp.StatusMessage(500))
 	assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
+	assert.NotContains(span.Tag(ext.ErrorMsg), errMsg, "response body must not be leaked into the error tag")
 }
 
 // Test that users can customize which HTTP status codes are considered an error
@@ -177,7 +178,7 @@ func TestWithStatusCheck(t *testing.T) {
 		span := spans[0]
 		assert.Equal("600", span.Tag(ext.HTTPCode))
 		require.Contains(t, span.Tags(), ext.ErrorMsg)
-		wantErr := fmt.Sprintf("%d: %s", 600, errMsg)
+		wantErr := fmt.Sprintf("%d: %s", 600, fasthttp.StatusMessage(600))
 		assert.Equal(wantErr, span.Tag(ext.ErrorMsg))
 	})
 	t.Run("notError", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- The `valyala/fasthttp` integration was setting the span's `error.message` tag to the **full, unbounded, unredacted HTTP response body** whenever the handler returned a status matching `cfg.isStatusError` (default: >=500).
- Applications with verbose error responses (stack traces, DB DSNs, internal error JSON) leaked that content into APM traces, visible to anyone with APM read access. No other server integration in this repo captures the response body this way — they all report only `"<code>: <reason phrase>"`.
- Replaces `string(fctx.Response.Body())` with `fasthttp.StatusMessage(status)`, matching the pattern already used by the `net/http`-based integrations (`instrumentation/httptrace/httptrace.go`).

## Test plan

- [x] Updated `TestStatusError` and `TestWithStatusCheck/isError` in `contrib/valyala/fasthttp/fasthttp_test.go` to expect the status reason phrase instead of the response body, plus an explicit assertion that the body text is no longer present in the tag.
- [x] `go test ./...` passes for `contrib/valyala/fasthttp`.
- [x] `go vet ./...` clean.

[APMSP-3531]: https://datadoghq.atlassian.net/browse/APMSP-3531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ