### PR TITLE
feat: enable local runs of GHA

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,29 @@
+# Config for `act` (https://github.com/nektos/act), used by `make act/*` and scripts/act.sh.
+# See .github/act/README.md for what act validates, and what it does not, before you rely
+# on it. In particular, act does not test your uncommitted code. Start there.
+
+# Map every runs-on label/group the act-runnable workflows use to the "Medium" runner image
+# (~500MB, act's documented default). Anything not listed here falls back to act's
+# interactive image-size prompt.
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-P ubuntu-24.04=catthehacker/ubuntu:act-latest
+-P ubuntu-22.04=catthehacker/ubuntu:act-latest
+# Group-based `runs-on: {group: "APM Larger Runners"}` jobs (test-core, test-contrib-matrix,
+# test-contrib) need an explicit mapping too. act matches on the group name, not a label.
+-P APM Larger Runners=catthehacker/ubuntu:act-latest
+
+# CI runs amd64. Under qemu emulation, act's toolcache cannot resolve `node` on PATH 
+# for the emulated architecture. It resolves fine under native arm64. This file does not 
+# force amd64 by default for that reason. Add `--container-architecture linux/amd64` on 
+# the command line yourself if you are hunting an architecture-specific bug, and expect to 
+# hit that failure on Apple Silicon.
+
+# Job containers join the host network namespace, so ports docker-compose publishes (3306,
+# 5432, 6379, 9126, ...) are reachable at localhost the same way they are on a GitHub-hosted
+# runner. This requires Docker Desktop >= 4.34 with host networking enabled on macOS.
+--network host
+
+# Where uploaded artifacts (act's stand-in for actions/upload-artifact and
+# actions/download-artifact, used to pass matrix results between unit-integration-tests.yml
+# jobs) get stored. Without this flag, artifact upload and download steps do nothing.
+--artifact-server-path /tmp/act-artifacts

