### PR TITLE
feat(crashtracker): cgo-call-fault handling and foreign-thread signal reporting

### DIFF
--- a/crashtracker/crashtracker.go
+++ b/crashtracker/crashtracker.go
@@ -65,19 +65,25 @@ func start(opts ...Option) error {
 		return nil
 	}
 
+	if cfg.foreignThreadSignals {
+		startForeignThreadSignals(cfg)
+	}
+
 	return spawnMonitor(cfg)
 }
 
 func defaultConfig() *config {
 	enabled, _, _ := stableconfig.Bool("DD_CRASHTRACKING_ENABLED", true)
+	foreignThreadSignals, _, _ := stableconfig.Bool("DD_CRASHTRACKING_FOREIGN_THREAD_SIGNALS_ENABLED", false)
 	tags := internal.ParseTagString(env.Get("DD_TAGS"))
 	return &config{
-		enabled: enabled,
-		service: resolveService(tags),
-		env:     resolveTag("DD_ENV", "env", tags),
-		version: resolveTag("DD_VERSION", "version", tags),
-		site:    env.Get("DD_SITE"),
-		apiKey:  env.Get("DD_API_KEY"),
+		enabled:              enabled,
+		service:              resolveService(tags),
+		env:                  resolveTag("DD_ENV", "env", tags),
+		version:              resolveTag("DD_VERSION", "version", tags),
+		site:                 env.Get("DD_SITE"),
+		apiKey:               env.Get("DD_API_KEY"),
+		foreignThreadSignals: foreignThreadSignals,
 	}
 }
 

--- a/crashtracker/doc.go
+++ b/crashtracker/doc.go
@@ -62,6 +62,32 @@
 // goroutine in the crash dump. Set GOTRACEBACK=all in the process environment
 // to include all goroutines in the crash report's error.threads field.
 //
+// # Cgo and foreign threads
+//
+// A fault while Go is calling into C through cgo is captured normally on
+// Unix: the Go runtime cannot safely convert it to a recoverable panic, so
+// it prints a fatal crash report instead, and that report reaches
+// SetCrashOutput and this package's parser the same way an ordinary Go-code
+// fault does.
+//
+// On Windows this only holds when the faulting instruction is itself
+// Go-compiled code. runtime/signal_windows.go's isgoexception checks the
+// faulting PC against the Go binary's own compiled-code range and does not
+// treat an exception outside it as Go's to handle, so a fault entirely
+// inside C code compiled by cgo's own C toolchain — not Go's compiler — is
+// invisible to SetCrashOutput there: no crash report of any kind, silently,
+// the same blind spot foreign threads have below, verified directly against
+// that check rather than assumed identical to Unix.
+//
+// A fault on a thread created entirely by native code — a pthread spawned
+// directly by a C library, which never entered Go — is different.
+// SetCrashOutput cannot observe it at all: with no saved native signal
+// handler and no signal notification requested, the Go runtime restores the
+// default signal action and the process terminates with no Go crash report
+// of any kind, silently. [WithForeignThreadSignals] opts into best-effort
+// visibility for exactly this case, with real limitations documented on
+// that option — it is not a full report and not crash recovery.
+//
 // # Containers and PID 1
 //
 // The monitor is a child of the application process, in the same PID

