### PR TITLE
fix(contrib/jackc/pgx.v5): measure each batch query's own span duration

### DIFF
--- a/contrib/jackc/pgx.v5/pgx_tracer.go
+++ b/contrib/jackc/pgx.v5/pgx_tracer.go
@@ -8,6 +8,7 @@ package pgx
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
@@ -36,20 +37,14 @@ const (
 	operationTypeAcquire                = "Acquire"
 )
 
-type tracedBatchQuery struct {
-	span *tracer.Span
-	data pgx.TraceBatchQueryData
-}
-
-func (tb *tracedBatchQuery) finish() {
-	tb.span.Finish(tracer.WithError(tb.data.Err))
-}
-
 // batchState holds per-batch mutable tracing state. It is stored in the context
 // returned by TraceBatchStart so that concurrent batches on different pool
 // connections each have isolated state, avoiding a race on shared pgxTracer fields.
 type batchState struct {
-	prevQuery *tracedBatchQuery
+	// lastCheckpoint is when the previous query in the batch had its result read,
+	// or the batch start time for the first query. It bounds the start of the next
+	// query's span.
+	lastCheckpoint time.Time
 }
 
 type contextKeyBatchState struct{}
@@ -213,7 +208,7 @@ func (t *pgxTracer) TraceBatchStart(ctx context.Context, conn *pgx.Conn, data pg
 		tracer.Tag(tagBatchNumQueries, data.Batch.Len()),
 	)
 	_, ctx = tracer.StartSpanFromContext(ctx, "pgx.batch", opts...)
-	ctx = context.WithValue(ctx, contextKeyBatchState{}, &batchState{})
+	ctx = context.WithValue(ctx, contextKeyBatchState{}, &batchState{lastCheckpoint: time.Now()})
 	return ctx
 }
 
@@ -224,24 +219,26 @@ func (t *pgxTracer) TraceBatchQuery(ctx context.Context, conn *pgx.Conn, data pg
 	if t.wrapped.batch != nil {
 		t.wrapped.batch.TraceBatchQuery(ctx, conn, data)
 	}
-	// Finish the previous batch query span before starting the next one, since pgx doesn't provide hooks or
-	// timestamp information about when the actual operation started or finished.
-	// batchState is stored per-batch in the context so concurrent batches on different pool connections
-	// each track their own prevQuery without racing on shared tracer state.
-	bs, _ := ctx.Value(contextKeyBatchState{}).(*batchState)
-	if bs != nil && bs.prevQuery != nil {
-		bs.prevQuery.finish()
+	// pgx reports a batch query only once its result has been read, and provides no
+	// timestamp for when the query itself started. The time elapsed since the previous
+	// checkpoint (the batch start, or the prior query's result) is the closest available
+	// estimate of this query's cost, so the span covers that interval. Attributing the
+	// interval until the next query is read instead would charge each query's cost to the
+	// query queued before it.
+	// batchState is stored per-batch in the context so concurrent batches on different pool
+	// connections each track their own checkpoint without racing on shared tracer state.
+	now := time.Now()
+	start := now
+	if bs, _ := ctx.Value(contextKeyBatchState{}).(*batchState); bs != nil {
+		start = bs.lastCheckpoint
+		bs.lastCheckpoint = now
 	}
 	opts := t.spanOptions(t.connInfoFor(conn), operationTypeQuery, data.SQL,
 		tracer.Tag(tagRowsAffected, data.CommandTag.RowsAffected()),
+		tracer.StartTime(start),
 	)
 	span, _ := tracer.StartSpanFromContext(ctx, "pgx.batch.query", opts...)
-	if bs != nil {
-		bs.prevQuery = &tracedBatchQuery{
-			span: span,
-			data: data,
-		}
-	}
+	span.Finish(tracer.WithError(data.Err), tracer.FinishTime(now))
 }
 
 func (t *pgxTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceBatchEndData) {
@@ -250,10 +247,6 @@ func (t *pgxTracer) TraceBatchEnd(ctx context.Context, conn *pgx.Conn, data pgx.
 	}
 	if t.wrapped.batch != nil {
 		t.wrapped.batch.TraceBatchEnd(ctx, conn, data)
-	}
-	if bs, _ := ctx.Value(contextKeyBatchState{}).(*batchState); bs != nil && bs.prevQuery != nil {
-		bs.prevQuery.finish()
-		bs.prevQuery = nil
 	}
 	t.finishSpan(ctx, data.Err)
 }

--- a/contrib/jackc/pgx.v5/pgx_tracer_test.go
+++ b/contrib/jackc/pgx.v5/pgx_tracer_test.go
@@ -291,6 +291,55 @@ func TestBatch(t *testing.T) {
 	assert.Equal(t, batchSpan.SpanID(), s.ParentID())
 }
 
+// TestBatchQuerySpanDurations asserts that each batched query's span duration
+// reflects the time spent on that query, not on the query queued before it. pgx
+// reports a batch query only once its result is read, so the wait for a slow query
+// must be attributed to that query's span rather than to its predecessor's.
+func TestBatchQuerySpanDurations(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	opts := append(tracingAllDisabled(), WithTraceBatch(true))
+
+	parent, ctx := tracer.StartSpanFromContext(context.Background(), "parent")
+
+	pool, err := NewPool(ctx, postgresDSN, opts...)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// The second query streams a large result set, so reading its rows takes
+	// meaningfully longer than reading the first query's result. pgx reports each
+	// batch query only once its result is consumed, so the read time must be
+	// attributed to the slow query's own span rather than to the fast query queued
+	// before it.
+	const slowQuery = `SELECT * FROM generate_series(1, 3000000)`
+	batch := &pgx.Batch{}
+	batch.Queue(`SELECT 1`)
+	batch.Queue(slowQuery)
+
+	br := pool.SendBatch(ctx, batch)
+	_, err = br.Exec() // SELECT 1: its result is available at the first flush
+	require.NoError(t, err)
+	rows, err := br.Query() // large result: reading the rows streams for a while
+	require.NoError(t, err)
+	for rows.Next() {
+	}
+	require.NoError(t, rows.Err())
+	rows.Close()
+	require.NoError(t, br.Close())
+
+	parent.Finish()
+
+	spans := mt.FinishedSpans()
+	fast := findBatchQuery(t, spans, "SELECT 1")
+	slow := findBatchQuery(t, spans, slowQuery)
+
+	assert.Greater(t, slow.Duration(), fast.Duration(),
+		"the streaming query's span should carry its own read time, not the fast query queued before it")
+	assert.GreaterOrEqual(t, slow.Duration(), 20*time.Millisecond,
+		"the streaming query's span should reflect the time spent reading its rows")
+}
+
 // TestConcurrentBatchRace asserts that concurrent batches executing on different
 // pool connections do not race on shared pgxTracer state. Run with -race.
 // Regression test for https://github.com/DataDog/dd-trace-go/issues/4668.
@@ -597,6 +646,17 @@ func TestPoolBeforeConnectTags(t *testing.T) {
 		assert.Equal(t, float64(5432), query.Tag(ext.NetworkDestinationPort))
 		assert.Equal(t, "postgres", query.Tag(ext.DBUser))
 	})