--- a/.github/act/README.md
+++ b/.github/act/README.md
@@ -1,0 +1,75 @@
+# Running GitHub Actions locally with `act`
+
+`act` lets you check a workflow-YAML edit before pushing, without waiting on a real CI run. The check covers the job graph, matrix expressions, composite-action wiring, and step logic.
+
+**By default, act does not test your local Go code.** Every checkout step in this repo's workflows pins an explicit `ref:` input, which makes act's checkout fetch that ref over the real network instead of taking a local-copy shortcut. It tests the last commit you pushed, not your working tree, and not even your local commits if you have not pushed them. There is no reliable workaround for that checkout behavior.
+
+Use act to check that you wrote the workflow YAML correctly, not to check that your code change passes CI. For a code change, use `make lint`, `make test`, or `make ci/run` instead (see "Reproducing CI locally" in [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+
+## Testing a real code change through act
+
+Push a scratch branch, then point the checkout step at it:
+
+```shell
+git push origin HEAD:refs/heads/wip/ci-check-$USER
+```
+
+Edit `pull_request.head.ref` and `.sha` in `.github/act/events/pull_request.json`, or pass `--input ref=wip/ci-check-$USER` for a workflow that accepts a `ref` input. Delete the branch when you finish.
+
+Pushing a scratch branch this way is a manual, occasional step.
+
+## What works under act
+
+`generate.yml`, `static-checks.yml` (except the `lint` job), `unit-integration-tests.yml`, `apidiff-check.yml`, and `config-audit.yml` run directly. Use the make targets below.
+
+`static-checks.yml`'s `lint` job posts PR review comments through `reviewdog` and mints a GitHub App token to do it. act cannot execute that step. Run `make lint/go` and `make lint/shell` directly instead.
+
+`system-tests.yml`, `parametric-tests.yml`, and `lambda-integration-tests.yml` check out a separate repository and hand off to its own harness. Clone that repository and run its harness directly instead of using act.
+
+Anything requiring `macos-latest`, `windows-latest`, or GitHub/AWS OIDC-authenticated API calls cannot run under act at all.
+
+## Usage
+
+```shell
+make act/list           # list every job act can see
+make act/generate       # runs the generate.yml job; no services or credentials needed, start here
+make act/static-checks  # excludes the lint job, see above
+make act/core-tests
+make act/contrib-tests CHUNK=3   # find the chunk with `make ci/contrib/chunks`
+```
+
+Each target wraps `act -W <file> -j <job>` (`scripts/act.sh`), using the platform mappings, network mode, and artifact server path pinned in [`.actrc`](../../.actrc). Run `scripts/act.sh` directly for anything not covered by a make target, for example to filter a matrix job:
+
+```shell
+./scripts/act.sh -W .github/workflows/static-checks.yml -j checklocks
+./scripts/act.sh -W .github/workflows/generate.yml -j generate --matrix go-version:1.23
+```
+
+## Event fixtures
+
+act has no real GitHub webhook to read, so `-e <file>` feeds it a fake `github.event` payload instead. `.github/act/events/` holds three:
+
+- **`pull_request.json`** simulates a `synchronize` event (new commits pushed to an open PR). Every `make act/*` target uses this one, via `ACT_EVENT` in the `Makefile`. Its empty `labels` array feeds `apidiff-check.yml`'s check for a `breaking-api-acknowledged` label; add the label name to the array if you need that check to see it as acknowledged.
+- **`push_main.json`** simulates a `push` to `main`, matching how `main-branch-tests.yml` triggers. No make target uses it. To use it, run `./scripts/act.sh -e .github/act/events/push_main.json ...`.
+- **`workflow_dispatch.json`** simulates a manual "Run workflow" click. No make target uses it. To use `config-audit.yml`'s dispatch-specific logic. run `./scripts/act.sh -e .github/act/events/workflow_dispatch.json ...`.
+
+## Known gotchas
+
+- **Apple Silicon runs arm64, not CI's amd64.** `.actrc` does not force `--container-architecture linux/amd64`, because that breaks act's Node-based actions (`actions/checkout`, `actions/cache`) under emulation. Pass the flag yourself if you need to test an architecture-specific bug.
+- **The runner image only approximates CI.** It is not a snapshot of the real GitHub-hosted runner, and it can resolve a different Go toolchain version than a local run. Treat a code-correctness finding from act as a lead to check locally, not as a verdict.
+- **The `github` event context is incomplete.** Anything not in `.github/act/events/*.json` (PR labels, milestones, `workflow_run` triggers) does not match a real GitHub event. Extend the JSON fixtures if you need to exercise that path.
+- **Host networking exposes your laptop, not an empty runner.** `--network host` means job containers share your machine's network namespace. A port your laptop already uses can make `docker compose up` fail to bind, or can silently point a test at your own local database instead of a throwaway one. Check `docker ps` for conflicts before you trust a green run.
+
+## Troubleshooting
+
+- **act prompts for a runner image size.** A `runs-on` label or group has no `-P` mapping in `.actrc`. Add one instead of answering the prompt.
+- **`address already in use` starting compose services.** Something local already holds one of CI's ports (3306, 5432, 6379, 9126). Stop it.
+- **Connection refused to a compose-published port.** Host networking is not active. Recheck the macOS prerequisites below.
+- **A result under act does not match a local run.** Expected, per "Known gotchas" above. Re-run the underlying script or tool on the host before you trust an act-only result.
+- **No DD_API_KEY found.** Expected, as `dd-octo-sts` will not work locally. The only impact is test result uploads, which is not necessary for local debugging.
+
+## Prerequisites
+
+- `act` >= 0.2.89 (`brew install act`)
+- Docker running locally
+- **macOS, for the test-core/test-contrib targets**: Docker Desktop >= 4.34, with host networking enabled (Settings -> Resources -> Network), a signed-in Docker account, and Enhanced Container Isolation disabled.

--- a/.github/act/events/pull_request.json
+++ b/.github/act/events/pull_request.json
@@ -1,0 +1,22 @@
+{
+  "action": "synchronize",
+  "pull_request": {
+    "number": 1,
+    "base": {
+      "ref": "main",
+      "sha": "0000000000000000000000000000000000000000"
+    },
+    "head": {
+      "ref": "act/local-run",
+      "sha": "1111111111111111111111111111111111111111"
+    },
+    "labels": []
+  },
+  "repository": {
+    "name": "dd-trace-go",
+    "full_name": "DataDog/dd-trace-go",
+    "owner": {
+      "login": "DataDog"
+    }
+  }
+}

--- a/.github/act/events/push_main.json
+++ b/.github/act/events/push_main.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/main",
+  "repository": {
+    "name": "dd-trace-go",
+    "full_name": "DataDog/dd-trace-go",
+    "owner": {
+      "login": "DataDog"
+    }
+  }
+}

--- a/.github/act/events/workflow_dispatch.json
+++ b/.github/act/events/workflow_dispatch.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/main",
+  "repository": {
+    "name": "dd-trace-go",
+    "full_name": "DataDog/dd-trace-go",
+    "owner": {
+      "login": "DataDog"
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,8 @@ updates:
       - "/contrib/haproxy/stream-processing-offload/cmd/spoa"
       - "/contrib/k8s.io/gateway-api/cmd/request-mirror"
       - "/internal/apps"
+      - "/scripts/ci-runner/go1.26"
+      - "/scripts/ci-runner/go1.27"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/testservices/docker-compose.yaml
+++ b/.github/testservices/docker-compose.yaml
@@ -11,6 +11,11 @@
 # memcached, mysql/postgres via cimg) — see the `ignore` rules in
 # .github/dependabot.yml, which restrict Dependabot to digest-only refreshes
 # for these.
+#
+# Consequently the versions here diverge from the root docker-compose.yaml,
+# which tracks current versions for local development. That divergence is
+# deliberate; it is tabulated and justified under "Reproducing CI locally" in
+# CONTRIBUTING.md. Reproduce a CI job against this stack with `make ci/run`.
 
 services:
   datadog-agent:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@
 /.gitmodules                    @DataDog/dd-trace-go-guild
 /.idea/                         @DataDog/dd-trace-go-guild
 /.orchestrion-version           @DataDog/dd-trace-go-guild
+/.actrc                         @DataDog/dd-trace-go-guild
 /.pre-commit-config.yaml        @DataDog/dd-trace-go-guild
 *.md                            @DataDog/dd-trace-go-guild
 /LICENSE                        @DataDog/dd-trace-go-guild

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,79 @@ make test/contrib
 make test/appsec
 ```
 
+### Reproducing CI locally
+
+`make ci/run` runs one CI job end to end. The target starts CI's service containers, runs CI's entrypoint with CI's environment, then stops the containers.
+
+```shell
+# Reproduce the test-core job
+make ci/run JOB=core
+
+# Reproduce one test-contrib chunk. CI splits contrib across 6 parallel jobs.
+# Print the split to find the chunk that holds your module, then run that chunk.
+make ci/contrib/chunks | grep gorilla/mux     # -> CHUNK=6
+make ci/run JOB=contrib CHUNK=6
+
+# Build tags work the same way as the workflow's `build_tags` input
+make ci/run JOB=contrib CHUNK=6 BUILD_TAGS=deadlock
+
+# Run the steps one at a time
+make ci/services                  # or SERVICES="mysql postgres redis" for a subset
+make ci/core                      # or: make ci/contrib CHUNK=6
+make ci/services/down
+```
+
+`make ci/services` binds the same host ports that CI uses, which include 3306, 5432, 6379, and 9126. If a local service already holds one of those ports, compose fails to bind.
+
+**`ci/core` requires bash 4 or later.** `scripts/ci_test_core.sh`, `scripts/test.sh`, and `scripts/cross_build.sh` use `mapfile`, a bash 4 builtin. macOS ships bash 3.2, so these scripts fail with `mapfile: command not found`. The default `PATH` puts `/bin` before Homebrew's prefix, so an installed bash 5 stays shadowed:
+
+```shell
+brew install bash
+export PATH="$(brew --prefix)/bin:$PATH"   # must come before /bin
+bash --version                             # expect 5.x
+```
+
+`make ci/contrib` does not need bash 4. No script on the contrib path uses a bash 4 feature.
+
+#### On Apple Silicon
+
+On arm64 macOS, the `ci/*` targets set `DOCKER_DEFAULT_PLATFORM=linux/amd64`. `scripts/test.sh` sets
+the same variable for the root service containers.
+
+Two reasons make the setting necessary. First, five of CI's images publish no arm64 manifest:
+`elasticsearch:2`, `elasticsearch:5`, `elasticsearch:6.8.13`, `cimg/mysql:8.0`, and
+`mssql/server:2019-latest`. Second, the other images do publish arm64 variants, and an arm64 variant
+does not reproduce CI, because CI runs amd64.
+
+The platform setting cannot fix two known failures:
+
+- **`elasticsearch6` does not start.** The container exits 78 with `system call filters failed to
+  install`, because the seccomp bootstrap check fails under emulation. Contrib tests that need
+  Elasticsearch 6 cannot run locally.
+- **`cassandra` exits 137.** The kernel OOM-killer stops the container. CI's service containers
+  require more memory than a default Docker Desktop VM provides: five Elasticsearch JVMs at 750 MB of
+  heap each, plus Cassandra and MSSQL.
+
+Raise the memory that Docker Desktop grants the VM. As an alternative, start a subset with
+`make ci/services SERVICES="…"`, then run your module directly.
+
+If `make ci/services` reports `does not provide the specified platform`, an earlier pull cached the
+image for the wrong architecture. `docker compose up` does not replace a cached image. To repair the
+local image store, run `make ci/services/pull`.
+
+#### Why the two compose files pin different versions
+
+docker-compose.yaml and .github/testservices/docker-compose.yaml diverge on purpose. Do not converge them.
+
+The root file serves local development, so it tracks current upstream versions and Dependabot can update its tags. The CI file holds old versions to cover compatibility matrices. These services must stay pinned: `cassandra`, `redis`, `consul`, `elasticsearch*`, `memcached`, `mysql`, and `postgres`. These pins keep coverage of versions that current images no longer represent. The `ignore` rules in [.github/dependabot.yml](./.github/dependabot.yml) enforce those pins and limit the CI file to digest-only refreshes.
+
+### Reproducing the cross-repository test suites
+
+Three workflows pass control to a harness in another repository, so this repository has no make target for them. Each harness already runs locally. Clone the harness and run it directly.
+
+- **System tests** ([system-tests.yml](./.github/workflows/system-tests.yml)) and **parametric tests** ([parametric-tests.yml](./.github/workflows/parametric-tests.yml)) both check out [DataDog/system-tests](https://github.com/DataDog/system-tests) and call its `./build.sh` and `./run.sh`. To reproduce a failure, clone system-tests and put your dd-trace-go checkout into `binaries/dd-trace-go`. For parametric tests, run `TEST_LIBRARY=golang ./run.sh PARAMETRIC`. For system tests, run `./build.sh golang -i weblog -w <weblog-variant>`, then run `./run.sh <SCENARIO>`. Take the variant and the scenario from the name of the failing job. The system-tests repository documents its own prerequisites.
+- **Lambda integration tests** ([lambda-integration-tests.yml](./.github/workflows/lambda-integration-tests.yml)) runs `contrib/aws/datadog-lambda-go/test/integration_tests/run_integration_tests.sh`. The script deploys to a Datadog-owned AWS sandbox through OIDC role chaining. You must have credentials for the AWS sandbox account.
+
 ### CODEOWNERS patterns
 
 [CODEOWNERS](./CODEOWNERS) is read by two consumers that do not implement the same matching rules: GitHub, which follows gitignore semantics, and CI Visibility, which uses the simpler matcher in [internal/civisibility/utils](./internal/civisibility/utils/codeowners.go) to attribute test results to teams. A pattern the two interpret differently assigns the right reviewers while silently mis-attributing test ownership.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,13 @@ make test/appsec
 
 ### Reproducing CI locally
 
-`make ci/run` runs one CI job end to end. The target starts CI's service containers, runs CI's entrypoint with CI's environment, then stops the containers.
+`make ci/run` runs one CI job end to end. The target starts CI's service containers, runs CI's entrypoint inside a container pinned to CI's Go version and Debian base, then stops the containers.
+
+The container runs as a non-root user, like CI's runner. A test that asserts real permission enforcement then behaves the same locally as it does on CI.
+
+`scripts/ci_runner_run.sh` copies your working tree into the container, and copies it back out again, instead of using a bind mount. The copy reflects whatever is on disk at run time, including uncommitted changes.
+
+The copy excludes `.git`, so a commit made while a long run is in progress cannot be overwritten when results come back.
 
 ```shell
 # Reproduce the test-core job
@@ -148,6 +154,9 @@ make ci/run JOB=contrib CHUNK=6
 # Build tags work the same way as the workflow's `build_tags` input
 make ci/run JOB=contrib CHUNK=6 BUILD_TAGS=deadlock
 
+# Test against the other Go version in CI's matrix (default: 1.27)
+make ci/run JOB=core GO_VERSION=1.26
+
 # Run the steps one at a time
 make ci/services                  # or SERVICES="mysql postgres redis" for a subset
 make ci/core                      # or: make ci/contrib CHUNK=6
@@ -156,15 +165,11 @@ make ci/services/down
 
 `make ci/services` binds the same host ports that CI uses, which include 3306, 5432, 6379, and 9126. If a local service already holds one of those ports, compose fails to bind.
 
-**`ci/core` requires bash 4 or later.** `scripts/ci_test_core.sh`, `scripts/test.sh`, and `scripts/cross_build.sh` use `mapfile`, a bash 4 builtin. macOS ships bash 3.2, so these scripts fail with `mapfile: command not found`. The default `PATH` puts `/bin` before Homebrew's prefix, so an installed bash 5 stays shadowed:
+`make ci/core` and `make ci/contrib` build the runner image on first use, through `make ci/runner/build`. They also cache Go's module and build data in named Docker volumes across runs. Remove those volumes with `make ci/cache/clean`.
 
-```shell
-brew install bash
-export PATH="$(brew --prefix)/bin:$PATH"   # must come before /bin
-bash --version                             # expect 5.x
-```
+The runner container forces `--platform linux/amd64` by default, matching CI's architecture. On Apple Silicon, this architecture runs under emulation. Emulation can multiply the wall-clock time of the `-race` detector CI's tests use. Override `CI_RUNNER_PLATFORM`, for example `make ci/run JOB=core CI_RUNNER_PLATFORM=linux/arm64`, for faster, less faithful local iteration.
 
-`make ci/contrib` does not need bash 4. No script on the contrib path uses a bash 4 feature.
+Running `scripts/ci_test_core.sh` directly, outside the container, still needs bash 4 or later. macOS ships bash 3.2. `make ci/core` and `make ci/run` do not have this requirement, because the container ships bash 5.
 
 To check the job graph, matrix expressions, or step logic before pushing, use [`act`](https://github.com/nektos/act) instead:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,28 @@ bash --version                             # expect 5.x
 
 `make ci/contrib` does not need bash 4. No script on the contrib path uses a bash 4 feature.
 
+To check the job graph, matrix expressions, or step logic before pushing, use [`act`](https://github.com/nektos/act) instead:
+
+```shell
+# Install act
+brew install act
+
+# Runs the generate.yml job: no services or credentials needed, start here
+make act/generate
+
+# static-checks.yml's jobs, minus the reviewdog-wrapped `lint` job (run `make lint/go` for that)
+make act/static-checks
+
+# unit-integration-tests.yml
+make act/core-tests
+make act/contrib-tests CHUNK=3   # find the chunk with `make ci/contrib/chunks`
+
+# List every job act can see
+make act/list
+```
+
+**By default, none of these test your uncommitted code.** Every checkout step in this repo's workflows pins an explicit `ref:`. That pin makes act's checkout fetch the last commit you *pushed* over the network, and it ignores your working tree. Use these targets to validate a workflow-YAML edit's mechanics. Use `make lint`, `make test`, or `make ci/run` to validate a code change instead. See [.github/act/README.md](./.github/act/README.md) for which workflows are runnable at all, and for the manual "push a scratch branch" recipe for the rare case where you need the real job graph exercised against your actual code.
+
 #### On Apple Silicon
 
 On arm64 macOS, the `ci/*` targets set `DOCKER_DEFAULT_PLATFORM=linux/amd64`. `scripts/test.sh` sets

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ BUILD_TAGS ?=
 CHUNK ?= 1
 JOB ?= core
 SERVICES ?=
+GO_VERSION ?= 1.27
+CI_RUNNER_PLATFORM ?= linux/amd64
 
 # CI's test-core job starts only the datadog-agent service
 # (`docker compose up -d datadog-agent`). Test-contrib starts the full stack.
@@ -142,19 +144,33 @@ ifeq ($(shell uname -s)-$(shell uname -m),Darwin-arm64)
 CI_PLATFORM := DOCKER_DEFAULT_PLATFORM=linux/amd64
 endif
 CI_COMPOSE := $(CI_PLATFORM) COMPOSE_FILE=.github/testservices/docker-compose.yaml COMPOSE_PROJECT_NAME=dd-trace-go-ci
-CI_ENV := $(CI_COMPOSE) INTEGRATION=true GOTOOLCHAIN=local GODEBUG=x509negativeserial=1 \
-	TEST_RESULTS=$(CI_TEST_RESULTS) BUILD_TAGS=$(BUILD_TAGS)
 REQUIRE_JQ = command -v jq > /dev/null || { echo "jq is required (brew install jq)" >&2; exit 1; }
-# scripts/ci_test_core.sh (like scripts/test.sh) uses `mapfile`, a bash 4
-# builtin. macOS ships bash 3.2. On macOS, `env bash` fails with a bare
-# "mapfile: command not found".
-REQUIRE_BASH4 = bash -c 'type mapfile' > /dev/null 2>&1 || { \
-	echo "this needs bash >= 4; found $$(bash --version | head -1)" >&2; \
-	echo "on macOS: brew install bash, then put its prefix ahead of /bin in PATH" >&2; \
-	exit 1; }
+
+# make ci/core and make ci/contrib run inside this image, so the Go toolchain and OS
+# match CI's linux/amd64 runner, not whatever this host has. scripts/ci_runner_run.sh
+# copies the working tree into the container and back out again. It also runs the test
+# command as a non-root user, matching CI's runner. See scripts/ci_runner_run.sh for why.
+CI_RUNNER_IMAGE := dd-trace-go-ci-runner:go$(GO_VERSION)
+CI_RUNNER_GOMODCACHE := dd-trace-go-ci-runner-gomodcache
+CI_RUNNER_GOCACHE := dd-trace-go-ci-runner-gocache
+CI_RUNNER_RUN = CI_RUNNER_PLATFORM=$(CI_RUNNER_PLATFORM) CI_RUNNER_GOMODCACHE=$(CI_RUNNER_GOMODCACHE) \
+	CI_RUNNER_GOCACHE=$(CI_RUNNER_GOCACHE) CI_TEST_RESULTS=$(CI_TEST_RESULTS) BUILD_TAGS=$(BUILD_TAGS) \
+	./scripts/ci_runner_run.sh
+
+.PHONY: ci/runner/build
+ci/runner/build: ## Build the containerized CI runner image (GO_VERSION=1.26|1.27, default 1.27)
+	@case "$(GO_VERSION)" in \
+	  1.26 | 1.27) ;; \
+	  *) echo "GO_VERSION must be '1.26' or '1.27' (got '$(GO_VERSION)')" >&2; exit 1 ;; \
+	esac
+	docker build --platform $(CI_RUNNER_PLATFORM) -t $(CI_RUNNER_IMAGE) -f scripts/ci-runner/go$(GO_VERSION)/Dockerfile .
+
+.PHONY: ci/cache/clean
+ci/cache/clean: ## Remove the CI runner's Go module and build cache volumes
+	docker volume rm -f $(CI_RUNNER_GOMODCACHE) $(CI_RUNNER_GOCACHE)
 
 .PHONY: ci/run
-ci/run: tools-install ## Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
+ci/run: ## Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
 	@case "$(JOB)" in \
 	  core) echo "==> reproducing the test-core job" ;; \
 	  contrib) echo "==> reproducing test-contrib, chunk $(CHUNK)" ;; \
@@ -186,10 +202,9 @@ ci/services/down: ## Stop CI's service containers
 	$(CI_COMPOSE) docker compose down
 
 .PHONY: ci/core
-ci/core: tools-install ## Run CI's test-core entrypoint alone (services must be up)
-	@$(REQUIRE_BASH4)
+ci/core: ci/runner/build ## Run CI's test-core entrypoint alone (services must be up)
 	@mkdir -p $(CI_TEST_RESULTS)
-	$(BIN_PATH) $(CI_ENV) DD_APPSEC_WAF_TIMEOUT=1h ./scripts/ci_test_core.sh
+	$(CI_RUNNER_RUN) -e DD_APPSEC_WAF_TIMEOUT=1h -- $(CI_RUNNER_IMAGE) ./scripts/ci_test_core.sh
 
 .PHONY: ci/contrib/chunks
 ci/contrib/chunks: ## List the contrib chunks CI splits test-contrib into
@@ -197,12 +212,12 @@ ci/contrib/chunks: ## List the contrib chunks CI splits test-contrib into
 	@go run ./scripts/ci_contrib_matrix.go | jq -r 'to_entries[] | "CHUNK=\(.key + 1)\t\(.value)"'
 
 .PHONY: ci/contrib
-ci/contrib: tools-install ## Run one test-contrib chunk alone (services must be up)
+ci/contrib: ci/runner/build ## Run one test-contrib chunk alone (services must be up)
 	@mkdir -p $(CI_TEST_RESULTS)
 	@$(REQUIRE_JQ)
 	@chunk=$$(go run ./scripts/ci_contrib_matrix.go | jq -er ".[$$(($(CHUNK) - 1))]") || \
 		{ echo "no chunk $(CHUNK); run 'make ci/contrib/chunks' for the valid range" >&2; exit 1; }; \
-	$(BIN_PATH) $(CI_ENV) DD_APPSEC_WAF_TIMEOUT=1m ./scripts/ci_test_contrib.sh default "$$chunk"
+	$(CI_RUNNER_RUN) -e DD_APPSEC_WAF_TIMEOUT=1m -- $(CI_RUNNER_IMAGE) ./scripts/ci_test_contrib.sh default "$$chunk"
 
 # act targets. These test the last pushed commit, not local changes.
 ACT_STATIC_CHECKS_JOBS := copyright check-github-actions check-modules check-docs check-format check-supported-config checklocks cross-compile

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,91 @@ test-deadlock: tools-install ## Run tests with deadlock detection
 test-debug-deadlock: tools-install ## Run tests with debug and deadlock detection
 	BUILD_TAGS=debug,deadlock $(BIN_PATH) ./scripts/test.sh --all
 
+# CI-parity targets. `make test/*` uses the root docker-compose.yaml; CI uses
+# .github/testservices/docker-compose.yaml. See "Reproducing
+# CI locally" in CONTRIBUTING.md.
+CI_TEST_RESULTS := /tmp/test-results
+BUILD_TAGS ?=
+CHUNK ?= 1
+JOB ?= core
+SERVICES ?=
+
+# CI's test-core job starts only the agent (`docker compose up -d datadog-agent`); only
+# test-contrib brings up the whole stack. Mirroring that keeps ci/run faithful and, on a
+# laptop, avoids the memory pressure of 20 containers when the job needs one.
+ifeq ($(JOB),core)
+CI_JOB_SERVICES := datadog-agent
+endif
+
+# Five images in CI's stack publish no arm64 manifest at all (elasticsearch:2,
+# elasticsearch:5, elasticsearch:6.8.13, cimg/mysql:8.0, mssql/server:2019-latest), so on
+# Apple Silicon they only run under emulation. The rest do ship arm64 variants — which is
+# its own problem, since CI runs amd64 and we want the same builds, not merely working
+# ones. scripts/test.sh forces the platform the same way for the root stack.
+ifeq ($(shell uname -s)-$(shell uname -m),Darwin-arm64)
+CI_PLATFORM := DOCKER_DEFAULT_PLATFORM=linux/amd64
+endif
+CI_COMPOSE := $(CI_PLATFORM) COMPOSE_FILE=.github/testservices/docker-compose.yaml COMPOSE_PROJECT_NAME=dd-trace-go-ci
+CI_ENV := $(CI_COMPOSE) INTEGRATION=true GOTOOLCHAIN=local GODEBUG=x509negativeserial=1 \
+	TEST_RESULTS=$(CI_TEST_RESULTS) BUILD_TAGS=$(BUILD_TAGS)
+REQUIRE_JQ = command -v jq > /dev/null || { echo "jq is required (brew install jq)" >&2; exit 1; }
+# scripts/ci_test_core.sh (like scripts/test.sh) uses `mapfile`, a bash 4 builtin. macOS
+# ships bash 3.2, so `env bash` there fails with a bare "mapfile: command not found".
+REQUIRE_BASH4 = bash -c 'type mapfile' > /dev/null 2>&1 || { \
+	echo "this needs bash >= 4; found $$(bash --version | head -1)" >&2; \
+	echo "on macOS: brew install bash, then put its prefix ahead of /bin in PATH" >&2; \
+	exit 1; }
+
+.PHONY: ci/run
+ci/run: tools-install ## Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
+	@case "$(JOB)" in \
+	  core) echo "==> reproducing the test-core job" ;; \
+	  contrib) echo "==> reproducing test-contrib, chunk $(CHUNK)" ;; \
+	  *) echo "JOB must be 'core' or 'contrib' (got '$(JOB)')" >&2; exit 1 ;; \
+	esac
+	@$(MAKE) --no-print-directory ci/services SERVICES="$(CI_JOB_SERVICES)"
+	@trap '$(MAKE) --no-print-directory ci/services/down' EXIT INT TERM; \
+	  $(MAKE) --no-print-directory ci/$(JOB) CHUNK=$(CHUNK) BUILD_TAGS=$(BUILD_TAGS)
+
+.PHONY: ci/services
+ci/services: ## Start CI's service containers (all, or SERVICES="a b")
+	@$(CI_COMPOSE) docker compose up -d --wait --wait-timeout 120 $(SERVICES) || { \
+	  echo "" >&2; \
+	  echo "ci/services failed. The two usual causes:" >&2; \
+	  echo "  'address already in use'         -> a local service holds one of CI's ports; stop it" >&2; \
+	  echo "  'does not provide the platform'  -> a cached image is the wrong arch; make ci/services/pull" >&2; \
+	  exit 1; }
+
+# An image pulled earlier without a forced platform is cached as arm64 only; `up` then
+# reports "does not provide the specified platform" and will not fetch the amd64 variant
+# on its own. Re-pulling with the platform forced repairs the local store.
+.PHONY: ci/services/pull
+ci/services/pull: ## Re-pull CI's images at CI's platform (repairs wrong-arch cache)
+	$(CI_COMPOSE) docker compose pull --policy always
+
+.PHONY: ci/services/down
+ci/services/down: ## Stop CI's service containers
+	$(CI_COMPOSE) docker compose down
+
+.PHONY: ci/core
+ci/core: tools-install ## Run CI's test-core entrypoint alone (services must be up)
+	@$(REQUIRE_BASH4)
+	@mkdir -p $(CI_TEST_RESULTS)
+	$(BIN_PATH) $(CI_ENV) DD_APPSEC_WAF_TIMEOUT=1h ./scripts/ci_test_core.sh
+
+.PHONY: ci/contrib/chunks
+ci/contrib/chunks: ## List the contrib chunks CI splits test-contrib into
+	@$(REQUIRE_JQ)
+	@go run ./scripts/ci_contrib_matrix.go | jq -r 'to_entries[] | "CHUNK=\(.key + 1)\t\(.value)"'
+
+.PHONY: ci/contrib
+ci/contrib: tools-install ## Run one test-contrib chunk alone (services must be up)
+	@mkdir -p $(CI_TEST_RESULTS)
+	@$(REQUIRE_JQ)
+	@chunk=$$(go run ./scripts/ci_contrib_matrix.go | jq -er ".[$$(($(CHUNK) - 1))]") || \
+		{ echo "no chunk $(CHUNK); run 'make ci/contrib/chunks' for the valid range" >&2; exit 1; }; \
+	$(BIN_PATH) $(CI_ENV) DD_APPSEC_WAF_TIMEOUT=1m ./scripts/ci_test_contrib.sh default "$$chunk"
+
 .PHONY: fix-modules
 fix-modules: tools-install ## Fix module dependencies and consistency
 	$(BIN_PATH) ./scripts/fix_modules.sh

--- a/Makefile
+++ b/Makefile
@@ -115,27 +115,29 @@ test-deadlock: tools-install ## Run tests with deadlock detection
 test-debug-deadlock: tools-install ## Run tests with debug and deadlock detection
 	BUILD_TAGS=debug,deadlock $(BIN_PATH) ./scripts/test.sh --all
 
-# CI-parity targets. `make test/*` uses the root docker-compose.yaml; CI uses
-# .github/testservices/docker-compose.yaml. See "Reproducing
-# CI locally" in CONTRIBUTING.md.
+# CI-parity targets. `make test/*` uses the root docker-compose.yaml. CI uses
+# .github/testservices/docker-compose.yaml instead. See "Reproducing CI
+# locally" in CONTRIBUTING.md.
 CI_TEST_RESULTS := /tmp/test-results
 BUILD_TAGS ?=
 CHUNK ?= 1
 JOB ?= core
 SERVICES ?=
 
-# CI's test-core job starts only the agent (`docker compose up -d datadog-agent`); only
-# test-contrib brings up the whole stack. Mirroring that keeps ci/run faithful and, on a
-# laptop, avoids the memory pressure of 20 containers when the job needs one.
+# CI's test-core job starts only the datadog-agent service
+# (`docker compose up -d datadog-agent`). Test-contrib starts the full stack.
+# Starting only the services the job needs keeps ci/run faithful to CI and
+# avoids the memory load of 20 containers on a laptop.
 ifeq ($(JOB),core)
 CI_JOB_SERVICES := datadog-agent
 endif
 
-# Five images in CI's stack publish no arm64 manifest at all (elasticsearch:2,
-# elasticsearch:5, elasticsearch:6.8.13, cimg/mysql:8.0, mssql/server:2019-latest), so on
-# Apple Silicon they only run under emulation. The rest do ship arm64 variants — which is
-# its own problem, since CI runs amd64 and we want the same builds, not merely working
-# ones. scripts/test.sh forces the platform the same way for the root stack.
+# Five images in CI's stack publish no arm64 manifest at all: elasticsearch:2,
+# elasticsearch:5, elasticsearch:6.8.13, cimg/mysql:8.0, and
+# mssql/server:2019-latest. On Apple Silicon, these run only under emulation.
+# The other images do ship arm64 variants, but those variants do not
+# reproduce CI, because CI runs amd64. scripts/test.sh forces the platform
+# the same way for the root stack.
 ifeq ($(shell uname -s)-$(shell uname -m),Darwin-arm64)
 CI_PLATFORM := DOCKER_DEFAULT_PLATFORM=linux/amd64
 endif
@@ -143,8 +145,9 @@ CI_COMPOSE := $(CI_PLATFORM) COMPOSE_FILE=.github/testservices/docker-compose.ya
 CI_ENV := $(CI_COMPOSE) INTEGRATION=true GOTOOLCHAIN=local GODEBUG=x509negativeserial=1 \
 	TEST_RESULTS=$(CI_TEST_RESULTS) BUILD_TAGS=$(BUILD_TAGS)
 REQUIRE_JQ = command -v jq > /dev/null || { echo "jq is required (brew install jq)" >&2; exit 1; }
-# scripts/ci_test_core.sh (like scripts/test.sh) uses `mapfile`, a bash 4 builtin. macOS
-# ships bash 3.2, so `env bash` there fails with a bare "mapfile: command not found".
+# scripts/ci_test_core.sh (like scripts/test.sh) uses `mapfile`, a bash 4
+# builtin. macOS ships bash 3.2. On macOS, `env bash` fails with a bare
+# "mapfile: command not found".
 REQUIRE_BASH4 = bash -c 'type mapfile' > /dev/null 2>&1 || { \
 	echo "this needs bash >= 4; found $$(bash --version | head -1)" >&2; \
 	echo "on macOS: brew install bash, then put its prefix ahead of /bin in PATH" >&2; \
@@ -170,9 +173,10 @@ ci/services: ## Start CI's service containers (all, or SERVICES="a b")
 	  echo "  'does not provide the platform'  -> a cached image is the wrong arch; make ci/services/pull" >&2; \
 	  exit 1; }
 
-# An image pulled earlier without a forced platform is cached as arm64 only; `up` then
-# reports "does not provide the specified platform" and will not fetch the amd64 variant
-# on its own. Re-pulling with the platform forced repairs the local store.
+# If you pull an image earlier without a forced platform, Docker caches it
+# as arm64 only. `up` then reports "does not provide the specified platform"
+# and does not fetch the amd64 variant on its own. Re-pulling with the
+# platform forced repairs the local store.
 .PHONY: ci/services/pull
 ci/services/pull: ## Re-pull CI's images at CI's platform (repairs wrong-arch cache)
 	$(CI_COMPOSE) docker compose pull --policy always
@@ -199,6 +203,42 @@ ci/contrib: tools-install ## Run one test-contrib chunk alone (services must be 
 	@chunk=$$(go run ./scripts/ci_contrib_matrix.go | jq -er ".[$$(($(CHUNK) - 1))]") || \
 		{ echo "no chunk $(CHUNK); run 'make ci/contrib/chunks' for the valid range" >&2; exit 1; }; \
 	$(BIN_PATH) $(CI_ENV) DD_APPSEC_WAF_TIMEOUT=1m ./scripts/ci_test_contrib.sh default "$$chunk"
+
+# act targets. These test the last pushed commit, not local changes.
+ACT_STATIC_CHECKS_JOBS := copyright check-github-actions check-modules check-docs check-format check-supported-config checklocks cross-compile
+ACT_EVENT := .github/act/events/pull_request.json
+# act cannot parse dynamic `runs-on:` expression (`${{ ... fromJson(...) ... }}`) for a listing.
+ACT_WORKFLOWS := generate.yml static-checks.yml unit-integration-tests.yml apidiff-check.yml config-audit.yml
+
+.PHONY: act/list
+act/list: ## List jobs in the workflows act can run (see .github/act/README.md)
+	@for wf in $(ACT_WORKFLOWS); do \
+		./scripts/act.sh -W .github/workflows/$$wf -l; \
+	done
+
+.PHONY: act/generate
+act/generate: ## Run generate.yml under act (tests the last pushed commit, see .github/act/README.md)
+	./scripts/act.sh -W .github/workflows/generate.yml -j generate -e $(ACT_EVENT)
+
+.PHONY: act/static-checks
+act/static-checks: ## Run static-checks.yml's jobs under act (excludes reviewdog-wrapped `lint`, use `make lint` for that)
+	@for job in $(ACT_STATIC_CHECKS_JOBS); do \
+		echo "==> act -j $$job"; \
+		./scripts/act.sh -W .github/workflows/static-checks.yml -j $$job -e $(ACT_EVENT) || exit 1; \
+	done
+
+.PHONY: act/core-tests
+act/core-tests: ## Run unit-integration-tests.yml's test-core job under act
+	./scripts/act.sh -W .github/workflows/unit-integration-tests.yml -j test-core \
+		-e $(ACT_EVENT) --input go-version=stable
+
+.PHONY: act/contrib-tests
+act/contrib-tests: ## Run one unit-integration-tests.yml test-contrib-matrix chunk under act (CHUNK=n, see `make ci/contrib/chunks`)
+	@$(REQUIRE_JQ)
+	@chunk=$$(go run ./scripts/ci_contrib_matrix.go | jq -er ".[$$(($(CHUNK) - 1))]") || \
+		{ echo "no chunk $(CHUNK); run 'make ci/contrib/chunks' for the valid range" >&2; exit 1; }; \
+	./scripts/act.sh -W .github/workflows/unit-integration-tests.yml -j test-contrib-matrix \
+		-e $(ACT_EVENT) --input go-version=stable --matrix "chunk:$$chunk"
 
 .PHONY: fix-modules
 fix-modules: tools-install ## Fix module dependencies and consistency

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Targets:
   test/integration     Run integration tests
   test-deadlock        Run tests with deadlock detection
   test-debug-deadlock  Run tests with debug and deadlock detection
+  ci/run               Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
+  ci/services          Start CI's service containers (all, or SERVICES="a b")
+  ci/services/pull     Re-pull CI's images at CI's platform (repairs wrong-arch cache)
+  ci/services/down     Stop CI's service containers
+  ci/core              Run CI's test-core entrypoint alone (services must be up)
+  ci/contrib/chunks    List the contrib chunks CI splits test-contrib into
+  ci/contrib           Run one test-contrib chunk alone (services must be up)
   fix-modules          Fix module dependencies and consistency
   fix/go               Apply go fix modernizations to Go code
   fix/go/diff          Preview go fix modernizations (dry-run)
@@ -107,3 +114,7 @@ For example if you're running tests that need the `mysql` database container to 
 ```shell
 docker compose -f docker-compose.yaml -p dd-trace-go up -d mysql
 ```
+
+These targets are not what CI runs. CI uses different entrypoints and different versions of the service containers. 
+
+To reproduce a CI failure, run `make ci/run JOB=core` or `make ci/run JOB=contrib CHUNK=n`. The target starts CI's service containers, runs the job, then stops the containers. For the per-step targets and the limits on Apple Silicon, see [Reproducing CI locally](./CONTRIBUTING.md#reproducing-ci-locally).

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Targets:
   test/integration     Run integration tests
   test-deadlock        Run tests with deadlock detection
   test-debug-deadlock  Run tests with debug and deadlock detection
+  ci/runner/build      Build the containerized CI runner image (GO_VERSION=1.26|1.27, default 1.27)
+  ci/cache/clean       Remove the CI runner's Go module and build cache volumes
   ci/run               Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
   ci/services          Start CI's service containers (all, or SERVICES="a b")
   ci/services/pull     Re-pull CI's images at CI's platform (repairs wrong-arch cache)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Targets:
   ci/core              Run CI's test-core entrypoint alone (services must be up)
   ci/contrib/chunks    List the contrib chunks CI splits test-contrib into
   ci/contrib           Run one test-contrib chunk alone (services must be up)
+  act/list             List jobs in the workflows act can run (see .github/act/README.md)
+  act/generate         Run generate.yml under act (tests the last pushed commit, see .github/act/README.md)
+  act/static-checks    Run static-checks.yml's jobs under act (excludes reviewdog-wrapped `lint`, use `make lint` for that)
+  act/core-tests       Run unit-integration-tests.yml's test-core job under act
+  act/contrib-tests    Run one unit-integration-tests.yml test-contrib-matrix chunk under act (CHUNK=n, see `make ci/contrib/chunks`)
   fix-modules          Fix module dependencies and consistency
   fix/go               Apply go fix modernizations to Go code
   fix/go/diff          Preview go fix modernizations (dry-run)
@@ -118,3 +123,5 @@ docker compose -f docker-compose.yaml -p dd-trace-go up -d mysql
 These targets are not what CI runs. CI uses different entrypoints and different versions of the service containers. 
 
 To reproduce a CI failure, run `make ci/run JOB=core` or `make ci/run JOB=contrib CHUNK=n`. The target starts CI's service containers, runs the job, then stops the containers. For the per-step targets and the limits on Apple Silicon, see [Reproducing CI locally](./CONTRIBUTING.md#reproducing-ci-locally).
+
+To check an edit to a workflow's YAML itself (job graph, matrix, step logic) before you push, run it under act: `make act/generate`, `make act/static-checks`, `make act/core-tests`, or `make act/contrib-tests CHUNK=n`. See [.github/act/README.md](./.github/act/README.md).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,9 @@
+# This is NOT the stack CI uses. `.github/workflows/unit-integration-tests.yml`
+# uses .github/testservices/docker-compose.yaml, which pins different — mostly
+# older — image versions on purpose. The divergence is deliberate and is
+# tabulated under "Reproducing CI locally" in CONTRIBUTING.md. To reproduce a
+# CI failure against CI's versions, use `make ci/run` instead of this file.
+
 services:
   aerospike:
     image: aerospike:ce-8.1.2.4_1@sha256:fb172169a3b0c217563a4c7eb88ef117c4d24ac64a3a66ad99a18c0dca36bd8c

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,6 +53,13 @@ Targets:
   test/integration     Run integration tests
   test-deadlock        Run tests with deadlock detection
   test-debug-deadlock  Run tests with debug and deadlock detection
+  ci/run               Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
+  ci/services          Start CI's service containers (all, or SERVICES="a b")
+  ci/services/pull     Re-pull CI's images at CI's platform (repairs wrong-arch cache)
+  ci/services/down     Stop CI's service containers
+  ci/core              Run CI's test-core entrypoint alone (services must be up)
+  ci/contrib/chunks    List the contrib chunks CI splits test-contrib into
+  ci/contrib           Run one test-contrib chunk alone (services must be up)
   fix-modules          Fix module dependencies and consistency
   fix/go               Apply go fix modernizations to Go code
   fix/go/diff          Preview go fix modernizations (dry-run)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,6 +53,8 @@ Targets:
   test/integration     Run integration tests
   test-deadlock        Run tests with deadlock detection
   test-debug-deadlock  Run tests with debug and deadlock detection
+  ci/runner/build      Build the containerized CI runner image (GO_VERSION=1.26|1.27, default 1.27)
+  ci/cache/clean       Remove the CI runner's Go module and build cache volumes
   ci/run               Reproduce a CI job end to end (JOB=core|contrib, CHUNK=n)
   ci/services          Start CI's service containers (all, or SERVICES="a b")
   ci/services/pull     Re-pull CI's images at CI's platform (repairs wrong-arch cache)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,6 +60,11 @@ Targets:
   ci/core              Run CI's test-core entrypoint alone (services must be up)
   ci/contrib/chunks    List the contrib chunks CI splits test-contrib into
   ci/contrib           Run one test-contrib chunk alone (services must be up)
+  act/list             List jobs in the workflows act can run (see .github/act/README.md)
+  act/generate         Run generate.yml under act (tests the last pushed commit, see .github/act/README.md)
+  act/static-checks    Run static-checks.yml's jobs under act (excludes reviewdog-wrapped `lint`, use `make lint` for that)
+  act/core-tests       Run unit-integration-tests.yml's test-core job under act
+  act/contrib-tests    Run one unit-integration-tests.yml test-contrib-matrix chunk under act (CHUNK=n, see `make ci/contrib/chunks`)
   fix-modules          Fix module dependencies and consistency
   fix/go               Apply go fix modernizations to Go code
   fix/go/diff          Preview go fix modernizations (dry-run)

--- a/scripts/act.sh
+++ b/scripts/act.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+  cat << EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [act args...]
+
+Thin wrapper around \`act\` (https://github.com/nektos/act): checks that act and Docker are
+available, then forwards every argument straight through to act. Flags in .actrc (platform
+mappings, --network, --artifact-server-path) apply automatically since act reads it from the
+working directory.
+
+See .github/act/README.md for what act validates, and what it does not, before you rely on it.
+
+Examples:
+  $(basename "${BASH_SOURCE[0]}") -W .github/workflows/generate.yml -j generate
+  $(basename "${BASH_SOURCE[0]}") -W .github/workflows/static-checks.yml -j checklocks
+  $(basename "${BASH_SOURCE[0]}") -l                          # list every job act can see
+EOF
+  exit 0
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+if ! command -v act > /dev/null 2>&1; then
+  echo "act is required: brew install act (see .github/act/README.md)" >&2
+  exit 1
+fi
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker must be running to use act" >&2
+  exit 1
+fi
+
+exec act "$@"

--- a/scripts/ci-runner/go1.26/Dockerfile
+++ b/scripts/ci-runner/go1.26/Dockerfile
@@ -1,0 +1,22 @@
+# This image pins the digest, following the convention in internal/apps/Dockerfile.
+# Dependabot refreshes the digest weekly through the docker group in .github/dependabot.yml.
+# make ci/core and make ci/contrib run inside this image for CI-matching Go 1.26 test runs.
+FROM golang:1.26-bookworm@sha256:9fdc884aacc3bec89b20ffc69f4bb369c78210e3e4f600387b5128b12c199f81 AS tools
+COPY _tools/ /dd-trace-go/_tools/
+COPY scripts/install_tools.sh /dd-trace-go/scripts/install_tools.sh
+COPY .github/workflows/apps/go-retry.sh /dd-trace-go/.github/workflows/apps/go-retry.sh
+WORKDIR /dd-trace-go
+RUN ./scripts/install_tools.sh --tools-dir _tools --bin-dir /opt/dd-trace-go-tools/bin
+
+FROM golang:1.26-bookworm@sha256:9fdc884aacc3bec89b20ffc69f4bb369c78210e3e4f600387b5128b12c199f81
+COPY --from=tools /opt/dd-trace-go-tools/bin /opt/dd-trace-go-tools/bin
+ENV PATH="/opt/dd-trace-go-tools/bin:${PATH}"
+# CI's GitHub-hosted runner runs tests as a non-root user, and some tests assert real
+# permission enforcement that root would bypass. scripts/ci_runner_run.sh drops to this
+# fixed UID with setpriv. setpriv --init-groups requires a real passwd entry, so this user
+# needs a home directory. GOPATH and GOCACHE sit under world-writable paths so that UID can
+# write to the cache volumes mounted there.
+RUN useradd --uid 1000 --create-home ciuser
+ENV GOPATH=/go GOCACHE=/go-build HOME=/home/ciuser
+RUN mkdir -p /go/pkg/mod /go-build && chmod -R 1777 /go /go-build
+WORKDIR /workspace

--- a/scripts/ci-runner/go1.27/Dockerfile
+++ b/scripts/ci-runner/go1.27/Dockerfile
@@ -1,0 +1,22 @@
+# This image pins the digest, following the convention in internal/apps/Dockerfile.
+# Dependabot refreshes the digest weekly through the docker group in .github/dependabot.yml.
+# make ci/core and make ci/contrib run inside this image for CI-matching Go 1.27 test runs.
+FROM golang:1.27-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b AS tools
+COPY _tools/ /dd-trace-go/_tools/
+COPY scripts/install_tools.sh /dd-trace-go/scripts/install_tools.sh
+COPY .github/workflows/apps/go-retry.sh /dd-trace-go/.github/workflows/apps/go-retry.sh
+WORKDIR /dd-trace-go
+RUN ./scripts/install_tools.sh --tools-dir _tools --bin-dir /opt/dd-trace-go-tools/bin
+
+FROM golang:1.27-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b
+COPY --from=tools /opt/dd-trace-go-tools/bin /opt/dd-trace-go-tools/bin
+ENV PATH="/opt/dd-trace-go-tools/bin:${PATH}"
+# CI's GitHub-hosted runner runs tests as a non-root user, and some tests assert real
+# permission enforcement that root would bypass. scripts/ci_runner_run.sh drops to this
+# fixed UID with setpriv. setpriv --init-groups requires a real passwd entry, so this user
+# needs a home directory. GOPATH and GOCACHE sit under world-writable paths so that UID can
+# write to the cache volumes mounted there.
+RUN useradd --uid 1000 --create-home ciuser
+ENV GOPATH=/go GOCACHE=/go-build HOME=/home/ciuser
+RUN mkdir -p /go/pkg/mod /go-build && chmod -R 1777 /go /go-build
+WORKDIR /workspace

--- a/scripts/ci_runner_run.sh
+++ b/scripts/ci_runner_run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat << EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-e KEY=VALUE ...] -- IMAGE COMMAND [ARG...]
+
+Runs COMMAND inside IMAGE, the way make ci/core and make ci/contrib do. The script copies
+the working tree into the container instead of bind-mounting it, then copies changed files
+back to the host when COMMAND exits.
+
+A bind mount is not used because Docker Desktop's bind-mount filesystem on macOS does not
+enforce Unix file permissions. A permission-enforcing test then fails for the wrong reason.
+For example, a 0000-permission file stays readable through a bind mount, but not through a
+container-native path.
+
+The container receives a copy of .git, because some tests read git metadata from the
+working tree. The script deletes that copy right before the container exits. The final
+copy-out therefore never overwrites the host's live .git with a stale snapshot from a long
+run.
+
+The script reads CI_RUNNER_PLATFORM, CI_RUNNER_GOMODCACHE, CI_RUNNER_GOCACHE,
+CI_TEST_RESULTS, and BUILD_TAGS from the environment.
+EOF
+  exit 0
+}
+
+EXTRA_ENV=()
+while [[ "${1:-}" != "--" ]]; do
+  case "${1:-}" in
+    -e)
+      EXTRA_ENV+=(-e "$2")
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      ;;
+    *)
+      echo "unexpected argument: ${1:-<none>}, expected -e KEY=VALUE or --" >&2
+      exit 1
+      ;;
+  esac
+done
+shift # drop the --
+
+IMAGE="$1"
+shift
+
+# Non-root user for permission-enforcing tests
+CID=$(docker create --platform "$CI_RUNNER_PLATFORM" --network host \
+  -v "$CI_RUNNER_GOMODCACHE:/go/pkg/mod" \
+  -v "$CI_RUNNER_GOCACHE:/go-build" \
+  -v "$CI_TEST_RESULTS:/tmp/test-results" \
+  -e INTEGRATION=true -e GOTOOLCHAIN=local -e GODEBUG=x509negativeserial=1 \
+  -e TEST_RESULTS=/tmp/test-results -e "BUILD_TAGS=$BUILD_TAGS" \
+  "${EXTRA_ENV[@]+"${EXTRA_ENV[@]}"}" \
+  "$IMAGE" sh -c '
+    chown -R 1000:1000 /workspace &&
+    setpriv --reuid=1000 --regid=1000 --init-groups -- "$@"
+    status=$?
+    rm -rf /workspace/.git /workspace/bin
+    exit "$status"
+  ' -- "$@")
+
+cleanup() { docker rm -f "$CID" > /dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+docker cp . "$CID":/workspace
+docker start -a "$CID"
+STATUS=$(docker inspect "$CID" --format '{{.State.ExitCode}}')
+
+docker cp "$CID":/workspace/. .
+
+exit "$STATUS"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Commit and PR titles should be prefixed with the general area of the pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

R&D Week

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
* If this resolves a GitHub issue, include "Fixes #XXXX" to link the issue and auto-close it on merge.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
