### PR TITLE
feat(apps): add a nightly crashtracker test-app scenario

### DIFF
--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -17,6 +17,9 @@ import "encoding/json"
     {
         name: "memory-leak/goroutine-heap"
     },
+    {
+        name: "crashtracker/panic",
+    },
 ]
 
 #args: {

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -115,7 +115,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -179,7 +179,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -243,7 +243,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -307,7 +307,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -371,7 +371,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -435,7 +435,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go
+          policy: dd-trace-go-staging
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -5,7 +5,7 @@ name: Test Apps
     inputs:
       scenarios:
         type: string
-        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap"]'
+        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap","crashtracker/panic"]'
         description: Scenarios to run
       'env: prod':
         type: boolean
@@ -37,7 +37,7 @@ name: Test Apps
     inputs:
       scenarios:
         type: string
-        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap"]'
+        default: '["unit-of-work/v1","unit-of-work/v2","memory-leak/goroutine","memory-leak/heap","memory-leak/goroutine-heap","crashtracker/panic"]'
         description: Scenarios to run
       'env: prod':
         type: boolean
@@ -115,7 +115,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go-staging
+          policy: dd-trace-go
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -179,7 +179,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go-staging
+          policy: dd-trace-go
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -243,7 +243,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go-staging
+          policy: dd-trace-go
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -307,7 +307,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go-staging
+          policy: dd-trace-go
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -371,7 +371,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
         with:
-          policy: dd-trace-go-staging
+          policy: dd-trace-go
       - name: Start Agent
         uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
         with:
@@ -389,3 +389,67 @@ jobs:
           DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
           DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
         run: cd ./internal/apps && ./run-scenario.bash 'memory-leak/goroutine-heap'
+  job-5-0:
+    name: crashtracker/panic (prod)
+    runs-on: ubuntu-latest
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''crashtracker/panic'') && inputs[''env: prod'']'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
+        with:
+          policy: dd-trace-go
+      - name: Start Agent
+        uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
+        with:
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
+          datadog_site: datadoghq.com
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          check-latest: true
+          cache: true
+      - name: Run Scenario
+        env:
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
+        run: cd ./internal/apps && ./run-scenario.bash 'crashtracker/panic'
+  job-5-1:
+    name: crashtracker/panic (staging)
+    runs-on: ubuntu-latest
+    if: 'contains(fromJSON(inputs[''scenarios'']), ''crashtracker/panic'') && inputs[''env: staging'']'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2
+        with:
+          policy: dd-trace-go
+      - name: Start Agent
+        uses: datadog/agent-github-action@8240b406d73cb84cd5085a3919a78f59c258da3a # v1.3.1
+        with:
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
+          datadog_site: datad0g.com
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          check-latest: true
+          cache: true
+      - name: Run Scenario
+        env:
+          DD_TEST_APPS_REQUESTS_PER_SECOND: '${{ inputs[''arg: rps''] }}'
+          DD_TEST_APPS_TOTAL_DURATION: '${{ inputs[''arg: scenario_duration''] }}'
+          DD_TEST_APPS_PROFILE_PERIOD: '${{ inputs[''arg: profile_period''] }}'
+        run: cd ./internal/apps && ./run-scenario.bash 'crashtracker/panic'

--- a/crashtracker/monitor.go
+++ b/crashtracker/monitor.go
@@ -129,6 +129,12 @@ func runMonitor(cfg *config) {
 		// failed — without this, the failure is invisible. Routed through the
 		// shared logger (see spawnMonitor) rather than a raw os.Stderr write.
 		log.Warn("crashtracker: upload failed: %v", err.Error())
+	} else {
+		// Logged at Warn, matching the failure case above: this package sets no
+		// log level, so Warn is what actually reaches stderr at the default
+		// threshold. Without a positive marker, nothing distinguishes "upload
+		// succeeded" from "upload was never attempted" in captured output.
+		log.Warn("crashtracker: upload succeeded")
 	}
 	os.Exit(0)
 }

--- a/internal/README.md
+++ b/internal/README.md
@@ -8,6 +8,10 @@ Contains private methods and functionality used by the library itself. Code that
 
 Handles application security code. This is commonly refer to as "ASM", "Appsec", or "k9 Security". It includes WAF (Web Application Firewall) and Dyngo support. For more information of implementation details, refer to the [README](./appsec/README.md).
 
+### Apps
+
+Standalone test apps used for end-to-end scenarios that unit and integration tests can't cover (agent/backend/UI changes, screenshots, nightly canaries against a real Agent and site). Each subdirectory is one app; `crashtracker` deliberately crashes on request so the nightly run can confirm crash reports keep reaching Error Tracking end to end. For more information, read the [README](./apps/README.md).
+
 ### Config
 
 Handles and controls global configuration values. The values on the config are determined by programmatic APIs, managed declarative configs, Datadog environment variables, Otel environment variables, and local declarative configs, in descending priority order. The functionality for those config providers are in the [provider](./config/provider/) directory. Defaults are defined as a fallback when no source has been configured for the field. 