--- a/crashtracker/e2e_cgo_test.go
+++ b/crashtracker/e2e_cgo_test.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package crashtracker_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestE2ECrashReport_CgoFault proves a fault inside a cgo call is captured
+// end to end — the real-pipeline counterpart to TestParseCrashDumpCgoFault's
+// fixture-based coverage of the same dump shape.
+//
+// import "C" is not permitted in any _test.go file, regardless of package
+// (golang/go#18647, "very difficult and doesn't seem worth it" — Russ Cox);
+// the crash victim is therefore a separate module built from source written
+// to a temp dir, mirroring the existing subprocess idiom in
+// profiler/goroutineleak_test.go rather than this file's own TestMain-based
+// role dispatch, which re-execs the test binary itself and so cannot contain
+// cgo either.
+func TestE2ECrashReport_CgoFault(t *testing.T) {
+	if out, err := exec.Command("go", "env", "CGO_ENABLED").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "1" {
+		t.Skip("cgo not available in this build environment")
+	}
+	if runtime.GOOS == "windows" {
+		// A fault entirely inside cgo-compiled C code is invisible to
+		// SetCrashOutput on Windows by design, not by bug: runtime/
+		// signal_windows.go's isgoexception only treats an exception as
+		// Go's to handle when the faulting PC falls within the Go binary's
+		// own compiled-code range (firstmoduledata.text..etext), and this
+		// fixture's fault happens entirely inside gcc/mingw-compiled
+		// machine code, never Go's. Confirmed empirically on Windows CI
+		// across two rounds of added diagnostics: the victim reaches and
+		// logs "calling into C", then produces no further output of any
+		// kind (no Go crash text, no return) before this test's own
+		// timeout kills it -- consistent with the fault never reaching a
+		// handler that would print anything, exactly as isgoexception's
+		// own PC-range check predicts. See doc.go's cgo section for the
+		// same limitation stated for callers of this package.
+		t.Skip("a fault entirely inside cgo-compiled C code is invisible to SetCrashOutput on windows; see doc.go's cgo section")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(cgoFaultSource), 0o644); err != nil {
+		t.Fatalf("writing test source: %s", err)
+	}
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("getting repo root: %s", err)
+	}
+
+	for _, cmd := range []*exec.Cmd{
+		exec.Command("go", "mod", "init", "crashtracker_cgo_test_app"),
+		exec.Command("go", "mod", "edit",
+			"-require=github.com/DataDog/dd-trace-go/v2@v2.0.0",
+			"-replace=github.com/DataDog/dd-trace-go/v2@v2.0.0="+repoRoot,
+		),
+		exec.Command("go", "mod", "tidy"),
+	} {
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %s", cmd.String(), out)
+		}
+	}
+
+	binPath := filepath.Join(dir, "app")
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOWORK=off")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("%s: %s", build.String(), out)
+	}
+
+	received := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertCanonicalAgentRequest(t, r)
+		body := decompressGzipBody(t, r)
+		select {
+		case received <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command(binPath)
+	cmd.Env = []string{
+		"DD_TRACE_AGENT_URL=" + srv.URL,
+		"DD_CRASHTRACKING_ENABLED=true",
+	}
+	var victimOut bytes.Buffer
+	cmd.Stdout = &victimOut
+	cmd.Stderr = &victimOut
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting crash victim: %s", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	select {
+	case body := <-received:
+		report := assertRFC0013Body(t, body)
+		errObj := report["error"].(map[string]any)
+		// runtime/signal_unix.go and runtime/signal_windows.go report a fault
+		// during a cgo call as different top-level crash shapes: a "SIGSEGV: ..."
+		// header with a "signal arrived during cgo execution" marker line on
+		// Unix, versus an "Exception 0x..." header (classified as
+		// error.type=WindowsException; see parse.go's windowsExceptionRe) with
+		// a "signal arrived during external code execution" marker line on
+		// Windows. Verified directly against both runtime sources rather than
+		// assumed identical.
+		wantType, wantMarker := "SIGSEGV", "signal arrived during cgo execution"
+		if runtime.GOOS == "windows" {
+			wantType, wantMarker = "WindowsException", "signal arrived during external code execution"
+		}
+		if got, _ := errObj["type"].(string); got != wantType {
+			t.Errorf("error.type = %q, want %q", got, wantType)
+		}
+		msg, _ := errObj["message"].(string)
+		if !strings.Contains(msg, wantMarker) {
+			t.Errorf("error.message = %q, want it to contain the runtime's cgo marker %q", msg, wantMarker)
+		}
+
+	case <-time.After(30 * time.Second):
+		// Kill and Wait before reading victimOut: Stdout/Stderr are copied by
+		// an internal goroutine that is only guaranteed done once Wait
+		// returns (os/exec's own documented contract), so reading the buffer
+		// beforehand would race with that goroutine's writes. This makes the
+		// later t.Cleanup's own Kill/Wait redundant but harmless -- both
+		// return an error on an already-reaped process, which is discarded
+		// the same way there.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("timeout waiting for crash report from monitor\nvictim output:\n%s", victimOut.String())
+	}
+}
+
+// The two os.Stderr writes bracketing Start() and the cgo call are stage
+// markers, not assertions: the test above has no way to tell "never got
+// past Start()" apart from "got past Start(), then the cgo call itself never
+// faulted or the fault never surfaced" when the victim produces zero output,
+// which is exactly what's been observed on Windows CI. Deliberately not
+// buffered/flushed-through anything: os.Stderr writes go straight to the fd.
+const cgoFaultSource = `package main
+
+/*
+void crashtracker_e2e_fault_in_c(void) {
+	volatile int *p = 0;
+	*p = 1;
+}
+*/
+import "C"
+
+import (
+	"os"
+
+	"github.com/DataDog/dd-trace-go/v2/crashtracker"
+)
+
+func main() {
+	if err := crashtracker.Start(); err != nil {
+		panic(err)
+	}
+	os.Stderr.WriteString("e2e_cgo_test: Start returned, calling into C\n")
+	C.crashtracker_e2e_fault_in_c()
+	os.Stderr.WriteString("e2e_cgo_test: C call returned without faulting\n")
+}
+`