+}
+
+func findBatchQuery(t *testing.T, spans []*mocktracer.Span, resource string) *mocktracer.Span {
+	t.Helper()
+	for _, s := range spans {
+		if s.OperationName() == "pgx.batch.query" && s.Tag(ext.ResourceName) == resource {
+			return s
+		}
+	}
+	t.Fatalf("no pgx.batch.query span with resource %q found in %d spans", resource, len(spans))
+	return nil
 }
 
 func findSpan(t *testing.T, spans []*mocktracer.Span, operationName string) *mocktracer.Span {


### PR DESCRIPTION
### What does this PR do?

Batch query spans now cover the interval from the previous checkpoint (the batch start, or the prior query's result) until the current query's result is read, instead of the interval until the _next_ query's result is read.

`TraceBatchQuery` fires once per query and only after that query's result has been fully read. Unfortunately, pgx provides no timestamp for when the query itself started. The tracer previously started a span at each query's hook and finished it at the next one, so every query's span measured the following query's processing cost rather than its own. In a batch of `[SELECT 1, SELECT * FROM generate_series(1, 3000000)]`, we  were seeing the `SELECT 1` query report a latency of ~160ms while the streaming query's span measured <1ms.

Each span is now created and finished within a single `TraceBatchQuery` call using explicit start and finish times.

### Motivation

Found while investigating why a slow query was invisible in APM. The application pipelines a tenant-scoping statement and the real query into a single batch — `[SELECT set_config(...), <query>]` — and the query's time was consistently reported on the `set_config` span while the query's own span read ~0. A full table scan hid behind that "0".

This doesn't fully solve the issue, though. Per-query timing from pgx's batch hooks is an estimate at best and only covers client read times. When PostgreSQL buffers small results and flushes them at the end of the batch, the first result read blocks for the whole batch, so that wait is attributed to the first query regardless. There is no reliable way to know when the server began executing an individual query. This PR only fixes the case where the attribution was provably wrong (reporting each query's cost to the query queued before it).

The chosen interval also keeps the child spans tiling the parent batch span, and avoids reporting a query that did take time as a zero-duration span.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
