### PR TITLE
ci: fix static-checks toolchain/cache defects and retry transient failures

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -33,17 +33,36 @@ runs:
         fi
 
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      id: setup-go
       with:
         go-version: ${{ inputs.go-version }}
         cache: true
         check-latest: true
+
+    # Callers that run a tool exporting its own GOROOT into $GITHUB_ENV before this
+    # action (e.g. reviewdog/action-golangci-lint installs a different Go release)
+    # leave a stale GOROOT behind that overrides the toolchain selected above. Re-align
+    # GOROOT with the toolchain actions/setup-go just selected so the `go` binary on
+    # PATH and its tool directory always come from the same tree.
+    - name: Align GOROOT with the selected toolchain
+      shell: bash
+      run: |
+        unset GOROOT
+        echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
 
     - name: Cache tools
       id: cache-tools
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ inputs.tools-bin }}
-        key: ${{ runner.os }}-go-${{ inputs.go-version }}-tools-${{ inputs.tools-dir }}-${{ inputs.tools-bin}}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        # Key on the resolved toolchain version, not the literal input: `stable`
+        # silently changes meaning when a new Go release ships, and a cache built
+        # against the old release would then feed stale binaries to the new one.
+        key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-tools-${{ inputs.tools-dir }}-${{ inputs.tools-bin}}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+        # Keep near-misses usable when the base branch moves go.mod/go.sum, which
+        # otherwise invalidates the key for every open PR at once.
+        restore-keys: |
+          ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-tools-${{ inputs.tools-dir }}-${{ inputs.tools-bin }}-
 
     - name: Install development tools
       if: steps.cache-tools.outputs.cache-hit != 'true'

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -23,6 +23,8 @@ jobs:
             devflow/mergegate
             label_issues
             check-title
+            dd-gitlab/.*
+            DDCI Status
 
 # Reason for ignored-name-patterns:
 #
@@ -31,3 +33,6 @@ jobs:
 #   prevents all open PRs from appearing as failing CI before reviews are complete, making PRs with actual
 #   CI failures indistinguishable from PRs that are simply awaiting review.
 # * check-title: CI job used to validate the PR title, enforced by branch protection rules, do not remove it.
+# * dd-gitlab/.* and DDCI Status: Datadog-internal GitLab statuses. They cannot be re-run from GitHub, and
+#   DDCI Status is already marked "Not required to merge", so re-reporting them as this workflow's failure
+#   sends people to the wrong place.

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -39,7 +39,28 @@ permissions:
   checks: write
 
 jobs:
+  # Populate the shared tools cache once, before the jobs below need it. When every
+  # job races to install tools and save the same cache key on a miss, only one wins
+  # the cache reservation and a failing job never saves at all (actions/cache skips
+  # the post step), so the cache can stay permanently cold. Mirrors the
+  # warm-repo-cache pattern in pull-request.yml.
+  warm-tools-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Setup Go and development tools
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{ inputs.go-version || 'stable' }}
+          tools-dir: ${{ github.workspace }}/_tools
+          tools-bin: ${{ github.workspace }}/bin
+
   copyright:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,6 +83,7 @@ jobs:
           make lint/misc
 
   check-github-actions:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,6 +103,7 @@ jobs:
           make lint/action
 
   check-modules:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -102,6 +125,7 @@ jobs:
         run: git diff --exit-code
 
   check-docs:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -123,6 +147,7 @@ jobs:
         run: git diff --exit-code
 
   check-format:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -144,6 +169,7 @@ jobs:
         run: git diff --exit-code
 
   lint:
+    needs: [warm-tools-cache]
     runs-on:
       group: "APM Larger Runners"
     permissions:
@@ -222,6 +248,7 @@ jobs:
         run: go run ./scripts/configinverter/main.go check
 
   checklocks:
+    needs: [warm-tools-cache]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -105,6 +105,11 @@ jobs:
           path: 'binaries/dd-trace-go'
 
       - name: Build and save weblog image
+        env:
+          # build.sh retries on failure but defaults to a single attempt, so any
+          # transient module-proxy hiccup during the in-image go mod download fails
+          # the whole aggregated System Tests check.
+          SYSTEM_TEST_BUILD_ATTEMPTS: "3"
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }} --save-to-binaries
 
       - name: Upload weblog image artifact
@@ -324,6 +329,8 @@ jobs:
 
       - name: Build weblog
         if: ${{ matrix.weblog-variant != 'envoy' && matrix.weblog-variant != 'haproxy' && matrix.weblog-variant != 'apim' }}
