### PR TITLE
fix: build metrics dropped dependency metrics

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install go-size-analyzer
         if: matrix.mode == 'standard'
         run: |
-          curl -L --fail "https://github.com/Zxilly/go-size-analyzer/releases/download/v1.13.0/go-size-analyzer_1.13.0_linux_amd64.tar.gz" -o gsa.tar.gz
+          curl -L --fail "https://github.com/Zxilly/go-size-analyzer/releases/download/v1.14.0/go-size-analyzer_1.14.0_linux_amd64.tar.gz" -o gsa.tar.gz
           tar -xzf gsa.tar.gz gsa
           chmod +x gsa
           echo "${{ github.workspace }}" >> "$GITHUB_PATH"

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -12,7 +12,9 @@ name: Build Metrics
 # - Warm module cache: runs go mod download (untimed) so measurement reflects compilation, not network
 # - Dependency attribution (standard mode only): go-size-analyzer breaks the binary down by
 #   vendor package, published as go.build.dependency_size_bytes.<dependency>, so a size
-#   regression can be traced to which dependency grew instead of just the binary total
+#   regression can be traced to which dependency grew instead of just the binary total.
+#   It also publishes go.build.dependency_total_size_bytes and go.build.dependency_count,
+#   the summed size and the count of all vendor packages, to track overall dependency bloat
 # - Datadog CI Visibility: publishes metrics and tags to job spans for dashboard trending and regression monitoring
 # - Runs on: Pull requests (when this file, scripts/*, orchestrion.yml, or any go.mod changes) and pushes to main
 # - Tags metrics by: build.toolchain, build.sample, build.cache, go.version, orchestrion.version

--- a/scripts/measure_build.sh
+++ b/scripts/measure_build.sh
@@ -19,8 +19,11 @@ set -euo pipefail
 # Output JSON includes all build_duration_samples (one per repeat) and a single
 # binary_size_bytes taken from the last build. In standard mode, if `gsa`
 # (go-size-analyzer) is on PATH, the JSON also includes dependency_sizes: the
-# top 10 vendor (third-party) packages contributing to that binary's size,
-# attributing size to specific dependencies instead of just the binary total.
+# top 10 vendor packages by size. The JSON also includes
+# dependency_total_size_bytes and dependency_count: the summed size and the
+# count of every vendor package, including packages outside the top 10.
+# These two fields attribute the binary size to specific dependencies and to
+# overall dependency bloat.
 #
 # Examples:
 #   scripts/measure_build.sh --sample net_http --mode standard
@@ -186,20 +189,24 @@ message "Durations: ${durations[*]}, size: $size bytes"
 # Dependency size attribution (standard mode only — orchestrion mode builds the
 # same source, so re-running the analysis there would just duplicate this data)
 DEPENDENCY_SIZES="[]"
+DEPENDENCY_TOTAL_SIZE_BYTES=0
+DEPENDENCY_COUNT=0
 if [[ "$MODE" == "standard" ]] && command -v gsa &> /dev/null; then
   message "Attributing binary size to dependencies with gsa..."
   bin_path="$OUT_DIR/$SAMPLE-$MODE.test"
   gsa_json="$OUT_DIR/gsa.json"
   if gsa "$bin_path" -f json --compact --no-disasm -o "$gsa_json"; then
+    # Filter vendor packages once. Reuse the result for the top-10 slice and the totals below.
+    VENDOR_PACKAGES=$(jq '[.packages | to_entries[] | select(.value.type == "vendor")]' "$gsa_json")
     DEPENDENCY_SIZES=$(jq '[
-      .packages
-      | to_entries
-      | map(select(.value.type == "vendor"))
-      | sort_by(-.value.size)
+      sort_by(-.value.size)
       | .[0:10]
       | .[]
       | { name: .key, metric_key: (.key | ascii_downcase | gsub("[^a-z0-9_]+"; "_")), size_bytes: .value.size }
-    ]' "$gsa_json")
+    ]' <<< "$VENDOR_PACKAGES")
+    DEPENDENCY_TOTAL_SIZE_BYTES=$(jq '[.[].value.size] | add // 0' <<< "$VENDOR_PACKAGES")
+    DEPENDENCY_COUNT=$(jq 'length' <<< "$VENDOR_PACKAGES")
+    message "  Dependencies: $DEPENDENCY_COUNT, total size: $DEPENDENCY_TOTAL_SIZE_BYTES bytes"
   else
     message "  gsa analysis failed; continuing without dependency_sizes"
   fi
@@ -216,8 +223,10 @@ JSON=$(jq -n \
   --argjson durations "$DURATION_ARRAY" \
   --argjson size "$size" \
   --argjson dependency_sizes "$DEPENDENCY_SIZES" \
+  --argjson dependency_total_size_bytes "$DEPENDENCY_TOTAL_SIZE_BYTES" \
+  --argjson dependency_count "$DEPENDENCY_COUNT" \
   --arg go_version "$GO_VERSION" \
-  '{ sample: $sample, mode: $mode, metrics: { build_duration_samples: $durations, binary_size_bytes: $size, dependency_sizes: $dependency_sizes }, go_version: $go_version }')
+  '{ sample: $sample, mode: $mode, metrics: { build_duration_samples: $durations, binary_size_bytes: $size, dependency_sizes: $dependency_sizes, dependency_total_size_bytes: $dependency_total_size_bytes, dependency_count: $dependency_count }, go_version: $go_version }')
 
 # Add orchestrion version if in orchestrion mode
 if [[ "$MODE" == "orchestrion" ]]; then

