### PR TITLE
fix(ci): run configinverter in its module context

### DIFF
--- a/.github/actions/supported_configurations_validation/action.yml
+++ b/.github/actions/supported_configurations_validation/action.yml
@@ -8,4 +8,4 @@ runs:
       shell: bash
       run: |-
         git diff internal/env/supported_configurations.json
-        go run ./scripts/configinverter/main.go check
+        GOWORK=off go -C scripts/configinverter run . -input ../../internal/env/supported_configurations.json check


### PR DESCRIPTION
## Summary

Run configinverter from its own Go module inside the supported-configurations composite action.

The action currently invokes a named Go file from the repository root. Callers that set `GOWORK=off` therefore select the root `go.mod`, which does not contain configinverter's `github.com/dave/jennifer` dependency.

The corrected command:

- sets `GOWORK=off` at the action boundary
- uses `go -C scripts/configinverter` to select the tool module
- runs the package instead of a named source file
- passes the repository-root input path explicitly

This keeps behavior independent of each caller's workspace configuration.

## Validation

- Reproduced the old command's missing-module failure with `GOWORK=off`
- Ran the corrected command from a shell with the root `go.work` enabled
- Ran the corrected command when the caller already had `GOWORK=off`
- Confirmed both runs selected `scripts/configinverter/go.mod`
- `GOWORK=off go -C scripts/configinverter test ./...`
- `make lint/action`
- `make lint/misc`
- `git diff --check`