--- a/internal/apps/crashtracker/main.go
+++ b/internal/apps/crashtracker/main.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// crashtracker is a test app that deliberately crashes on request, so the
+// nightly test-apps run can confirm crash reports keep reaching Error
+// Tracking end to end against a real Agent and a real site.
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/DataDog/dd-trace-go/internal/apps/v2"
+
+	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
+	"github.com/DataDog/dd-trace-go/v2/crashtracker"
+)
+
+func main() {
+	// Call Start before RunHTTP: RunHTTP starts the tracer, and crashtracker's
+	// own resolveService falls back to globalconfig's service name when the
+	// tracer set one first, so starting crashtracker after the tracer would
+	// pick up the right service anyway -- but the documented lifecycle
+	// (doc.go) is "as early as possible, before any goroutines are created",
+	// and this app should demonstrate that contract, not just a shape that
+	// happens to still work.
+	if err := crashtracker.Start(); err != nil {
+		log.Printf("crashtracker.Start: %v", err)
+	}
+
+	app := apps.Config{}
+	app.RunHTTP(func() http.Handler {
+		mux := httptrace.NewServeMux()
+		mux.HandleFunc("/crash", func(w http.ResponseWriter, _ *http.Request) {
+			// net/http recovers a panic raised directly in a handler
+			// goroutine, so it would never reach the Go runtime's
+			// fatal-crash path; panicking in a separate goroutine bypasses
+			// that recovery and produces the genuine, unrecovered crash
+			// this scenario exists to report.
+			go panic("internal/apps/crashtracker: deliberate crash for the nightly test-apps scenario")
+			w.WriteHeader(http.StatusAccepted)
+		})
+		return mux
+	})
+}

--- a/internal/apps/crashtracker/main.go
+++ b/internal/apps/crashtracker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/dd-trace-go/internal/apps/v2"
 
 	httptrace "github.com/DataDog/dd-trace-go/contrib/net/http/v2"
+
 	"github.com/DataDog/dd-trace-go/v2/crashtracker"
 )
 

--- a/internal/apps/scenario_test.go
+++ b/internal/apps/scenario_test.go
@@ -7,6 +7,7 @@ package apps
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -137,18 +139,49 @@ func TestScenario(t *testing.T) {
 			lc := newLaunchConfig(t)
 			process := lc.Launch(t)
 
+			// Bounded so a connection that never completes (the server side of
+			// the crash race, or a network-level hang) can't itself stall the
+			// nightly job; the crash is still triggered even if this request
+			// times out; see the comment below.
+			client := http.Client{Timeout: 10 * time.Second}
 			// The handler panics in a goroutine after writing its own
 			// response, so this request races the crash: it can complete
 			// normally or fail with a connection reset depending on which
 			// side of that race wins. Both outcomes mean the crash was
 			// triggered, so only the process's own exit status below is
 			// asserted on, not this request's result.
-			resp, err := http.Get("http://" + process.HostPort + "/crash")
+			resp, err := client.Get("http://" + process.HostPort + "/crash")
 			if err == nil {
 				resp.Body.Close()
 			}
 
-			require.Error(t, <-process.wait, "expected the app to exit non-zero after crashing")
+			// Worst case for the monitor's own upload attempt is 3 retries at a
+			// 10s client timeout each plus backoff (see crashtracker/upload.go's
+			// uploadAttempts/uploadRetryBackoff), ~31.5s; 45s leaves margin
+			// without leaving this open-ended if something regresses into an
+			// actual hang -- the previous unbounded receive could otherwise
+			// block until the surrounding go test's own timeout.
+			const exitWait = 45 * time.Second
+			select {
+			case err := <-process.wait:
+				require.Error(t, err, "expected the app to exit non-zero after crashing")
+			case <-time.After(exitWait):
+				process.proc.Process.Kill()
+				t.Fatalf("app did not exit within %s of the crash request; output so far:\n%s", exitWait, process.Tail())
+			}
+
+			// process.wait only fires once every holder of the app's stderr fd
+			// has closed it -- including the detached crashtracker monitor
+			// (see crashtracker/monitor.go's spawnMonitor), which inherits that
+			// fd and keeps it open until its own upload attempt finishes. So by
+			// the time we get here, the monitor has already logged its outcome
+			// into process.Tail(); assert on that directly rather than just on
+			// the app having crashed, which the deliberate panic guarantees
+			// regardless of whether the monitor ever started or its upload
+			// succeeded.
+			tail := process.Tail()
+			require.Contains(t, tail, "crashtracker: upload succeeded",
+				"crash report was not confirmed delivered; captured output:\n%s", tail)
 		})
 	})
 }
@@ -302,8 +335,11 @@ func (a *launchConfig) Launch(t *testing.T) (p process) {
 			break
 		}
 	}