--- a/scripts/publish_build_metrics.sh
+++ b/scripts/publish_build_metrics.sh
@@ -61,12 +61,19 @@ mapfile -t DEP_NAMES < <(jq -r '.metrics.dependency_sizes[]?.name' "$METRICS_FIL
 mapfile -t DEP_KEYS < <(jq -r '.metrics.dependency_sizes[]?.metric_key' "$METRICS_FILE")
 mapfile -t DEP_SIZES < <(jq -r '.metrics.dependency_sizes[]?.size_bytes' "$METRICS_FILE")
 
+# Total dependency bloat: the summed size and the count of every vendor
+# package. When gsa does not run, in orchestrion mode or after a failed 
+# analysis, the value is 0.
+DEPENDENCY_TOTAL_SIZE_BYTES=$(jq -r '.metrics.dependency_total_size_bytes // 0' "$METRICS_FILE")
+DEPENDENCY_COUNT=$(jq -r '.metrics.dependency_count // 0' "$METRICS_FILE")
+
 message "Parsed metrics:"
 message "  Sample: $SAMPLE"
 message "  Mode: $MODE"
 message "  Durations: ${DURATIONS[*]}s"
 message "  Size: $SIZE bytes"
 message "  Dependencies attributed: ${#DEP_KEYS[@]}"
+message "  Total dependencies: $DEPENDENCY_COUNT, total size: $DEPENDENCY_TOTAL_SIZE_BYTES bytes"
 message "  Go version: $GO_VERSION"
 if [[ -n "$ORCHESTRION_VERSION" ]]; then
   message "  Orchestrion version: $ORCHESTRION_VERSION"
@@ -92,6 +99,11 @@ for i in "${!DEP_KEYS[@]}"; do
   # Publish dependency size bytes by rank (0 = single largest dependency in this build)
   MEASURE_ARGS+=(--measures "go.build.top_dependency_size_bytes.${i}:${DEP_SIZES[$i]}")
 done
+
+if [[ "$DEPENDENCY_COUNT" -gt 0 ]]; then
+  MEASURE_ARGS+=(--measures "go.build.dependency_total_size_bytes:${DEPENDENCY_TOTAL_SIZE_BYTES}")
+  MEASURE_ARGS+=(--measures "go.build.dependency_count:${DEPENDENCY_COUNT}")
+fi
 
 DATADOG_SITE="${DATADOG_SITE:-datadoghq.com}" datadog-ci measure --level job \
   "${MEASURE_ARGS[@]}" ||


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

| Datadog field | Type | Represents | When published |
|---|---|---|---|
| `@go.build.binary_size_bytes` | Measure | Size in bytes of the compiled test binary, taken from the last of the 3 repeat builds | Always |
| `@go.build.duration_seconds` | Measure | Mean build wall-clock time across all repeat builds | Always |
| `@go.build.duration_seconds.<i>` | Measure | Build time (seconds) of an individual repeat, `i` = 0, 1, 2 for the default 3 repeats | Always |
| `@go.build.dependency_size_bytes.<dependency>` | Measure | Size in bytes contributed by one specific vendor dependency; `<dependency>` is the sanitized import path (e.g. `github_com_datadog_go_libddwaf_v5`) | Standard mode only, top 10 largest dependencies, when `gsa` succeeds |
| `@go.build.top_dependency_size_bytes.<i>` | Measure | Same top-10 dependency sizes, indexed by rank (`0` = single largest, `9` = tenth-largest) instead of by name | Standard mode only, when `gsa` succeeds |
| `@go.build.dependency_total_size_bytes` | Measure | Summed size in bytes of every vendor package linked into the binary, not just the top 10 — overall dependency-bloat total | Standard mode only, when `gsa` succeeds |
| `@go.build.dependency_count` | Measure | Number of vendor packages linked into the binary | Standard mode only, when `gsa` succeeds |
| `@build.toolchain` | Tag | Which toolchain built the binary: `standard` or `orchestrion` | Always |
| `@build.sample` | Tag | Which integration sample was built (e.g. `sql`, `net_http`) | Always |
| `@build.cache` | Tag | Cache state for the measurement — always `cold`, since the build cache is cleaned before each timed build | Always |
| `@go.version` | Tag | Go toolchain version used | Always |
| `@orchestrion.version` | Tag | Orchestrion module version used | Orchestrion mode only |
| `@build.top_dependency_name.<i>` | Tag | Import-path name of the `i`-th ranked (0 = largest) vendor dependency by size | Standard mode only, when `gsa` succeeds |

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
