### PR TITLE
fix(openfeature): fix agentless ETag test flakes and a related init deadlock

### DIFF
--- a/openfeature/agentless_source_httptest_test.go
+++ b/openfeature/agentless_source_httptest_test.go
@@ -28,6 +28,11 @@ import (
 // system-tests' utils/mocked_backend/ffe.py UFC_ETAG.
 const fakeUFCBackendETag = `"ufc-v1"`
 
+// fakeUFCBackendMalformedETag is the ETag a "malformed_with_etag" response
+// carries. It must differ from fakeUFCBackendETag so a test can assert that
+// the source's held ETag did not advance to it.
+const fakeUFCBackendMalformedETag = `"ufc-malformed"`
+
 const fakeUFCValidBody = `{
 	"data": {
 		"id": "1",
@@ -104,6 +109,14 @@ func (b *fakeUFCBackend) handle(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"flags": [`))
+	case "malformed_with_etag":
+		// Carries its own distinct ETag so a test can tell "the held ETag did
+		// not advance to this response's ETag" apart from "there was no ETag to
+		// advance to".
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", fakeUFCBackendMalformedETag)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"flags": [`))
 	case "not_modified":
 		w.Header().Set("ETag", fakeUFCBackendETag)
 		w.WriteHeader(http.StatusNotModified)