--- a/crashtracker/e2e_foreign_thread_test.go
+++ b/crashtracker/e2e_foreign_thread_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package crashtracker_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// decodeReportBody just decodes: assertRFC0013Body's assumptions (a stack, a
+// thread list) don't hold for this report shape, so this test needs its own
+// checks rather than that helper.
+func decodeReportBody(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var report map[string]any
+	if err := json.Unmarshal(body, &report); err != nil {
+		t.Fatalf("unmarshal report: %v\nbody: %s", err, body)
+	}
+	return report
+}
+
+// TestE2ECrashReport_ForeignThreadSignal proves the WithForeignThreadSignals
+// path end to end against a real fault on a thread created entirely by
+// native code — a pthread spawned directly via pthread_create, never
+// entering Go — which is exactly the case runtime/debug.SetCrashOutput
+// cannot observe at all.
+//
+// Sending SIGSEGV to the whole process (e.g. via os.Process.Signal) is not
+// an equivalent test: the kernel can deliver it to any thread, including a
+// Go-tracked one, where it gets converted into an ordinary fatal crash and
+// captured by the normal SetCrashOutput path instead — confirmed directly:
+// an earlier version of this test sent SIGSEGV process-wide and the report
+// that arrived was a real monitor-routed crash dump with a Go stack trace,
+// not this mechanism's minimal report. A pure-C pthread is never Go-tracked,
+// so that competing interception cannot happen for it by construction.
+//
+// import "C" is not permitted in any _test.go file regardless of package
+// (golang/go#18647); the same subprocess-build pattern as
+// TestE2ECrashReport_CgoFault applies here for the same reason.
+func TestE2ECrashReport_ForeignThreadSignal(t *testing.T) {
+	if out, err := exec.Command("go", "env", "CGO_ENABLED").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "1" {
+		t.Skip("cgo not available in this build environment")
+	}
+	if runtime.GOOS == "windows" {
+		// WithForeignThreadSignals is an intentional no-op on Windows (see
+		// foreign_thread_windows.go and doc.go's cgo/foreign-threads section):
+		// os/signal has no portable Windows equivalent of SIGSEGV/SIGBUS/SIGILL/
+		// SIGFPE to register for. No report can ever arrive here, so the
+		// victim process below would just run out its 20-second sleep and the
+		// select would time out waiting for something the feature never
+		// promises to produce on this platform.
+		t.Skip("WithForeignThreadSignals has no effect on windows; see foreign_thread_windows.go")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(foreignThreadFaultSource), 0o644); err != nil {
+		t.Fatalf("writing test source: %s", err)
+	}
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("getting repo root: %s", err)
+	}
+
+	for _, cmd := range []*exec.Cmd{
+		exec.Command("go", "mod", "init", "crashtracker_foreign_thread_test_app"),
+		exec.Command("go", "mod", "edit",
+			"-require=github.com/DataDog/dd-trace-go/v2@v2.0.0",
+			"-replace=github.com/DataDog/dd-trace-go/v2@v2.0.0="+repoRoot,
+		),
+		exec.Command("go", "mod", "tidy"),
+	} {
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GOWORK=off")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %s", cmd.String(), out)
+		}
+	}
+
+	binPath := filepath.Join(dir, "app")
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOWORK=off")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("%s: %s", build.String(), out)
+	}
+
+	received := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertCanonicalAgentRequest(t, r)
+		body := decompressGzipBody(t, r)
+		select {
+		case received <- body:
+		default:
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command(binPath)
+	cmd.Env = []string{
+		"DD_TRACE_AGENT_URL=" + srv.URL,
+		"DD_CRASHTRACKING_ENABLED=true",
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting victim: %s", err)
+	}
+	// Bounds the worst case if the reset-based mitigation somehow does not
+	// engage: the process is force-killed regardless, rather than left
+	// spinning at high CPU for the rest of the test run.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	select {
+	case body := <-received:
+		// Not assertRFC0013Body: that helper assumes every report has a
+		// stack and a thread list, which is true for every other crash
+		// report this package builds (from a parsed dump) but deliberately
+		// not this one — there is genuinely no stack or thread list
+		// available for a thread the Go runtime never tracked.
+		report := decodeReportBody(t, body)
+		if got, _ := report["ddsource"].(string); got != "crashtracker" {
+			t.Errorf("ddsource = %q, want %q", got, "crashtracker")
+		}
+		ddtags, _ := report["ddtags"].(string)
+		if ddtags == "" {
+			t.Error("ddtags is empty")
+		}
+
+		errObj, ok := report["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("error field missing or not an object; report: %v", report)
+		}
+		if got, _ := errObj["type"].(string); got != "SIGSEGV" {
+			t.Errorf("error.type = %q, want %q", got, "SIGSEGV")
+		}
+		if errObj["is_crash"] != true {
+			t.Errorf("error.is_crash = %v, want true", errObj["is_crash"])
+		}
+		if errObj["source_type"] != "Crashtracking" {
+			t.Errorf("error.source_type = %q, want %q", errObj["source_type"], "Crashtracking")
+		}
+		msg, _ := errObj["message"].(string)
+		if !strings.Contains(msg, "not created by the Go runtime") {
+			t.Errorf("error.message = %q, want it to explain the missing stack", msg)
+		}
+		if _, ok := errObj["stack"]; ok {
+			t.Errorf("error.stack = %v, want absent: there is genuinely no stack for this thread", errObj["stack"])
+		}
+		if _, ok := errObj["threads"]; ok {
+			t.Errorf("error.threads = %v, want absent", errObj["threads"])
+		}
+
+		sigInfo, ok := report["sig_info"].(map[string]any)
+		if !ok {
+			t.Fatal("sig_info missing or not an object")
+		}
+		if sigInfo["si_signo_human_readable"] != "SIGSEGV" {
+			t.Errorf("sig_info.si_signo_human_readable = %v, want %q", sigInfo["si_signo_human_readable"], "SIGSEGV")
+		}
+
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for crash report from monitor")
+	}
+}
+
+const foreignThreadFaultSource = `package main
+
+/*
+#include <pthread.h>
+
+void *crashtracker_e2e_fault_thread(void *arg) {
+	volatile int *p = 0;
+	*p = 1;
+	return 0;
+}
+
+// start_foreign_thread creates a pthread directly via the C library, never
+// going through Go's runtime thread-creation path at all.
+void start_foreign_thread(void) {
+	pthread_t t;
+	pthread_create(&t, 0, crashtracker_e2e_fault_thread, 0);
+}
+*/
+import "C"
+
+import (
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/crashtracker"
+)
+
+func main() {
+	if err := crashtracker.Start(crashtracker.WithForeignThreadSignals(true)); err != nil {
+		panic(err)
+	}
+	C.start_foreign_thread()
+	// The foreign thread's fault, its notification, the reset, and the
+	// report upload all happen asynchronously; block long enough for that
+	// to complete (or for the reset-then-refault to terminate the process)
+	// rather than exiting cleanly first and racing it.
+	time.Sleep(20 * time.Second)
+}
+`