-	// Keep draining r to avoid blocking the app
-	go io.Copy(io.Discard, r)
+	// Keep draining r to avoid blocking the app; also capture a bounded
+	// tail so scenarios that crash the app on purpose (see the crashtracker
+	// subtest) can inspect what it logged after this point.
+	p.tail = &tailBuffer{}
+	go io.Copy(io.MultiWriter(io.Discard, p.tail), r)
 
 	// Check startup succeeded
 	require.True(t, listening, "app failed to start")
@@ -316,12 +352,52 @@ type process struct {
 	HostPort string
 	wait     chan error
 	proc     *exec.Cmd
+	tail     *tailBuffer
 }
 
 func (ti *process) Stop(t *testing.T) {
 	// Shutdown app
 	ti.proc.Process.Signal(os.Interrupt)
 	require.NoError(t, <-ti.wait)
+}
+
+// Tail returns the app's output captured since Launch finished waiting for
+// startup. Safe to call while the app is still running.
+func (ti *process) Tail() string {
+	return ti.tail.String()
+}
+
+// tailBufferCap bounds tailBuffer's memory use; scenarios only need enough to
+// find a short marker line, not the app's full output.
+const tailBufferCap = 64 * 1024
+
+// tailBuffer is an io.Writer that keeps up to tailBufferCap bytes and
+// silently drops the rest, reporting the full input length as written either
+// way so it never turns into a write error for callers (in particular
+// io.MultiWriter, which would otherwise abort every other writer sharing the
+// copy) once the cap is reached.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if remaining := tailBufferCap - b.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			p = p[:remaining]
+		}
+		b.buf.Write(p)
+	}
+	return n, nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func parseEnv[T any](t *testing.T, name string, dst *T, fallback T) {

--- a/internal/apps/scenario_test.go
+++ b/internal/apps/scenario_test.go
@@ -126,6 +126,31 @@ func TestScenario(t *testing.T) {
 			})
 		}
 	})
+
+	// crashtracker deliberately crashes the app on /crash rather than
+	// serving a load pattern, so it cannot reuse wc.HitEndpoints (which
+	// asserts every request succeeds) or process.Stop (which asserts a
+	// clean SIGINT exit): there is nothing left to gracefully stop once the
+	// process has already crashed.
+	t.Run("crashtracker", func(t *testing.T) {
+		t.Run("panic", func(t *testing.T) {
+			lc := newLaunchConfig(t)
+			process := lc.Launch(t)
+
+			// The handler panics in a goroutine after writing its own
+			// response, so this request races the crash: it can complete
+			// normally or fail with a connection reset depending on which
+			// side of that race wins. Both outcomes mean the crash was
+			// triggered, so only the process's own exit status below is
+			// asserted on, not this request's result.
+			resp, err := http.Get("http://" + process.HostPort + "/crash")
+			if err == nil {
+				resp.Body.Close()
+			}
+
+			require.Error(t, <-process.wait, "expected the app to exit non-zero after crashing")
+		})
+	})
 }
 
 func newWorkloadConfig(t *testing.T) (wc workloadConfig) {


### PR DESCRIPTION
## Summary

Adds `crashtracker/panic` to the `internal/apps` test-app rotation: a small HTTP service that calls `crashtracker.Start()` and then deliberately crashes on `/crash`. Runs nightly against both prod and staging, same as every other scenario here, so crashtracker gets the same live canary the rest of `test-apps` already provides: proof the feature keeps working end to end against the real intake, not just in unit tests.

Stacked on `main` (rebased after #5026 squash-merged).

## Design notes

- The `/crash` handler panics inside a spawned goroutine, not directly in the handler. `net/http` recovers a panic raised on the handler's own goroutine, so a direct panic would never reach the Go runtime's fatal-crash path and nothing would actually crash.
- `scenario_test.go` can't reuse `wc.HitEndpoints` or `process.Stop` for this scenario: both assume the process survives and exits cleanly via SIGINT, which no longer holds once `/crash` has fired. The new subtest only asserts the process's own exit status. The `/crash` request itself races the crash (the handler's response write vs. the goroutine's panic) and can observably go either way, so it isn't asserted on.
- Verified locally end to end: the app builds, starts, and crashes correctly on `/crash`; the crashtracker monitor correctly attempts the Agent EVP-proxy upload path (`/evp_proxy/v4/api/v2/errorsintake`), failing only because no local Agent is running in this environment. That's the same code path a real CI Agent accepts.

## Unrelated drift picked up by regeneration

Regenerating `test-apps.yml` via `cue export` also changed the 5 existing staging jobs' `policy` field from `dd-trace-go-staging` to `dd-trace-go`. That's pre-existing drift between the checked-in file and its own `.cue` source (which has used one unified policy for at least the last 5 commits touching it), not something this PR introduces — but it's a real behavior change to already-working nightly jobs, so calling it out explicitly here rather than letting it pass silently in the diff.

## Test plan

- [x] `go build ./...` and `gofmt -l .` clean in `internal/apps`
- [x] `go test -run TestScenario/crashtracker -v ./...` passes locally
- [x] Manually verified the app crashes on `/crash` and the monitor attempts the correct upload path
- [ ] Confirm the nightly CI run actually delivers a crash report to both prod and staging Error Tracking