@@ -144,9 +157,12 @@ func (b *fakeUFCBackend) handle(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// newTestAgentlessSource builds a source pointed at backend's origin, with
-// retries sped up (no real waiting) unless the test needs otherwise.
-func newTestAgentlessSource(t *testing.T, backend *fakeUFCBackend, pollInterval time.Duration, apply func(*universalFlagsConfiguration)) *agentlessSource {
+// newAgentlessSourceOnly builds a source pointed at backend's origin, with
+// retries sped up (no real waiting), but never calls start(). Stop on a
+// source whose run loop never started would otherwise wait out its full
+// context timeout in cleanup, since doneCh would never close: this leaves
+// lifecycle to the caller instead, for tests that drive pollOnce directly.
+func newAgentlessSourceOnly(t *testing.T, backend *fakeUFCBackend, pollInterval time.Duration, apply func(*universalFlagsConfiguration)) *agentlessSource {
 	t.Helper()
 	src, err := newAgentlessSource(internalffe.Settings{
 		AgentlessBaseURL: backend.server.URL,
@@ -155,6 +171,15 @@ func newTestAgentlessSource(t *testing.T, backend *fakeUFCBackend, pollInterval 
 	}, apply)
 	require.NoError(t, err)
 	src.retryDelay = func(int) time.Duration { return 0 }
+	return src
+}
+
+// newTestAgentlessSource builds a source pointed at backend's origin, with
+// retries sped up (no real waiting) unless the test needs otherwise, and
+// starts its poll loop.
+func newTestAgentlessSource(t *testing.T, backend *fakeUFCBackend, pollInterval time.Duration, apply func(*universalFlagsConfiguration)) *agentlessSource {
+	t.Helper()
+	src := newAgentlessSourceOnly(t, backend, pollInterval, apply)
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -180,73 +205,96 @@ func TestAgentlessSource_StartDoesNotBlock(t *testing.T) {
 	}, 2*time.Second, time.Millisecond, "the first poll must still happen, just asynchronously")
 }
 
+// TestAgentlessSource_ETagNotAdvancedOnParseFailure drives pollOnce directly,
+// rather than start()+Eventually on a request count: the previous version
+// waited for requestsTotal >= 3, then read the backend's single shared
+// lastIfNoneMatch field, which a fourth request (the loop's next tick) could
+// overwrite before the assertion ran, and a request count alone cannot
+// distinguish a request that arrived from one whose response was already
+// processed. Calling pollOnce synchronously removes both races: each call
+// only returns once its request has both arrived and been fully handled, and
+// each backend.status() snapshot is read for the specific request that
+// produced it, not for whatever request happens to be latest.
 func TestAgentlessSource_ETagNotAdvancedOnParseFailure(t *testing.T) {
 	backend := newFakeUFCBackend(t)
-	backend.setResponses("valid", "malformed", "not_modified")
+	// The malformed response carries its own distinct ETag: this test's
+	// contract is that a malformed body never advances the held ETag to a new
+	// value, and a malformed response with no ETag at all could not tell that
+	// apart from correctly not advancing.
+	backend.setResponses("valid", "malformed_with_etag", "not_modified")
 
 	var mu sync.Mutex
 	var applied []*universalFlagsConfiguration
-	src := newTestAgentlessSource(t, backend, 5*time.Millisecond, func(c *universalFlagsConfiguration) {
+	src := newAgentlessSourceOnly(t, backend, time.Hour, func(c *universalFlagsConfiguration) {
 		mu.Lock()
 		defer mu.Unlock()
 		applied = append(applied, c)
 	})
 
-	src.start()
+	outer, _ := src.pollOnce() // valid: applies configuration and stores the ETag
+	require.Equal(t, pollOutcomeSuccess, outer)
+	assert.Equal(t, fakeUFCBackendETag, src.currentETag())
 
-	require.Eventually(t, func() bool {
-		requests, _, _, _ := backend.status()
-		return requests >= 3
-	}, 2*time.Second, time.Millisecond)
+	outer, _ = src.pollOnce() // malformed_with_etag: must not advance the ETag
+	require.Equal(t, pollOutcomeStop, outer)
+	assert.Equal(t, fakeUFCBackendETag, src.currentETag(), "a malformed payload must never be acknowledged as received")
 
-	// The third request (after the malformed second response) must still
-	// carry the ETag from the first, valid response: a malformed payload
-	// must never be acknowledged as received.
 	_, _, lastIfNoneMatch, _ := backend.status()
-	assert.Equal(t, fakeUFCBackendETag, lastIfNoneMatch)
+	assert.Equal(t, fakeUFCBackendETag, lastIfNoneMatch, "the third request must still carry the ETag from the first, valid response")
+
+	outer, _ = src.pollOnce() // not_modified: confirms the server still recognizes that ETag
+	require.Equal(t, pollOutcomeSuccess, outer)
 
 	mu.Lock()
 	defer mu.Unlock()
 	require.Len(t, applied, 1, "only the first, valid poll should have applied a configuration")
 }
 
+// TestAgentlessSource_ETagAnd304 drives pollOnce directly instead of
+// start()+Eventually: waiting for requestsTotal >= 1 only proves a request
+// arrived, not that its response was processed, and a second request (the
+// loop's next tick) could overwrite the backend's shared lastIfNoneMatch
+// field before either assertion ran.
 func TestAgentlessSource_ETagAnd304(t *testing.T) {
 	backend := newFakeUFCBackend(t)
 	backend.setResponses("valid", "not_modified")
 
-	src := newTestAgentlessSource(t, backend, 5*time.Millisecond, func(*universalFlagsConfiguration) {})
-	src.start()
+	src := newAgentlessSourceOnly(t, backend, time.Hour, func(*universalFlagsConfiguration) {})
 
-	require.Eventually(t, func() bool {
-		requests, _, _, _ := backend.status()
-		return requests >= 1
-	}, 2*time.Second, time.Millisecond)
+	outer, _ := src.pollOnce()
+	require.Equal(t, pollOutcomeSuccess, outer)
 	_, _, lastIfNoneMatch, _ := backend.status()
 	assert.Empty(t, lastIfNoneMatch, "the first request must not carry an ETag")
 
-	require.Eventually(t, func() bool {
-		requests, _, _, _ := backend.status()
-		return requests >= 2
-	}, 2*time.Second, time.Millisecond)
-
+	outer, _ = src.pollOnce()
+	require.Equal(t, pollOutcomeSuccess, outer)
 	_, _, lastIfNoneMatch, _ = backend.status()
-	assert.Equal(t, fakeUFCBackendETag, lastIfNoneMatch)
+	assert.Equal(t, fakeUFCBackendETag, lastIfNoneMatch, "the second request must carry the ETag stored from the first")
 }
 
+// TestAgentlessSource_BlankETagClears drives pollOnce directly instead of
+// start()+Eventually on a request count, for the same reason as the two
+// tests above: requestsTotal >= 3 only proves the third request arrived, and
+// a fourth request could overwrite the shared lastIfNoneMatch field before
+// the assertion ran.
 func TestAgentlessSource_BlankETagClears(t *testing.T) {
 	backend := newFakeUFCBackend(t)
 	backend.setResponses("valid", "valid_no_etag", "valid")
 
-	src := newTestAgentlessSource(t, backend, 5*time.Millisecond, func(*universalFlagsConfiguration) {})
-	src.start()
+	src := newAgentlessSourceOnly(t, backend, time.Hour, func(*universalFlagsConfiguration) {})
 
-	require.Eventually(t, func() bool {
-		requests, _, _, _ := backend.status()
-		return requests >= 3
-	}, 2*time.Second, time.Millisecond)
+	outer, _ := src.pollOnce() // valid: stores the ETag
+	require.Equal(t, pollOutcomeSuccess, outer)
+	assert.Equal(t, fakeUFCBackendETag, src.currentETag())
 
+	outer, _ = src.pollOnce() // valid_no_etag: must clear the held ETag
+	require.Equal(t, pollOutcomeSuccess, outer)
+	assert.Empty(t, src.currentETag(), "a blank ETag response must clear the held ETag")
+
+	outer, _ = src.pollOnce() // valid: confirms the cleared ETag reached the request
+	require.Equal(t, pollOutcomeSuccess, outer)
 	_, _, lastIfNoneMatch, _ := backend.status()
-	assert.Empty(t, lastIfNoneMatch, "a blank ETag response must clear the held ETag")
+	assert.Empty(t, lastIfNoneMatch, "the third request must not carry an ETag, since the second response cleared it")
 }
 
 func TestAgentlessSource_RetryWithinPoll(t *testing.T) {
@@ -306,7 +354,11 @@ func TestAgentlessSource_PollOnceReturnsRetryAfter(t *testing.T) {
 	backend := newFakeUFCBackend(t)
 	backend.setResponses("throttled")
 
-	src := newTestAgentlessSource(t, backend, time.Hour, func(*universalFlagsConfiguration) {})
+	// This source's run loop never starts, so it must use newAgentlessSourceOnly,
+	// not newTestAgentlessSource: the latter's cleanup calls Stop, which would
+	// wait out its full context timeout for a doneCh that a never-started run
+	// loop can never close.
+	src := newAgentlessSourceOnly(t, backend, time.Hour, func(*universalFlagsConfiguration) {})
 	outcome, retryAfter := src.pollOnce()
 	assert.Equal(t, pollOutcomeRetryable, outcome)
 	assert.Equal(t, 2*time.Second, retryAfter)

--- a/openfeature/exposure_test.go
+++ b/openfeature/exposure_test.go
@@ -432,16 +432,24 @@ func TestExposureWriter_ConcurrentAppend(t *testing.T) {
 	wg.Wait()
 
 	// Verify no panic occurred and buffer has events
-	// Due to deduplication, we expect fewer events than total operations
 	if len(writer.buffer) == 0 {
 		t.Error("expected some events in buffer after concurrent appends")
 	}
 
-	// With 10 unique (flag, subject) pairs and varying allocations/variants,
-	// we should have significantly fewer events than numGoroutines * opsPerGoroutine
+	// The dedup cache key is (flag, subject) only; allocation is part of the
+	// cached value, so an allocation change on an existing key is a real
+	// change, not a duplicate. With allocation varying by goroutineID%3, a
+	// legal interleaving can make every append to a given (flag, subject) key
+	// observe a different allocation than the previous one — for example,
+	// goroutines completing in round-robin order by ID. Deduplication then
+	// correctly keeps every one of those changes, so the buffer can be as
+	// large as numGoroutines*opsPerGoroutine; it can never exceed that, since
+	// each append contributes at most one buffered event.
+	// TestExposureWriter_ConcurrentAppend_Deduplication below is the test that
+	// pins strict deduplication, using identical events from every goroutine.
 	totalOps := numGoroutines * opsPerGoroutine
-	if len(writer.buffer) >= totalOps {
-		t.Errorf("deduplication not working: got %d events, expected fewer than %d", len(writer.buffer), totalOps)
+	if len(writer.buffer) > totalOps {
+		t.Errorf("got %d events, expected at most %d", len(writer.buffer), totalOps)
 	}
 }
 

--- a/openfeature/flageval_pii_test.go
+++ b/openfeature/flageval_pii_test.go
@@ -222,7 +222,6 @@ func TestProviderStampsConsentFromEvaluatedConfig(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &DatadogProvider{configuration: tc.config}
-			p.configChange.L = &p.mu
 
 			res := p.evaluate(context.Background(), "pii-flag", "fallback", of.FlattenedContext{
 				of.TargetingKey: piiCanonicalTargetingKey,
@@ -240,7 +239,6 @@ func TestProviderStampsConsentFromEvaluatedConfig(t *testing.T) {
 
 	t.Run("missing flag still carries consent", func(t *testing.T) {
 		p := &DatadogProvider{configuration: piiTestConfig(true)}
-		p.configChange.L = &p.mu
 
 		res := p.evaluate(context.Background(), "no-such-flag", "fallback", of.FlattenedContext{
 			of.TargetingKey: piiCanonicalTargetingKey,
@@ -596,7 +594,6 @@ func TestConsentIsNotReReadAfterEvaluation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &DatadogProvider{configuration: piiTestConfig(tc.consentAtEvaluation)}
-			p.configChange.L = &p.mu
 			w := newFlagEvalLoggingWriter(ProviderConfig{})
 
 			// Evaluate against the current configuration, then run the hook exactly as the

--- a/openfeature/integration_test.go
+++ b/openfeature/integration_test.go
@@ -24,8 +24,12 @@ import (
 // TestEndToEnd_BooleanFlag tests the complete flow from configuration to flag evaluation
 // using the actual OpenFeature SDK client.
 func TestEndToEnd_BooleanFlag(t *testing.T) {
-	// Create provider and configuration
-	provider := newDatadogProvider(ProviderConfig{})
+	// Create provider and configuration. ExposureFlushInterval is set far
+	// beyond this test's runtime: this test only asserts on the writer's
+	// buffer, which append populates synchronously, but SetProviderAndWait
+	// below starts the background flush ticker, which could otherwise drain
+	// a correctly recorded event out of the buffer before a subtest reads it.
+	provider := newDatadogProvider(ProviderConfig{ExposureFlushInterval: time.Hour})
 	config := createE2EBooleanConfig()
 	provider.updateConfiguration(&config)
 
@@ -303,7 +307,11 @@ func TestEndToEnd_IntegerFlag(t *testing.T) {
 
 // TestEndToEnd_FloatFlag tests float flag evaluation.
 func TestEndToEnd_FloatFlag(t *testing.T) {
-	provider := newDatadogProvider(ProviderConfig{})
+	// ExposureFlushInterval is set far beyond this test's runtime for the same
+	// reason as TestEndToEnd_BooleanFlag: this test only asserts on the
+	// writer's buffer, and the background flush ticker could otherwise drain
+	// it first.
+	provider := newDatadogProvider(ProviderConfig{ExposureFlushInterval: time.Hour})
 	config := createE2EFloatConfig()
 	provider.updateConfiguration(config)
 
@@ -332,8 +340,9 @@ func TestEndToEnd_FloatFlag(t *testing.T) {
 		t.Errorf("expected 0.15, got %f", value)
 	}
 
-	// Verify exposure event was recorded
-	time.Sleep(10 * time.Millisecond)
+	// Verify exposure event was recorded. append is synchronous, and the
+	// background flush ticker cannot fire within this test's runtime (see
+	// the ExposureFlushInterval comment above), so no sleep is needed here.
 	exposures := getExposureBuffer(writer)
 	if len(exposures) <= initialBufferSize {
 		t.Error("expected exposure event to be recorded")
@@ -1602,7 +1611,8 @@ func TestEndToEnd_ExposureFlushInterval(t *testing.T) {
 	}
 }
 
-// TestEndToEnd_ExposureDoLogFalse tests that exposure events are NOT sent when doLog is false.
+// TestEndToEnd_ExposureDoLogFalse tests that exposure events are NOT sent
+// when doLog is false.
 func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 	var receivedCount int
 	var mu sync.Mutex
@@ -1615,16 +1625,25 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
-	defer server.Close()
+	// The explicit flush below must reach this server, so close it only
+	// after the provider (registered via t.Cleanup below) has stopped:
+	// t.Cleanup runs in LIFO order, so registering this Close first runs it
+	// last.
+	t.Cleanup(server.Close)
 
 	t.Setenv("DD_TRACE_AGENT_URL", server.URL)
 	t.Setenv("DD_SERVICE", "dolog-test")
 
+	// A background flush ticker would race the buffer assertions below, so
+	// this test flushes explicitly instead of waiting on ExposureFlushInterval.
 	provider := newDatadogProvider(ProviderConfig{
-		ExposureFlushInterval: 50 * time.Millisecond,
+		ExposureFlushInterval: time.Hour,
 	})
 
-	// Create config with doLog=false
+	// no-log-flag has DoLog=false: evaluating it must never buffer an event.
+	// logged-flag has the default DoLog (true) and is the positive control:
+	// without it, a regression that stopped buffering for every flag would
+	// pass this test for the wrong reason.
 	config := &universalFlagsConfiguration{
 		Format: "SERVER",
 		Environment: environment{
@@ -1652,6 +1671,26 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 					},
 				},
 			},
+			"logged-flag": {
+				Key:           "logged-flag",
+				Enabled:       true,
+				VariationType: valueTypeBoolean,
+				Variations: map[string]*variant{
+					"on": {Key: "on", Value: true},
+				},
+				Allocations: []*allocation{
+					{
+						Key:   "logged-allocation",
+						Rules: []*rule{},
+						Splits: []*split{
+							{
+								Shards:       []*shard{},
+								VariationKey: "on",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	provider.updateConfiguration(config)
@@ -1664,8 +1703,6 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 		provider.Shutdown()
 	})
 
-	time.Sleep(20 * time.Millisecond)
-
 	client := of.NewClient("test-app-dolog")
 	ctx := context.Background()
 
@@ -1675,7 +1712,9 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 	writer.buffer = make([]exposureEvent, 0)
 	writer.mu.Unlock()
 
-	// Evaluate flag multiple times
+	// Evaluate the doLog=false flag multiple times and assert absence at the
+	// synchronous enqueue seam, rather than through a finite sleep-based
+	// observation window that a delayed flush worker could pass vacuously.
 	for i := range 5 {
 		evalCtx := of.NewEvaluationContext(fmt.Sprintf("user-%d", i), map[string]any{})
 		_, err := client.BooleanValue(ctx, "no-log-flag", false, evalCtx)
@@ -1683,17 +1722,34 @@ func TestEndToEnd_ExposureDoLogFalse(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}
+	if buf := getExposureBuffer(writer); len(buf) != 0 {
+		t.Errorf("expected no buffered events for doLog=false, got %d", len(buf))
+	}
 
-	// Wait for potential flush
-	time.Sleep(150 * time.Millisecond)
+	// Positive control: the default-DoLog flag must still buffer and flush,
+	// establishing that the transport and hook path work at all.
+	evalCtx := of.NewEvaluationContext("control-user", map[string]any{})
+	_, err = client.BooleanValue(ctx, "logged-flag", false, evalCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf := getExposureBuffer(writer); len(buf) != 1 {
+		t.Fatalf("expected exactly 1 buffered event for the positive control, got %d", len(buf))
+	}
+
+	writer.flush()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return receivedCount > 0
+	}, 5*time.Second, time.Millisecond, "expected the positive control's flush to reach the agent")
 
 	mu.Lock()
 	count := receivedCount
 	mu.Unlock()
-
-	// Should NOT have received any payloads
-	if count > 0 {
-		t.Errorf("expected NO exposure events with doLog=false, but received %d payloads", count)
+	if count != 1 {
+		t.Errorf("expected exactly 1 payload (the positive control only), got %d", count)
 	}
 }
 
@@ -1825,29 +1881,33 @@ func TestEndToEnd_ExposureContextAttributes(t *testing.T) {
 	}
 }
 
-// TestEndToEnd_ExposureAgentSide tests that the payload is good
+// TestEndToEnd_ExposureAgentSide tests that the payload structure the writer
+// sends is well formed, using a server that responds 200 (the assertions
+// exercise the payload the client actually sent, not the agent's handling of
+// an error response).
 func TestEndToEnd_ExposureAgentSide(t *testing.T) {
-	// Create a server that always returns errors
+	// Send each decoded payload (or decode error) to the test goroutine over a
+	// channel, rather than asserting inside the handler goroutine: require's
+	// FailNow only stops the calling goroutine via runtime.Goexit, so a
+	// failure there would not reliably fail the test, and the test could
+	// return before the handler even runs.
+	payloads := make(chan exposurePayload, 1)
+	decodeErrs := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
-		var expPayload exposurePayload
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&expPayload))
-
-		// Verify that the payload has the expected structure
-		require.NotEmpty(t, expPayload.Exposures)
-		for _, exp := range expPayload.Exposures {
-			require.NotEmpty(t, exp.Flag.Key)
-			require.NotEmpty(t, exp.Subject.ID)
-			require.NotEmpty(t, exp.Variant.Key)
-			require.NotZero(t, exp.Timestamp)
+		var payload exposurePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			decodeErrs <- err
+			return
 		}
-
-		require.NotEmpty(t, expPayload.Context.Version)
-		require.NotEmpty(t, expPayload.Context.Service)
-		require.NotEmpty(t, expPayload.Context.Env)
+		payloads <- payload
 	}))
-	defer server.Close()
+	// The provider's own shutdown flush must reach this server, so close it
+	// only after the provider (registered via t.Cleanup below) has stopped:
+	// t.Cleanup runs in LIFO order, so registering this Close first runs it
+	// last.
+	t.Cleanup(server.Close)
 
 	t.Setenv("DD_TRACE_AGENT_URL", server.URL)
 	t.Setenv("DD_SERVICE", "error-test")
@@ -1889,11 +1949,31 @@ func TestEndToEnd_ExposureAgentSide(t *testing.T) {
 		t.Error("expected feature to be enabled despite agent failure")
 	}
 
-	// Events should still be buffered locally
-	_ = getExposureBuffer(writer)
+	// Wait for the handler to receive and decode a payload, rather than
+	// sleeping a fixed interval and never checking whether it did: the flush
+	// is asynchronous, so a loaded CI runner can take longer than any
+	// interval short enough to keep the test fast.
+	var payload exposurePayload
+	select {
+	case payload = <-payloads:
+	case err := <-decodeErrs:
+		t.Fatalf("failed to decode exposure payload: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for an exposure payload")
+	}
 
-	// After flush attempt, buffer should be cleared (even though send failed)
-	time.Sleep(150 * time.Millisecond)
+	// Verify that the payload has the expected structure.
+	require.NotEmpty(t, payload.Exposures)
+	for _, exp := range payload.Exposures {
+		require.NotEmpty(t, exp.Flag.Key)
+		require.NotEmpty(t, exp.Subject.ID)
+		require.NotEmpty(t, exp.Variant.Key)
+		require.NotZero(t, exp.Timestamp)
+	}
+
+	require.NotEmpty(t, payload.Context.Version)
+	require.NotEmpty(t, payload.Context.Service)
+	require.NotEmpty(t, payload.Context.Env)
 }
 
 // TestEndToEnd_AllThreeFixes tests a complex scenario that exercises all three fixes together.
@@ -2048,6 +2128,12 @@ func TestEndToEnd_ExposureSerialID(t *testing.T) {
 		}
 	}`))
 	require.Equal(t, rc.ApplyStateAcknowledged, status.State)
+
+	// The SDK has no API to unregister a named provider; it retains this
+	// registration, and the background exposure/flag-evaluation writers
+	// SetNamedProviderAndWait starts, for the rest of the test process unless
+	// stopped directly.
+	t.Cleanup(provider.Shutdown)
 
 	domain := "exposure-serial-id-test-app"
 	require.NoError(t, of.SetNamedProviderAndWait(domain, provider))

--- a/openfeature/integration_test.go
+++ b/openfeature/integration_test.go
@@ -1449,74 +1449,84 @@ func TestEndToEnd_ExposurePayloadStructure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Wait for the flush to reach the fake agent. Polling rather than sleeping a
-	// fixed interval: the flush is asynchronous, so a loaded CI runner can take
+	// Wait for both exposures to reach the fake agent, across however many
+	// payloads they land in. The 50ms flush interval can legitimately drain
+	// the buffer between the two evaluations above, splitting them into two
+	// one-exposure payloads instead of a single two-exposure one: this test's
+	// contract is that both exposures arrive with the right fields, not that
+	// they share a batch boundary. Polling rather than sleeping a fixed
+	// interval: the flush is asynchronous, so a loaded CI runner can take
 	// longer than any interval short enough to keep the test fast.
+	var allExposures []exposureEvent
+	var firstPayloadContext exposureContext
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(receivedPayloads) > 0
-	}, 5*time.Second, time.Millisecond, "expected at least one payload to be sent to agent")
-
-	// Verify payloads were received
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Verify payload structure
-	payload := receivedPayloads[0]
+		allExposures = nil
+		for _, payload := range receivedPayloads {
+			allExposures = append(allExposures, payload.Exposures...)
+		}
+		if len(receivedPayloads) > 0 {
+			firstPayloadContext = receivedPayloads[0].Context
+		}
+		return len(allExposures) >= 2
+	}, 5*time.Second, time.Millisecond, "expected both exposures to be sent to agent")
 
 	// Log context for debugging
-	t.Logf("Payload context: %+v", payload.Context)
+	t.Logf("Payload context: %+v", firstPayloadContext)
 
 	// Verify context (be lenient since env vars might not always work in tests)
-	if payload.Context.Service == "" {
+	if firstPayloadContext.Service == "" {
 		t.Logf("Warning: service name is empty (expected 'test-service')")
 	}
-	if payload.Context.Version == "" {
+	if firstPayloadContext.Version == "" {
 		t.Logf("Warning: version is empty (expected '1.2.3')")
 	}
-	if payload.Context.Env == "" {
+	if firstPayloadContext.Env == "" {
 		t.Logf("Warning: env is empty (expected 'testing')")
 	}
 
 	// Verify exposures
-	if len(payload.Exposures) != 2 {
-		t.Errorf("expected 2 exposures, got %d", len(payload.Exposures))
+	if len(allExposures) != 2 {
+		t.Fatalf("expected 2 exposures, got %d", len(allExposures))
 	}
 
-	if len(payload.Exposures) >= 2 {
-		// First exposure
-		exp1 := payload.Exposures[0]
-		if exp1.Flag.Key != "feature-rollout" {
-			t.Errorf("expected flag 'feature-rollout', got %q", exp1.Flag.Key)
-		}
-		if exp1.Subject.ID != "user-abc" {
-			t.Errorf("expected subject 'user-abc', got %q", exp1.Subject.ID)
-		}
-		if exp1.Allocation.Key != "us-rollout" {
-			t.Errorf("expected allocation 'us-rollout', got %q", exp1.Allocation.Key)
-		}
-		if exp1.Variant.Key != "on" {
-			t.Errorf("expected variant 'on', got %q", exp1.Variant.Key)
-		}
-		if exp1.Timestamp == 0 {
-			t.Error("expected non-zero timestamp")
-		}
+	// Index by subject rather than position: which evaluation's exposure lands
+	// in which payload is not part of this test's contract, only that both
+	// arrived with the right fields.
+	exposuresBySubject := make(map[string]exposureEvent, len(allExposures))
+	for _, exp := range allExposures {
+		exposuresBySubject[exp.Subject.ID] = exp
+	}
 
-		// Verify subject attributes are included
-		if exp1.Subject.Attributes == nil {
-			t.Error("expected subject attributes to be present")
-		} else {
-			if country, ok := exp1.Subject.Attributes["country"]; !ok || country != "US" {
-				t.Errorf("expected country attribute 'US', got %v", country)
-			}
-		}
+	exp1, ok := exposuresBySubject["user-abc"]
+	if !ok {
+		t.Fatal("expected an exposure for subject 'user-abc'")
+	}
+	if exp1.Flag.Key != "feature-rollout" {
+		t.Errorf("expected flag 'feature-rollout', got %q", exp1.Flag.Key)
+	}
+	if exp1.Allocation.Key != "us-rollout" {
+		t.Errorf("expected allocation 'us-rollout', got %q", exp1.Allocation.Key)
+	}
+	if exp1.Variant.Key != "on" {
+		t.Errorf("expected variant 'on', got %q", exp1.Variant.Key)
+	}
+	if exp1.Timestamp == 0 {
+		t.Error("expected non-zero timestamp")
+	}
 
-		// Second exposure
-		exp2 := payload.Exposures[1]
-		if exp2.Subject.ID != "user-xyz" {
-			t.Errorf("expected subject 'user-xyz', got %q", exp2.Subject.ID)
+	// Verify subject attributes are included
+	if exp1.Subject.Attributes == nil {
+		t.Error("expected subject attributes to be present")
+	} else {
+		if country, ok := exp1.Subject.Attributes["country"]; !ok || country != "US" {
+			t.Errorf("expected country attribute 'US', got %v", country)
 		}
+	}
+
+	if _, ok := exposuresBySubject["user-xyz"]; !ok {
+		t.Error("expected an exposure for subject 'user-xyz'")
 	}
 }
 
@@ -1565,23 +1575,31 @@ func TestEndToEnd_ExposureFlushInterval(t *testing.T) {
 	writer.buffer = make([]exposureEvent, 0)
 	writer.mu.Unlock()
 
-	// Generate events continuously
+	// Generate one event, wait for it to be flushed, then repeat: generating
+	// all events upfront let a delayed flush worker drain every one of them
+	// into a single request, after which an empty buffer produces no further
+	// flushes no matter how long the test then waits for a second one.
+	// Producing the next event only after observing a flush guarantees the
+	// buffer is non-empty for the next tick.
 	for i := range 5 {
 		evalCtx := of.NewEvaluationContext(fmt.Sprintf("user-%d", i), map[string]any{
 			"country": "US",
 		})
-		_, _ = client.BooleanValue(ctx, "feature-rollout", false, evalCtx)
-		time.Sleep(30 * time.Millisecond)
-	}
+		_, err := client.BooleanValue(ctx, "feature-rollout", false, evalCtx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	// Wait for at least 2 flushes. Polling rather than sleeping a fixed interval:
-	// the flush ticker is asynchronous, so a loaded CI runner can take longer than
-	// any interval short enough to keep the test fast.
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return flushCount >= 2
-	}, 5*time.Second, time.Millisecond, "expected at least 2 flushes")
+		wantFlushes := i + 1
+		// Polling rather than sleeping a fixed interval: the flush ticker is
+		// asynchronous, so a loaded CI runner can take longer than any interval
+		// short enough to keep the test fast.
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return flushCount >= wantFlushes
+		}, 5*time.Second, time.Millisecond, "expected %d flushes", wantFlushes)
+	}
 }
 
 // TestEndToEnd_ExposureDoLogFalse tests that exposure events are NOT sent when doLog is false.

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -64,7 +64,14 @@ type DatadogProvider struct {
 	configuration *universalFlagsConfiguration
 	metadata      openfeature.Metadata
 
-	configChange sync.Cond
+	// configChange is closed and replaced with a fresh channel each time
+	// updateConfiguration runs, so a waiter that reads it while p.mu is held
+	// observes either the current channel (not yet closed, so it can select
+	// on it) or the update it was waiting for (configuration already set).
+	// This channel-per-generation approach, rather than sync.Cond, keeps the
+	// wait naturally selectable against ctx.Done() without a helper goroutine
+	// that can race the wait it is meant to interrupt.
+	configChange chan struct{}
 
 	hooks []openfeature.Hook
 
@@ -157,8 +164,8 @@ func newDatadogProvider(config ProviderConfig) *DatadogProvider {
 		flagEvalMetricsHook:   evalMetricsHook,
 		flagEvalLoggingWriter: evalWriter,
 		flagEvalLoggingHook:   evalLoggingHook,
+		configChange:          make(chan struct{}),
 	}
-	p.configChange.L = &p.mu
 
 	return p
 }
@@ -169,7 +176,16 @@ func (p *DatadogProvider) updateConfiguration(config *universalFlagsConfiguratio
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.configuration = config
-	p.configChange.Broadcast()
+	// Wake every waiter blocked on the current generation, then start a fresh
+	// one for the next update: a closed channel cannot be reused as a signal.
+	// configChange is nil on a DatadogProvider built as a bare struct literal
+	// (several tests do this to exercise evaluate directly), which never
+	// waits on it through InitWithContext; guard the close so that remains
+	// safe rather than requiring every such test to also initialize it.
+	if p.configChange != nil {
+		close(p.configChange)
+	}
+	p.configChange = make(chan struct{})
 }
 
 // getConfiguration returns the current configuration (for testing purposes).
@@ -193,36 +209,23 @@ func (p *DatadogProvider) Init(evaluationContext openfeature.EvaluationContext) 
 	return p.InitWithContext(ctx, evaluationContext)
 }
 
-// waitForConfigurationUpdate waits for a configuration update or context cancellation.
-// Assumes mutex is locked on entry, temporarily unlocks during wait, relocks on exit.
+// waitForConfigurationUpdate waits for a configuration update or context
+// cancellation. The caller must hold p.mu on entry. p.mu is released while
+// waiting and reacquired before this returns, whether or not it returns an
+// error.
 func (p *DatadogProvider) waitForConfigurationUpdate(ctx context.Context) error {
-	defer p.mu.Lock() // Always relock when function exits
-
-	// Check if context was cancelled before waiting
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	// Create channel to signal condition variable completion
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		p.mu.Lock()
-		defer p.mu.Unlock()
-		p.configChange.Wait()
-	}()
-
-	// Temporarily unlock to allow configuration update and context handling
+	// Read the current generation while still holding p.mu, so this can never
+	// wait on a channel that a concurrent updateConfiguration already closed
+	// and replaced.
+	generation := p.configChange
 	p.mu.Unlock()
+	defer p.mu.Lock()
 
-	// Wait for either context cancellation or configuration update
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-done:
-		return nil // Configuration updated, defer will relock
+	case <-generation:
+		return nil
 	}
 }
 

--- a/openfeature/provider_test.go
+++ b/openfeature/provider_test.go
@@ -636,6 +636,102 @@ func TestSetProviderWithContextAndWaitTimeout(t *testing.T) {
 	t.Logf("Successfully got timeout error as expected: %v", err)
 }
 
+// runWithDeadline runs fn in a goroutine and fails the test if fn does not
+// return within timeout, rather than hanging the test process forever. This
+// guards the two regression tests below against a reintroduced deadlock in
+// waitForConfigurationUpdate: a plain call could hang indefinitely instead of
+// failing.
+func runWithDeadline(t *testing.T, timeout time.Duration, fn func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		t.Fatalf("function did not return within %s; likely deadlocked", timeout)
+		return nil // unreachable: t.Fatalf stops this goroutine via runtime.Goexit
+	}
+}
+
+// TestInitWithContext_AlreadyCancelled pins a regression: InitWithContext
+// must return promptly with ctx.Err() when ctx is already cancelled before
+// the call, rather than deadlocking. The prior waitForConfigurationUpdate
+// unlocked p.mu unconditionally on return via defer, including on the
+// already-cancelled path where it had never unlocked p.mu at all, so the
+// deferred lock call would try to lock a mutex this same goroutine already
+// held.
+func TestInitWithContext_AlreadyCancelled(t *testing.T) {
+	provider := newDatadogProvider(ProviderConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before InitWithContext ever sees it
+
+	err := runWithDeadline(t, 2*time.Second, func() error {
+		return provider.InitWithContext(ctx, openfeature.EvaluationContext{})
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
+// TestInitWithContext_CancelledDuringWait pins the same contract as
+// TestInitWithContext_AlreadyCancelled, but for cancellation arriving while
+// InitWithContext is already blocked waiting for configuration, rather than
+// before the call.
+func TestInitWithContext_CancelledDuringWait(t *testing.T) {
+	provider := newDatadogProvider(ProviderConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- provider.InitWithContext(ctx, openfeature.EvaluationContext{})
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let InitWithContext reach its wait
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("InitWithContext did not return after cancellation; likely deadlocked")
+	}
+}
+
+// TestInitWithContext_ConfigurationArrivesDuringWait pins that a real
+// configuration update still wakes a blocked InitWithContext, guarding
+// against a fix that stops missing cancellation but breaks the success path
+// instead (for example, by waiting on a channel nothing ever closes).
+func TestInitWithContext_ConfigurationArrivesDuringWait(t *testing.T) {
+	provider := newDatadogProvider(ProviderConfig{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- provider.InitWithContext(ctx, openfeature.EvaluationContext{})
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let InitWithContext reach its wait
+	provider.updateConfiguration(createTestConfig())
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("InitWithContext did not return after configuration update; likely deadlocked")
+	}
+}
+
 func TestSetProviderWithContextAndWaitSuccess(t *testing.T) {
 	// Create a provider and set up its configuration immediately
 	provider := newDatadogProvider(ProviderConfig{})

--- a/openfeature/span_enrichment_test.go
+++ b/openfeature/span_enrichment_test.go
@@ -192,6 +192,10 @@ func TestSpanEnrichment_Integration(t *testing.T) {
 	defer mt.Stop()
 
 	provider := newDatadogProvider(ProviderConfig{})
+	// The SDK has no API to unregister a named provider; without this, its
+	// background exposure/flag-evaluation writers keep running for the rest
+	// of the test process.
+	t.Cleanup(provider.Shutdown)
 	status := processConfigUpdate(provider, "datadog/2/ASM_FEATURES/test/config", []byte(`{
 		"createdAt":"2026-01-01T00:00:00Z",
 		"format":"SERVER",
@@ -299,6 +303,10 @@ func TestSpanEnrichment_Integration(t *testing.T) {
 func setupEnrichmentProvider(t *testing.T, domain string) *of.Client {
 	t.Helper()
 	provider := newDatadogProvider(ProviderConfig{})
+	// The SDK has no API to unregister a named provider; without this, its
+	// background exposure/flag-evaluation writers keep running for the rest
+	// of the test process.
+	t.Cleanup(provider.Shutdown)
 	status := processConfigUpdate(provider, "datadog/2/ASM_FEATURES/test/config", []byte(`{
 		"createdAt":"2026-01-01T00:00:00Z",
 		"format":"SERVER",


### PR DESCRIPTION
## Summary

Investigates and fixes two reported flaky tests in `openfeature`
(`TestAgentlessSource_BlankETagClears` and
`TestAgentlessSource_ETagNotAdvancedOnParseFailure`), plus related issues
found while auditing for other potential flakes. Four separate, independently
buildable commits:

1. **`fix(openfeature): avoid deadlock on cancelled initialization`**
   Fixes a real production defect: `waitForConfigurationUpdate` could try to
   relock a mutex the calling goroutine already held when `ctx` was already
   cancelled, hanging `InitWithContext` forever. Replaces the `sync.Cond`
   wait with a channel-per-generation design and adds three bounded
   regressions.

2. **`test(openfeature): make agentless polling tests deterministic`**
   `BlankETagClears` and `ETagAnd304` waited on a request count via
   `Eventually`, then read the fake backend's single shared
   `lastIfNoneMatch` field — a later request could overwrite that field
   before the assertion ran. Rewrites all three ETag tests (including
   `ETagNotAdvancedOnParseFailure`, which has the same shape but was not
   reproduced) to drive `pollOnce` synchronously instead.

3. **`test(openfeature): remove exposure scheduling assumptions`**
   Fixes a batch-boundary assumption in `ExposurePayloadStructure`, a
   finite-producer assumption in `ExposureFlushInterval`, and an
   over-strict deduplication assertion in `ConcurrentAppend` that a legal
   goroutine interleaving could violate.

4. **`test(openfeature): synchronize delivery checks and provider cleanup`**
   Fixes in-handler assertions in `ExposureAgentSide` (which don't
   reliably fail the test), hardens `ExposureDoLogFalse` with a positive
   control and explicit flush, pins two buffer-read races against the
   default background flush ticker, and adds cleanup for three leaked
   named-provider registrations.

## Reproduction

Locally reproduced `BlankETagClears` (1/500 plain, 4/3000 under
`-race -cpu=1,2,8`) and a second flake in the same family,
`ETagAnd304` (0/500 plain, 7/3000 under race), both caused by the same
overwrite-before-assertion bug. `ETagNotAdvancedOnParseFailure` did **not**
reproduce locally in ~6500 combined runs; it is fixed alongside the other two
because it shares the same fragile pattern, not because it was confirmed
flaky here. The original CI failure details for it were not available.

## Validation

- `go build ./...`
- `go vet ./openfeature/...`
- `go test -race ./openfeature/... -count=10 -shuffle=on -cpu=1,2,8` (30 full
  package runs, all green)
- `go test -race ./openfeature -run '^TestAgentlessSource_(BlankETagClears|ETagNotAdvancedOnParseFailure|ETagAnd304)$' -count=2000 -cpu=1,2,8`
- Targeted repeats (30-50x) on each individually rewritten test

## Notes for reviewers

- Marked as draft pending review of the `waitForConfigurationUpdate`
  redesign (commit 1) in particular — it changes a synchronization
  primitive in production code and deserves careful review of the
  channel-per-generation approach vs. alternatives.
- `openfeature/ffe-system-test-data` submodule must be initialized
  (`git submodule update --init --recursive`) for the full package to run;
  unrelated to this change but worth calling out since some fixture tests
  fail without it.