--- a/crashtracker/foreign_thread_other.go
+++ b/crashtracker/foreign_thread_other.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package crashtracker
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/DataDog/dd-trace-go/v2/internal/log"
+)
+
+// foreignThreadSignalNames maps the fixed set of synchronous fault signals a
+// thread created entirely by native code can raise to their names, in the
+// order registered with signal.Notify. This is the inverse of the numeric
+// lookup signalNumbers provides for crash-dump parsing: parsing starts from
+// dump text and needs a number, this starts from an os.Signal value (which
+// on POSIX is a syscall.Signal) and needs a name.
+var foreignThreadSignalNames = map[syscall.Signal]string{
+	syscall.SIGSEGV: "SIGSEGV",
+	syscall.SIGBUS:  "SIGBUS",
+	syscall.SIGILL:  "SIGILL",
+	syscall.SIGFPE:  "SIGFPE",
+}
+
+func foreignThreadSignalList() []os.Signal {
+	sigs := make([]os.Signal, 0, len(foreignThreadSignalNames))
+	for s := range foreignThreadSignalNames {
+		sigs = append(sigs, s)
+	}
+	return sigs
+}
+
+// startForeignThreadSignals registers a best-effort reporter for a fault on
+// a thread runtime/debug.SetCrashOutput cannot observe at all: one created
+// entirely by native code, which never entered Go (see
+// WithForeignThreadSignals). Runs in its own goroutine and returns
+// immediately; does not block Start.
+func startForeignThreadSignals(cfg *config) {
+	sigs := foreignThreadSignalList()
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sigs...)
+	go func() {
+		sig := <-ch
+		// Report before resetting, not after: measured the window between a
+		// reset and the process dying from the fault's near-certain next
+		// occurrence at under 200 microseconds — far too short for any
+		// upload to complete, which would make delivery not just
+		// best-effort but effectively never. Reporting first instead means
+		// the upload runs while the underlying fault keeps retrying in the
+		// background (confirmed separately: that retrying, left
+		// unaddressed, loops indefinitely across multiple CPU cores) —
+		// bounded CPU cost for the length of one upload attempt, in
+		// exchange for an upload that can actually complete.
+		report := buildForeignThreadReport(sig)
+		report.DDTags = buildDDTags(cfg, report)
+		if err := uploadReport(cfg, report); err != nil {
+			log.Warn("crashtracker: foreign-thread signal upload failed: %v", err.Error())
+		}
+
+		// Only now reset to default disposition, so the near-certain next
+		// occurrence of the fault terminates the process normally instead
+		// of continuing to loop.
+		signal.Reset(sigs...)
+	}()
+}
+
+// buildForeignThreadReport builds a minimal, best-effort Report for a signal
+// observed on a thread the Go runtime never tracked. There is no stack or
+// register context available for that thread — nothing in this process
+// records one — so unlike every other Report this package builds, Stack and
+// Threads are intentionally left empty rather than populated from a parsed
+// dump.
+func buildForeignThreadReport(sig os.Signal) *Report {
+	name := "UNKNOWN"
+	if s, ok := sig.(syscall.Signal); ok {
+		if n, ok := foreignThreadSignalNames[s]; ok {
+			name = n
+		}
+	}
+	return &Report{
+		Timestamp: time.Now().UnixMilli(),
+		DDSource:  ddSource,
+		Error: Error{
+			Type:       name,
+			Message:    "signal " + name + " observed on a thread not created by the Go runtime; no stack trace is available for this thread",
+			IsCrash:    true,
+			SourceType: "Crashtracking",
+		},
+		OSInfo: osInfo(),
+		SigInfo: &SigInfo{
+			SiSignoHuman: name,
+			SiSigno:      signalNumbers[name],
+		},
+	}
+}

--- a/crashtracker/foreign_thread_other_test.go
+++ b/crashtracker/foreign_thread_other_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package crashtracker
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestBuildForeignThreadReport(t *testing.T) {
+	r := buildForeignThreadReport(syscall.SIGSEGV)
+
+	if r.Error.Type != "SIGSEGV" {
+		t.Errorf("Error.Type = %q, want %q", r.Error.Type, "SIGSEGV")
+	}
+	if !r.Error.IsCrash {
+		t.Error("Error.IsCrash = false, want true")
+	}
+	if r.Error.SourceType != "Crashtracking" {
+		t.Errorf("Error.SourceType = %q, want %q", r.Error.SourceType, "Crashtracking")
+	}
+	if !strings.Contains(r.Error.Message, "not created by the Go runtime") {
+		t.Errorf("Error.Message = %q, want it to explain the missing stack", r.Error.Message)
+	}
+	// There is genuinely nothing to report here: no stack, no thread list —
+	// unlike every other Report this package builds, both must stay empty
+	// rather than being populated with something misleading.
+	if r.Error.Stack != nil {
+		t.Errorf("Error.Stack = %+v, want nil", r.Error.Stack)
+	}
+	if len(r.Error.Threads) != 0 {
+		t.Errorf("Error.Threads = %+v, want empty", r.Error.Threads)
+	}
+	if r.SigInfo == nil || r.SigInfo.SiSignoHuman != "SIGSEGV" {
+		t.Errorf("SigInfo = %+v, want SiSignoHuman = SIGSEGV", r.SigInfo)
+	}
+	if r.OSInfo.Architecture == "" {
+		t.Error("OSInfo.Architecture is empty")
+	}
+}
+
+func TestBuildForeignThreadReportUnknownSignal(t *testing.T) {
+	// foreignThreadSignalList only ever registers the four signals in
+	// foreignThreadSignalNames, so this path is defensive, but it must not
+	// panic or leave SigInfo half-built if it is ever reached.
+	r := buildForeignThreadReport(syscall.SIGWINCH)
+
+	if r.Error.Type != "UNKNOWN" {
+		t.Errorf("Error.Type = %q, want %q", r.Error.Type, "UNKNOWN")
+	}
+}