+        env:
+          SYSTEM_TEST_BUILD_ATTEMPTS: "3"
         run: ./build.sh golang -i weblog -w ${{ matrix.weblog-variant }}
 
       - name: Download ${{ matrix.weblog-variant }} artifacts


### PR DESCRIPTION
### What does this PR do?

Fixes a set of CI-infrastructure defects (documented in an investigation of the recurring `static-checks` and `System Tests` failures on #5114 / #5295 — none of which were caused by the code in those PRs):

**1. `GOROOT` leaks between the two Go setups in the `lint` job** (root cause of the recurring `lint` failure)

`reviewdog/action-golangci-lint` installs its own Go (e.g. go1.26.7) and exports `GOROOT` into `$GITHUB_ENV`. The later `./.github/actions/setup-go` step installs a different toolchain (e.g. go1.27.1) on `PATH`, but the stale `GOROOT` survives, so `GOTOOLDIR` resolves `compile` out of the old tree and every compilation dies with `compile: version "go1.26.7" does not match go tool version "go1.27.1"` — present even in *green* runs, only fatal when `go install tools` actually executes. The composite action now re-aligns `GOROOT` with the toolchain `actions/setup-go` just selected.

**2. Cache-reservation deadlock starves the tools cache**

All `static-checks` jobs start concurrently and share one tools-cache key. On a miss they all run `install_tools.sh`, then race to save the same key: only one wins the reservation, and if the winner is `lint` (which then fails at its `setup-go` step), its `actions/cache` post-step is skipped and the cache is never written — `static-checks` failed 6/6 on #5295 for exactly this reason. A dedicated `warm-tools-cache` job (mirroring `warm-repo-cache` in `pull-request.yml`) now populates the cache once, and the tools-consuming jobs depend on it.

**3. Tools cache key churns on every base movement**

`hashFiles('**/go.mod', '**/go.sum')` is evaluated against the merge ref, so every `main` movement touching any go.mod/go.sum invalidates the key for *all* open PRs simultaneously (observed: key changed between two same-day pushes to #5114 with no dependency change in the PR). `restore-keys` now keeps near-misses usable.

**4. Tools cache key records the literal string `stable`**

With `check-latest: true`, a cache built while `stable` meant go1.26.x is a valid hit for a later run where `stable` means go1.27.x — stale binaries from the wrong toolchain, the same failure class as (1) arriving via the cache. The key now uses `actions/setup-go`'s resolved `go-version` output.

**5. Weblog image builds capped at 1 attempt**

The system-tests `build.sh` retry harness reads `SYSTEM_TEST_BUILD_ATTEMPTS` (default 1), so every transient module-proxy hiccup during the in-image `go mod download` failed the whole aggregated `System Tests` check. Both build steps now set `SYSTEM_TEST_BUILD_ATTEMPTS: "3"`.

**6. Go module proxy / checksum DB transients are unretried**

Seven failures in one afternoon across #5114/#5295, all `sum.golang.org`/`proxy.golang.org` `INTERNAL_ERROR` or `502 Bad Gateway`. `go-retry.sh` now retries these transient network signatures *without* wiping caches (the caches are healthy; dropping the module cache on a network error would force pointless re-downloads). Real corruption signatures still clear caches as before. Note: a failed download can also surface later as a compile error (`undefined: echo`), which the header comment now documents.

**7. Cosmetic: `all-jobs-are-green` re-reports Datadog-internal GitLab statuses**

`dd-gitlab/default-pipeline`, `dd-gitlab/microbenchmarks-*` and `DDCI Status` cannot be re-run from GitHub (and `DDCI Status` is already *Not required to merge*), so they are now in `ignored-name-patterns` instead of being reported as this workflow's failure.

### Motivation

Investigation notes from getting #5114 / #5295 green: `static-checks` failed 6/6 on #5295 between 2026-09-01 and 2026-09-09 while passing 6/6 on the base branch, and the underlying test suites were healthy throughout (8816/8820 tests, with every failure being a download error). These fixes target the infrastructure defects only; no library code is touched.

Not addressed here (follow-ups): narrowing what `actions/setup-go`'s module cache stores (the ~1.4 GB entries churn the 10 GB per-repo cache limit) and a clearer diagnostic when a module-download failure presents as a compile error in `govulncheck`.

⚠️ Note: the tools-cache key change in (4) orphans all existing `go-*-tools-*` caches once — the first run per PR after merge pays one tools install.