### PR TITLE
test(openfeature): de-flake exposure end-to-end tests

### DIFF
--- a/openfeature/integration_test.go
+++ b/openfeature/integration_test.go
@@ -1449,16 +1449,18 @@ func TestEndToEnd_ExposurePayloadStructure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Wait for flush
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the flush to reach the fake agent. Polling rather than sleeping a
+	// fixed interval: the flush is asynchronous, so a loaded CI runner can take
+	// longer than any interval short enough to keep the test fast.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(receivedPayloads) > 0
+	}, 5*time.Second, time.Millisecond, "expected at least one payload to be sent to agent")
 
 	// Verify payloads were received
 	mu.Lock()
 	defer mu.Unlock()
-
-	if len(receivedPayloads) == 0 {
-		t.Fatal("expected at least one payload to be sent to agent")
-	}
 
 	// Verify payload structure
 	payload := receivedPayloads[0]
@@ -1572,17 +1574,14 @@ func TestEndToEnd_ExposureFlushInterval(t *testing.T) {
 		time.Sleep(30 * time.Millisecond)
 	}
 
-	// Wait for multiple flushes
-	time.Sleep(200 * time.Millisecond)
-
-	mu.Lock()
-	count := flushCount
-	mu.Unlock()
-
-	// We should have received at least 2 flushes
-	if count < 2 {
-		t.Errorf("expected at least 2 flushes, got %d", count)
-	}
+	// Wait for at least 2 flushes. Polling rather than sleeping a fixed interval:
+	// the flush ticker is asynchronous, so a loaded CI runner can take longer than
+	// any interval short enough to keep the test fast.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return flushCount >= 2
+	}, 5*time.Second, time.Millisecond, "expected at least 2 flushes")
 }
 
 // TestEndToEnd_ExposureDoLogFalse tests that exposure events are NOT sent when doLog is false.
@@ -1745,16 +1744,18 @@ func TestEndToEnd_ExposureContextAttributes(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Wait for flush
-	time.Sleep(150 * time.Millisecond)
+	// Wait for the flush to reach the fake agent. Polling rather than sleeping a
+	// fixed interval: the flush is asynchronous, so a loaded CI runner can take
+	// longer than any interval short enough to keep the test fast.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return receivedPayload != nil
+	}, 5*time.Second, time.Millisecond, "expected payload to be received")
 
 	mu.Lock()
 	payload := receivedPayload
 	mu.Unlock()
-
-	if payload == nil {
-		t.Fatal("expected payload to be received")
-	}
 
 	if len(payload.Exposures) == 0 {
 		t.Fatal("expected at least one exposure")


### PR DESCRIPTION
### What does this PR do?

Replaces fixed `time.Sleep` waits with `require.Eventually` polling in three exposure end-to-end tests, so they wait for the asynchronous flush to actually arrive instead of guessing how long it takes:

| test | before |
|---|---|
| `TestEndToEnd_ExposurePayloadStructure` | `time.Sleep(100 * time.Millisecond)` |
| `TestEndToEnd_ExposureFlushInterval` | `time.Sleep(200 * time.Millisecond)` |
| `TestEndToEnd_ExposureContextAttributes` | `time.Sleep(150 * time.Millisecond)` |

No production code changes.

Two nearby sleeps are deliberately left alone: the one in `TestEndToEnd_ExposureDoLogFalse` asserts that **no** payload arrives, which polling cannot prove, and the one at the end of `TestEndToEnd_ExposureAgentSide` is followed by no assertion.

### Motivation

`TestEndToEnd_ExposurePayloadStructure` failed on a `windows-latest` CI runner with `integration_test.go:1460: expected at least one payload to be sent to agent`, in an unrelated PR. The flush is asynchronous, so on a loaded runner 100ms is not enough and the test fails for reasons unrelated to the change under review. Polling keeps the tests fast on a fast machine and patient on a slow one.

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