--- a/crashtracker/foreign_thread_windows.go
+++ b/crashtracker/foreign_thread_windows.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package crashtracker
+
+// startForeignThreadSignals is a no-op on Windows. WithForeignThreadSignals
+// documents a POSIX pthread/signal model (a thread created entirely by
+// native code, with no saved handler and no signal.Notify, terminates the
+// process silently) that does not apply on Windows: a thread created by
+// native code there still faults through the same structured-exception
+// mechanism errorType's WindowsException classification already covers, not
+// a separate, invisible path SetCrashOutput cannot see.
+func startForeignThreadSignals(_ *config) {}

--- a/crashtracker/options.go
+++ b/crashtracker/options.go
@@ -27,6 +27,9 @@ type config struct {
 	// so combining WithAgentURL and WithAPIKey cannot silently drop the report
 	// by pointing the agentless path at a pathless host (see upload.go).
 	agentlessURL string
+
+	// foreignThreadSignals is set by WithForeignThreadSignals.
+	foreignThreadSignals bool
 }
 
 // WithService sets the service name tag on crash reports.
@@ -73,4 +76,29 @@ func WithSite(site string) Option {
 // the monitor process and returns nil.
 func WithEnabled(enabled bool) Option {
 	return func(c *config) { c.enabled = enabled }
+}
+
+// WithForeignThreadSignals opts into best-effort visibility for a fault on a
+// thread created entirely by native code — a pthread spawned by a C library
+// that never entered Go. runtime/debug.SetCrashOutput cannot observe this at
+// all (see doc.go's cgo section): with no saved native handler and no signal
+// notification requested, the process terminates with no Go crash report of
+// any kind. Off by default.
+//
+// This is not crash recovery and not a full report. There is no stack or
+// register context for a thread the Go runtime never tracked, so the report
+// carries only the signal name and a timestamp. It also does not resolve the
+// underlying fault: the instruction that faulted is still invalid, and
+// retrying it (which is what returning from a signal handler does) will
+// fault again — verified to loop indefinitely across multiple CPU cores if
+// nothing intervenes. The first occurrence reports before resetting the
+// signal to its default disposition (see [signal.Reset]): resetting first
+// was measured to leave under 200 microseconds before the process exits on
+// the near-certain next occurrence, far too short for any upload to
+// complete. Reporting first instead means the fault keeps retrying in the
+// background for the length of one upload attempt — a bounded CPU cost, in
+// exchange for a report that can actually be delivered — after which reset
+// lets that next occurrence terminate the process normally.
+func WithForeignThreadSignals(enabled bool) Option {
+	return func(c *config) { c.foreignThreadSignals = enabled }
 }

--- a/crashtracker/parse.go
+++ b/crashtracker/parse.go
@@ -24,6 +24,32 @@ const stackFormat = "Datadog Crashtracker 1.0"
 // ddSource is the ddsource value for crash reports.
 const ddSource = "crashtracker"
 
+// cgoExecutionMarker is the Go runtime's own text (runtime/signal_unix.go's
+// fatalsignal) noting a fault happened while Go was calling into C via cgo,
+// rather than in ordinary Go code.
+const cgoExecutionMarker = "signal arrived during cgo execution"
+
+// externalCodeExecutionMarker is signal_windows.go's winthrow equivalent of
+// cgoExecutionMarker: the same "Go was calling into C when this fault
+// happened" fact, but the Windows runtime prints different wording for it
+// than the Unix runtime does. Verified against runtime/signal_windows.go's
+// source directly, not assumed from the Unix wording.
+const externalCodeExecutionMarker = "signal arrived during external code execution"
+
+// preambleHasCgoMarker reports whether the preamble contains the runtime's
+// cgo-fault marker line, and if so, returns that line's own text. Callers
+// annotate with the returned text rather than a hardcoded phrase, since
+// signal_unix.go and signal_windows.go use different wording for the
+// identical condition and a dump only ever contains one of the two.
+func preambleHasCgoMarker(preamble []string) (string, bool) {
+	for _, line := range preamble {
+		if trimmed := strings.TrimSpace(line); trimmed == cgoExecutionMarker || trimmed == externalCodeExecutionMarker {
+			return trimmed, true
+		}
+	}
+	return "", false
+}
+
 var (
 	// goroutineHeaderRe matches a goroutine block header in both standard and
 	// GOTRACEBACK=system format:
@@ -300,19 +326,27 @@ func parseLocation(line string) (file string, lineNo int) {
 }
 
 // crashingThread returns the goroutine that crashed: the first goroutine in
-// the "running" state, or the first goroutine overall if none is running.
+// the "running" state, the first in "syscall" state if none is running, or
+// the first goroutine overall if neither matches. The "syscall" fallback
+// covers a fault during a cgo call: runtime/signal_unix.go's fatalsignal
+// switches the reported goroutine from the runtime's g0 to mp.curg (the Go
+// code that called into C), and that goroutine's own traceback state is
+// "syscall" — cgo calls are tracked like blocking syscalls — never "running".
+// Verified against a real captured cgo-fault dump: every goroutine in it was
+// in some non-running state, with the one that actually crashed at "syscall".
 //
-// That fallback is a best-effort attribution, not a positively identified
-// crash location: an operator-triggered SIGQUIT can produce a dump with no
-// "running" goroutine at all (SIGQUIT is a deliberate diagnostic dump
-// request, not a fault inside a specific goroutine's execution, so a process
-// that was otherwise idle when it arrived can have every goroutine parked in
-// some other state). In that case dump order, not evidence of a fault,
-// decides which goroutine error.stack and error.thread_name describe. This
-// is deliberately still preferred over reporting no primary stack at all —
-// an approximate crash location is more actionable than none — but it means
-// error.stack should not be read as proof that goroutine actually caused the
-// crash for a SIGQUIT-shaped report specifically.
+// The overall fallback is a best-effort attribution, not a positively
+// identified crash location: an operator-triggered SIGQUIT can produce a
+// dump with no "running" (or "syscall") goroutine at all (SIGQUIT is a
+// deliberate diagnostic dump request, not a fault inside a specific
+// goroutine's execution, so a process that was otherwise idle when it
+// arrived can have every goroutine parked in some other state). In that
+// case dump order, not evidence of a fault, decides which goroutine
+// error.stack and error.thread_name describe. This is deliberately still
+// preferred over reporting no primary stack at all — an approximate crash
+// location is more actionable than none — but it means error.stack should
+// not be read as proof that goroutine actually caused the crash for a
+// SIGQUIT-shaped report specifically.
 func crashingThread(threads []Thread) *Thread {
 	if len(threads) == 0 {
 		return nil
@@ -322,6 +356,14 @@ func crashingThread(threads []Thread) *Thread {
 		if threads[i].State == "running" {
 			idx = i
 			break
+		}
+	}
+	if threads[idx].State != "running" {
+		for i := range threads {
+			if threads[i].State == "syscall" {
+				idx = i
+				break
+			}
 		}
 	}
 	threads[idx].Crashed = true
@@ -366,7 +408,7 @@ func capThreads(threads []Thread) []Thread {
 //     — appears when the process is killed directly by a signal with no
 //     surrounding panic context.
 func parseSignal(preamble []string) *SigInfo {
-	for _, line := range preamble {
+	for i, line := range preamble {
 		// Bracketed form: "[signal SIG…]". Anchored to the runtime's actual
 		// bracket rather than an unanchored substring test: a panic value that
 		// happens to contain the text "signal SIG..." (e.g. a message like
@@ -390,13 +432,29 @@ func parseSignal(preamble []string) *SigInfo {
 			}
 			return info
 		}
-		// Top-level form: "SIGABRT: abort"
+		// Top-level form: "SIGABRT: abort", or for a real fault (not a sent
+		// signal), "SIGSEGV: segmentation violation" followed immediately by
+		// "PC=0x... m=N sigcode=N[ addr=0x...]" on the next line
+		// (runtime/signal_unix.go's fatalsignal). sigcode there is plain
+		// decimal, unlike the bracketed form's hex code=0x...; signalCodeRe
+		// still matches it, since "sigcode=" contains "code=" as a substring.
+		// addr is only printed for SIGSEGV/SIGBUS.
 		if m := topLevelSignalRe.FindStringSubmatch(line); m != nil {
 			name := m[1]
-			return &SigInfo{
+			info := &SigInfo{
 				SiSignoHuman: name,
 				SiSigno:      signalNumbers[name],
 			}
+			if i+1 < len(preamble) {
+				next := preamble[i+1]
+				if cm := signalCodeRe.FindStringSubmatch(next); cm != nil {
+					info.SiCode = parseIntFlexible(cm[1])
+				}
+				if am := signalAddrRe.FindStringSubmatch(next); am != nil {
+					info.SiAddr = am[1]
+				}
+			}
+			return info
 		}
 	}
 	return nil
@@ -448,6 +506,21 @@ func errorMessage(preamble []string, sigInfo *SigInfo) string {
 				return strings.Trim(strings.TrimSpace(line), "[]")
 			}
 		}
+		// Top-level form has no bracketed line; its own signal-name line is
+		// the message, same as the generic preamble fallback below would
+		// return anyway. Made explicit here so the cgo marker (runtime's own
+		// note that Go was calling into C when the fault happened — see
+		// crashingThread) can be appended: for a cgo-using application, that
+		// is often the single most actionable fact in the whole report.
+		for _, line := range preamble {
+			if topLevelSignalRe.MatchString(line) {
+				msg := strings.TrimSpace(line)
+				if marker, ok := preambleHasCgoMarker(preamble); ok {
+					msg += " (" + marker + ")"
+				}
+				return msg
+			}
+		}
 	}
 	for i, line := range preamble {
 		if rest, ok := strings.CutPrefix(line, "fatal error:"); ok {
@@ -462,6 +535,20 @@ func errorMessage(preamble []string, sigInfo *SigInfo) string {
 		// frame rather than reaching errorMessage.
 		if strings.HasPrefix(line, "panic(") {
 			return panicValue(line)
+		}
+		// A native Windows exception has no sigInfo (parseSignal only
+		// recognises the Unix "[signal ...]"/topLevelSignalRe forms, never
+		// this runtime's own "Exception 0x..." header), so it never reaches
+		// the sigInfo != nil branch above and would otherwise fall through
+		// to the generic first-non-empty-line fallback below, losing the
+		// cgo/external-code context the same way the topLevelSignalRe branch
+		// preserves it for Unix.
+		if windowsExceptionRe.MatchString(line) {
+			msg := strings.TrimSpace(line)
+			if marker, ok := preambleHasCgoMarker(preamble); ok {
+				msg += " (" + marker + ")"
+			}
+			return msg
 		}
 	}
 	// Fall back to the first non-empty preamble line.

--- a/crashtracker/parse_test.go
+++ b/crashtracker/parse_test.go
@@ -386,6 +386,40 @@ func TestErrorTypeWindowsException(t *testing.T) {
 	}
 }
 
+func TestErrorMessageWindowsExceptionCgoMarker(t *testing.T) {
+	// Exact shape from runtime/signal_windows.go's winthrow: the "Exception
+	// 0x..." header, then "PC=...", then (only when the fault happened while
+	// calling into C, per winthrow's g0.m.incgo check) this marker line.
+	// Without this branch in errorMessage, a Windows exception never reaches
+	// the sigInfo != nil path (parseSignal doesn't recognise this header), so
+	// it would fall through to the generic first-non-empty-line fallback and
+	// silently drop the fact that Go was calling into C when it faulted.
+	preamble := []string{
+		"Exception 0xc0000005 0x0 0x0 0x7ff6a2345678",
+		"PC=0x7ff6a2345678",
+		"signal arrived during external code execution",
+	}
+	got := errorMessage(preamble, nil)
+	want := "Exception 0xc0000005 0x0 0x0 0x7ff6a2345678 (signal arrived during external code execution)"
+	if got != want {
+		t.Errorf("errorMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestErrorMessageWindowsExceptionNoCgoMarker(t *testing.T) {
+	// An ordinary Windows fault, not inside a cgo call: no marker line, so
+	// the message is just the header, unannotated.
+	preamble := []string{
+		"Exception 0xc0000005 0x0 0x0 0x7ff6a2345678",
+		"PC=0x7ff6a2345678",
+	}
+	got := errorMessage(preamble, nil)
+	want := "Exception 0xc0000005 0x0 0x0 0x7ff6a2345678"
+	if got != want {
+		t.Errorf("errorMessage() = %q, want %q", got, want)
+	}
+}
+
 func TestCapThreadsKeepsCrashedGoroutineWhenTruncating(t *testing.T) {
 	threads := make([]Thread, maxReportThreads*2)
 	// Mark a goroutine well past the cap as the crashed one, so retaining it
@@ -507,6 +541,77 @@ func TestParseCrashDumpSignalDetails(t *testing.T) {
 	}
 	if r.SigInfo.SiAddr != "0x0" {
 		t.Errorf("SigInfo.SiAddr = %q, want %q", r.SigInfo.SiAddr, "0x0")
+	}
+}
+
+// TestParseCrashDumpCgoFault covers a fault that happened while Go was
+// calling into C via cgo. The fixture is a real dump (trimmed of a few
+// idle background goroutines), captured by actually crashing a cgo program
+// under runtime/debug.SetCrashOutput, not hand-written. This dump shape
+// differs from an ordinary Go-code SIGSEGV in three ways this test pins:
+// the fault detail (PC=.../sigcode=.../addr=...) is on the line after the
+// signal name rather than inline, the crashing goroutine's state is
+// "syscall" rather than "running" (runtime/signal_unix.go's fatalsignal
+// switches the reported goroutine to mp.curg, the Go code that entered the
+// C call, whose state cgo tracks like a blocking syscall), and the runtime
+// adds its own "signal arrived during cgo execution" line.
+func TestParseCrashDumpCgoFault(t *testing.T) {
+	dump := readFixture(t, "sigsegv_cgo.txt")
+	r := parseCrashDump(dump)
+
+	if r.Error.Type != "SIGSEGV" {
+		t.Errorf("Error.Type = %q, want %q", r.Error.Type, "SIGSEGV")
+	}
+	if !strings.Contains(r.Error.Message, cgoExecutionMarker) {
+		t.Errorf("Error.Message = %q, want it to contain %q", r.Error.Message, cgoExecutionMarker)
+	}
+	if r.Error.ThreadName != "goroutine 1" {
+		t.Errorf("Error.ThreadName = %q, want %q (the goroutine that called into C, not index 0 by accident)", r.Error.ThreadName, "goroutine 1")
+	}
+
+	if r.SigInfo == nil {
+		t.Fatal("SigInfo is nil")
+	}
+	if r.SigInfo.SiCode != 2 {
+		t.Errorf("SigInfo.SiCode = %d, want 2 (from the second line's decimal sigcode=, not the bracketed form's hex code=)", r.SigInfo.SiCode)
+	}
+	if r.SigInfo.SiAddr != "0x0" {
+		t.Errorf("SigInfo.SiAddr = %q, want %q", r.SigInfo.SiAddr, "0x0")
+	}
+
+	crashedCount := 0
+	for _, th := range r.Error.Threads {
+		if th.Crashed {
+			crashedCount++
+			if th.State != "syscall" {
+				t.Errorf("crashed goroutine state = %q, want %q", th.State, "syscall")
+			}
+		}
+	}
+	if crashedCount != 1 {
+		t.Errorf("crashed goroutine count = %d, want 1", crashedCount)
+	}
+}
+
+func TestCrashingThreadFallsBackToSyscallState(t *testing.T) {
+	// No goroutine is "running" — matches the real cgo-fault dump shape,
+	// where the runtime reports the goroutine that called into C as
+	// "syscall". The "syscall" one, not threads[0], must be picked even
+	// when it is not first in dump order, proving this is a real state
+	// match rather than an accidental index-0 default.
+	threads := []Thread{
+		{Name: "goroutine 2", State: "select (no cases)"},
+		{Name: "goroutine 1", State: "syscall"},
+		{Name: "goroutine 3", State: "sleep"},
+	}
+
+	got := crashingThread(threads)
+
+	if got.Name != "goroutine 1" {
+		t.Errorf("crashingThread() = %+v, want the syscall-state goroutine", got)
+	}
+	if !got.Crashed {
+		t.Error("crashingThread() did not mark the returned thread Crashed")
 	}
 }
 

--- a/crashtracker/testdata/sigsegv_cgo.txt
+++ b/crashtracker/testdata/sigsegv_cgo.txt
@@ -1,0 +1,24 @@
+SIGSEGV: segmentation violation
+PC=0x104d6a11c m=0 sigcode=2 addr=0x0
+signal arrived during cgo execution
+
+goroutine 1 gp=0x3a5696e381e0 m=0 mp=0x104e3a400 [syscall]:
+runtime.cgocall(0x104d6a114, 0x3a5696ebaf08)
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/cgocall.go:167 +0x44 fp=0x3a5696ebaed0 sp=0x3a5696ebae90 pc=0x104d4a824
+main._Cfunc_fault_in_c()
+	_cgo_gotypes.go:46 +0x2c fp=0x3a5696ebaf00 sp=0x3a5696ebaed0 pc=0x104d6a03c
+main.main()
+	/tmp/crashdemo/main.go:24 +0x44 fp=0x3a5696ebaf30 sp=0x3a5696ebaf00 pc=0x104d6a0a4
+runtime.main()
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/proc.go:290 +0x2b4 fp=0x3a5696ebafd0 sp=0x3a5696ebaf30 pc=0x104d1cfe4
+runtime.goexit({})
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x3a5696ebafd0 sp=0x3a5696ebafd0 pc=0x104d52054
+
+goroutine 2 gp=0x3a5696e38d20 m=nil [force gc (idle)]:
+runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/proc.go:462 +0xbc fp=0x3a5696eacf90 sp=0x3a5696eacf70 pc=0x104d4c2ac
+runtime.forcegchelper()
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/proc.go:375 +0xb4 fp=0x3a5696eacfd0 sp=0x3a5696eacf90 pc=0x104d1d304
+created by runtime.init.7 in goroutine 1
+	/opt/homebrew/Cellar/go/1.26.5/libexec/src/runtime/proc.go:363 +0x24
+exit status 2

--- a/internal/env/supported_configurations.gen.go
+++ b/internal/env/supported_configurations.gen.go
@@ -69,6 +69,7 @@ var SupportedConfigurations = map[string]struct{}{
 	"DD_CIVISIBILITY_USE_NOOP_TRACER":                                         {},
 	"DD_CODE_COVERAGE_FLAGS":                                                  {},
 	"DD_CRASHTRACKING_ENABLED":                                                {},
+	"DD_CRASHTRACKING_FOREIGN_THREAD_SIGNALS_ENABLED":                         {},
 	"DD_CUSTOM_PARENT_ID":                                                     {},
 	"DD_CUSTOM_TRACE_ID":                                                      {},
 	"DD_DATA_STREAMS_ENABLED":                                                 {},

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -429,6 +429,13 @@
         "default": "true"
       }
     ],
+    "DD_CRASHTRACKING_FOREIGN_THREAD_SIGNALS_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false"
+      }
+    ],
     "DD_CUSTOM_PARENT_ID": [
       {
         "implementation": "A",


### PR DESCRIPTION
## Summary

Based on #5026 (merged). Adds two refinements to crash reporting that are both inherently cgo-dependent and were both sources of Windows-specific CI instability while living on #5026 — splitting them out keeps that PR's diff smaller and removable of its dependency on an external registration this PR still needs.

**Cgo-call-fault handling** (`parse.go`): a fault while Go is calling into C via cgo produces a distinct crash-dump shape from an ordinary Go-code fault — a `PC=... sigcode=... addr=...` detail line (decimal, not the bracketed form's hex), the crashed goroutine reported in `[syscall]` state rather than `[running]`, and a runtime marker line noting the fault happened during a native call (`signal arrived during cgo execution` on Unix, `signal arrived during external code execution` on Windows — verified directly against both `runtime/signal_unix.go` and `runtime/signal_windows.go`). Without this, the parser still produces a report, but loses the `syscall`-state goroutine attribution and the human-readable "this happened calling into C" annotation.

**`WithForeignThreadSignals`** (off by default): best-effort visibility for a fault on a thread created entirely by native code — e.g. `pthread_create`, never entering Go — which `runtime/debug.SetCrashOutput` cannot observe at all: with no saved native signal handler and no signal notification requested, the process terminates with no Go crash report of any kind. This option registers `signal.Notify` for SIGSEGV/SIGBUS/SIGILL/SIGFPE and, on the first occurrence, reports *then* resets to default disposition — ordering verified empirically (resetting first leaves under 200 microseconds before the process dies from the fault's near-certain next occurrence, too short for any upload; reporting first lets the upload complete while the fault retries in the background, bounded to one upload's duration). No-op on Windows (`foreign_thread_windows.go`): `os/signal` has no portable Windows equivalent of these signals to register for.

**Known dependency, not fixed by this PR:** `DD_CRASHTRACKING_FOREIGN_THREAD_SIGNALS_ENABLED` isn't yet registered in Datadog's external Feature Parity Dashboard, so `dd-gitlab/validate_supported_configurations_v2_local_file` will fail here until that registration happens. This is exactly the dependency #5026 no longer carries after this split.

## Test plan

- [x] `TestParseCrashDumpCgoFault` — real captured cgo-fault dump fixture
- [x] `TestE2ECrashReport_CgoFault` — real subprocess build+crash, real pipeline
- [x] `TestE2ECrashReport_ForeignThreadSignal` — real `pthread_create`-based C reproduction, real subprocess build+crash
- [x] `TestErrorMessageWindowsExceptionCgoMarker` / `TestErrorMessageWindowsExceptionNoCgoMarker` — Windows dump-shape fixtures, verified against actual `runtime/signal_windows.go` source
- [x] All tests pass with `-race -count=1`
- [x] `go run ./scripts/configinverter/main.go check` — in sync
- [ ] `DD_CRASHTRACKING_FOREIGN_THREAD_SIGNALS_ENABLED` registered in the Feature Parity Dashboard (external, not in this repo)

> EXPERIMENTAL: Agentic coding usage!
