### PR TITLE
ci: stop public Go module proxy errors from failing CI

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -13,6 +13,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Make transient module-proxy failures survivable for every step that follows in the job.
+    #
+    # The separator is load-bearing. Go's default is `https://proxy.golang.org,direct`, and with a
+    # comma the go command falls through to the next entry ONLY on 404/410 — a 5xx, a timeout, a
+    # TLS error or a dropped HTTP/2 stream is fatal and `direct` is never tried
+    # (cmd/go/internal/modfetch/proxy.go: fallBackOnError is set only for `|`). With a pipe it
+    # falls through on any error. cmd/go has no retry of its own (golang/go#28194), so this and
+    # apps/go-retry.sh are the only two lines of defence.
+    #
+    # Written to GITHUB_ENV rather than the action's `env:` because a composite action's env does
+    # not reach the calling job's later steps. Set only when unset, so a workflow or step that
+    # deliberately pins GOPROXY (e.g. GOPROXY=direct for a single command) still wins.
+    - name: Configure GOPROXY fallback
+      shell: bash
+      run: |
+        if [[ -z "${GOPROXY:-}" ]]; then
+          echo 'GOPROXY=https://proxy.golang.org|direct' >> "$GITHUB_ENV"
+        fi
+
     - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ inputs.go-version }}

--- a/.github/workflows/apps/go-retry.sh
+++ b/.github/workflows/apps/go-retry.sh
@@ -28,14 +28,29 @@
 # full, network-bound re-download. Archive-signature wipes are uncounted, since they're proven
 # on-disk corruption rather than a defensive guess.
 #
+# A second, independent signature class covers *network* failures talking to the Go module proxy
+# (proxy.golang.org / sum.golang.org). These are transient and must be handled differently from
+# corruption: the module cache is deliberately left alone, because refetching it is exactly what
+# failed. Wiping it would multiply the traffic that caused the failure in the first place.
+# The dominant observed shape is an HTTP/2 stream reset ("stream error: stream ID N;
+# INTERNAL_ERROR"), which is neither a 5xx nor a 404/410 -- so a status-code-only pattern misses it,
+# and a comma-separated GOPROXY offers no fallback for it either (see go help goproxy: only 404/410
+# fall through on ',', any error falls through on '|'). cmd/go performs no retries of its own
+# (golang/go#28194), so this is the only retry layer there is.
+# Network retries back off exponentially with jitter: a large matrix retrying in lockstep would
+# re-create the load spike that triggered the reset.
+#
 # Usage:
 #   source go-retry.sh
 #   retry_on_corruption <cmd> [args...]                  # output streams to the caller as-is
 #   retry_on_corruption_to_file <outfile> <cmd> [args...] # <cmd>'s stdout is captured to <outfile>
 corruption_re='internal compiler error|zip: checksum error|not the start of an archive file|found pointer to free object|fatal error: fault|unexpected signal during runtime execution|signal SIGSEGV'
 archive_corruption_re='zip: checksum error|not the start of an archive file'
+# Transient module-proxy/network failures. Ordered roughly by observed frequency in this repo.
+network_re='stream error.*(INTERNAL_ERROR|PROTOCOL_ERROR|REFUSED_STREAM)|(proxy|sum)\.golang\.org[^[:space:]]*: [45][0-9][0-9]|(proxy|sum)\.golang\.org.*(i/o timeout|TLS handshake|connection reset|unexpected EOF|no such host|server misbehaving)|google\.com/sorry|dial tcp.*(i/o timeout|connection refused|connection reset)|(Get|reading) "?https://(proxy|sum)\.golang\.org'
 
 : "${GO_RETRY_MAX_MODCACHE_WIPES:=2}"
+: "${GO_RETRY_NETWORK_BACKOFF_BASE:=5}"
 _go_retry_modcache_wipes="${_go_retry_modcache_wipes:-0}"
 _go_retry_active="${_go_retry_active:-0}"
 
@@ -57,6 +72,37 @@ _clean_caches_on_retry() {
   fi
 }
 
+# _go_retry_handle_failure <log> <attempt> <max>
+# Decides whether the just-failed attempt is worth retrying and, if so, performs the remediation
+# appropriate to *why* it failed. Returns 0 to retry, 1 to give up. Shared by both entry points so
+# the two can't drift apart.
+#
+# Corruption is checked first: a log carrying both signatures has proven on-disk damage, and that
+# needs the cache wipe regardless of whatever network noise accompanied it.
+_go_retry_handle_failure() {
+  local log="$1" attempt="$2" max="$3"
+
+  if grep -qE "$corruption_re" "$log"; then
+    [ "$attempt" -ge "$max" ] && return 1
+    echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
+    _clean_caches_on_retry "$log"
+    return 0
+  fi
+
+  if grep -qE "$network_re" "$log"; then
+    [ "$attempt" -ge "$max" ] && return 1
+    # GOPROXY_FAILURE is a stable token: CI dashboards count these to size module-proxy flakiness.
+    echo "::warning::GOPROXY_FAILURE transient module-proxy/network failure (attempt ${attempt}/${max}); backing off and retrying"
+    # Exponential backoff with jitter, and no cache clearing: the fetch is what failed, so the
+    # bytes already on disk are the one thing worth keeping.
+    local delay=$((GO_RETRY_NETWORK_BACKOFF_BASE * (1 << (attempt - 1))))
+    sleep "$((delay + RANDOM % (delay + 1)))"
+    return 0
+  fi
+
+  return 1
+}
+
 retry_on_corruption() {
   if [ "$_go_retry_active" = "1" ]; then
     "$@"
@@ -69,11 +115,9 @@ retry_on_corruption() {
   # captured for signature matching, then echoed back so nothing is lost from the logs.
   until "$@" 2>"$log"; do
     cat "$log" >&2
-    if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+    if ! _go_retry_handle_failure "$log" "$attempt" "$max"; then
       rm -f "$log"; _go_retry_active=0; return 1
     fi
-    echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-    _clean_caches_on_retry "$log"
     attempt=$((attempt + 1))
   done
   cat "$log" >&2
@@ -95,11 +139,9 @@ retry_on_corruption_to_file() {
   # every attempt, so a failed first attempt never leaves partial output for a retry to append to.
   until "$@" >"$outfile" 2>"$log"; do
     cat "$log" >&2
-    if [ "$attempt" -ge "$max" ] || ! grep -qE "$corruption_re" "$log"; then
+    if ! _go_retry_handle_failure "$log" "$attempt" "$max"; then
       rm -f "$log"; _go_retry_active=0; return 1
     fi
-    echo "::warning::Go toolchain/cache corruption signature detected (attempt ${attempt}/${max}); clearing caches and retrying"
-    _clean_caches_on_retry "$log"
     attempt=$((attempt + 1))
   done
   cat "$log" >&2

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -26,6 +26,7 @@ on:
       - 'orchestrion/**'
       - 'scripts/**'
 env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
   DD_APPSEC_WAF_TIMEOUT: 1m
   PACKAGES: >-
     ./appsec/...

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -43,12 +43,68 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   id-token: write
   contents: read
 
 jobs:
+  # Primes the Go module cache once, so the 106 build-metrics jobs below restore it instead of
+  # each re-downloading the workspace dependency set from proxy.golang.org. Before this job
+  # existed, those cold downloads were the repo's single largest source of module-proxy traffic
+  # and the dominant cause of this workflow's failures (HTTP/2 stream resets from
+  # proxy.golang.org / sum.golang.org part-way through `go mod download`).
+  #
+  # `measure_build.sh` runs inside internal/orchestrion/_integration, which is a `go.work` member
+  # and the workflow does not set GOWORK=off — so resolution spans the whole workspace and the
+  # cache key has to cover every go.sum plus go.work.sum, not just the sample's module.
+  go-mod-caching:
+    name: Prepare Go modules cache
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{ steps.cfg.outputs.key }}
+      path: ${{ steps.cfg.outputs.path }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Compute cache configuration
+        id: cfg
+        run: |
+          echo "key=go-pkg-mod-build-metrics-${{ hashFiles('**/go.sum', 'go.work.sum') }}" >> "$GITHUB_OUTPUT"
+          echo "path=go_pkg_mod_cache" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+          cache: false # we manage the module cache ourselves
+          check-latest: true
+
+      - name: Cache Go modules
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.cfg.outputs.path }}
+          key: ${{ steps.cfg.outputs.key }}
+          lookup-only: true
+
+      - name: Download Go modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          GOMODCACHE: ${{ github.workspace }}/${{ steps.cfg.outputs.path }}
+        run: |
+          source ./.github/workflows/apps/go-retry.sh
+          retry_on_corruption go mod download -x
+
   build-metrics:
+    needs:
+      - go-mod-caching
     strategy:
       fail-fast: false
       matrix:
@@ -116,11 +172,24 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Restore Go modules cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ needs.go-mod-caching.outputs.path }}
+          key: ${{ needs.go-mod-caching.outputs.key }}
+          restore-keys: go-pkg-mod-build-metrics-
+          # A cache-service miss must not fail the job: falling back to a cold fetch is slower and
+          # proxy-dependent, but still correct.
+          fail-on-cache-miss: false
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
-          cache: false  # Cold build cache for accurate measurements
+          # We manage the module cache ourselves (restored above). This does NOT weaken the cold
+          # build-cache guarantee the measurements rely on: measure_build.sh runs `go clean -cache`
+          # inside do_build, before every timed build.
+          cache: false
           check-latest: true
 
       - name: Install go-size-analyzer
@@ -133,6 +202,8 @@ jobs:
 
       - name: Measure build
         id: measure
+        env:
+          GOMODCACHE: ${{ github.workspace }}/${{ needs.go-mod-caching.outputs.path }}
         run: ./scripts/measure_build.sh --sample ${{ matrix.sample }} --mode ${{ matrix.mode }} --output "$RUNNER_TEMP/metrics.json"
 
       - name: Upload metrics artifact

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/config-audit.yml'
   workflow_dispatch:
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/gotip-testing.yml
+++ b/.github/workflows/gotip-testing.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: { } # manually
 
 env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
   TEST_RESULTS: ${{ github.workspace }}/tip-results # path to where test results will be saved
 
 permissions:

--- a/.github/workflows/govulncheck-fix.yml
+++ b/.github/workflows/govulncheck-fix.yml
@@ -5,6 +5,9 @@ on:
     - cron: '00 06 * * 1'  # Mondays at 6 AM UTC
   workflow_dispatch:
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   contents: write
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -34,6 +34,9 @@ concurrency:
   group: govulncheck-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   contents: read
   security-events: write # required for SARIF upload to GitHub Code Scanning

--- a/.github/workflows/lambda-integration-tests.yml
+++ b/.github/workflows/lambda-integration-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 15 * * *' # Daily at 15:00 UTC
   workflow_dispatch: # Allow manual triggering
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   contents: read
   id-token: write # Required for OIDC authentication

--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -24,6 +24,9 @@ on:
   schedule: # nightly
     - cron: "0 0 * * *"
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/parametric-tests.yml
+++ b/.github/workflows/parametric-tests.yml
@@ -28,6 +28,9 @@ on:
   schedule:
     - cron:  '00 04 * * 2-6'
 
+env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
+
 permissions:
   contents: read
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -23,6 +23,7 @@ on:
         type: string
 
 env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
   # Users may build our library with GOTOOLCHAIN=local. If they do, and our
   # go.mod file specifies a newer Go version than their local toolchain, their
   # build will break. Run our tests with GOTOOLCHAIN=local to ensure that

--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -109,6 +109,9 @@ on: {
 }
 
 env: {
+  // Fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410,
+  // which is all a comma-separated GOPROXY falls through on.
+  GOPROXY: "https://proxy.golang.org|direct",
   DD_ENV: "github",
   DD_TAGS: "github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} ${{ inputs['arg: tags'] }}",
 }

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -62,6 +62,7 @@ name: Test Apps
         default: trigger:manual
         description: Extra DD_TAGS
 env:
+  GOPROXY: https://proxy.golang.org|direct
   DD_ENV: github
   DD_TAGS: 'github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} ${{ inputs[''arg: tags''] }}'
 permissions:

--- a/.github/workflows/unit-integration-tests.yml
+++ b/.github/workflows/unit-integration-tests.yml
@@ -13,6 +13,7 @@ on:
         default: ""
 
 env:
+  GOPROXY: "https://proxy.golang.org|direct" # fall back to `direct` on any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a comma-separated GOPROXY falls through on
   DD_APPSEC_WAF_TIMEOUT: 1m # Increase time WAF time budget to reduce CI flakiness
   # Users may build our library with GOTOOLCHAIN=local. If they do, and our
   # go.mod file specifies a newer Go version than their local toolchain, their

--- a/.gitlab/benchmarks/micro/bp-runner.yml
+++ b/.gitlab/benchmarks/micro/bp-runner.yml
@@ -19,8 +19,11 @@ experiments:
             git clone --branch $BRANCH https://github.com/DataDog/dd-trace-go "$CODE_SRC"
             cd "$CODE_SRC" && git checkout $COMMIT_SHA
 
-            # Download module dependencies required by `go test -bench`
-            go mod download
+            # Download module dependencies required by `go test -bench`. Fall back to `direct` on
+            # any proxy error (5xx, timeout, dropped stream) -- not just 404/410, which is all a
+            # comma-separated GOPROXY falls through on -- since a single flaky fetch here fails
+            # the whole benchmark run.
+            GOPROXY="https://proxy.golang.org|direct" go mod download
           fi
 
         cpus: 4-47

--- a/scripts/measure_build.sh
+++ b/scripts/measure_build.sh
@@ -121,14 +121,20 @@ message "  Output dir: $OUT_DIR"
 
 cd "$INTEGRATION_DIR" || die "Failed to cd to $INTEGRATION_DIR"
 
+# Retry helper for the two untimed, network-bound steps below. Both talk to the module proxy and
+# the checksum database, and neither is retried by the go command itself (golang/go#28194), so a
+# single dropped HTTP/2 stream part-way through would otherwise fail the whole measurement.
+# shellcheck source=.github/workflows/apps/go-retry.sh
+source "$REPO_ROOT/.github/workflows/apps/go-retry.sh"
+
 # Warm module cache (untimed)
 message "Warming module download cache..."
-go mod download || die "go mod download failed"
+retry_on_corruption go mod download || die "go mod download failed"
 
 # For orchestrion mode, ensure the binary is installed (untimed)
 if [[ "$MODE" == "orchestrion" ]]; then
   message "Installing orchestrion binary..."
-  go install "github.com/DataDog/orchestrion" || die "Failed to install orchestrion"
+  retry_on_corruption go install "github.com/DataDog/orchestrion" || die "Failed to install orchestrion"
   ORCHESTRION_VERSION="$(go list -m -f '{{.Version}}' github.com/DataDog/orchestrion)"
   message "  Orchestrion version: $ORCHESTRION_VERSION"
 fi


### PR DESCRIPTION
## Summary

`build-metrics.yml` fails ~10% of its runs. Of the last 6 failures, 5 carry the same signature:

```
go mod download failed
stream error: stream ID 397; INTERNAL_ERROR
```

That's an HTTP/2 stream reset from `proxy.golang.org`/`sum.golang.org` (tracked upstream as [golang/go#69544](https://github.com/golang/go/issues/69544)) under load, and the loop is closed: `cache: false` on that workflow's `setup-go` step disables the module cache along with the build cache, so all 106 jobs (53 samples × 2 modes) cold-fetch the same ~713-module dependency graph on every run — the single largest source of module-proxy traffic in the repo. `measure_build.sh` already runs `go clean -cache` before every timed build, so the module cache was never load-bearing for the measurements `cache: false` was meant to protect.

Separately, GOPROXY defaults to a comma-separated chain (`proxy.golang.org,direct`). Per `cmd/go`'s fallback rules, a comma only falls through to `direct` on 404/410 — a 5xx, a timeout, or a dropped stream is fatal and `direct` is never tried (verified against `cmd/go/internal/modfetch/proxy.go` and reproduced locally). `smoke-tests.yml` already worked around this with a pipe-separated chain; nothing else in the repo did.

## Changes

- **`build-metrics.yml`**: adds a `go-mod-caching` primer job (same pattern as `appsec.yml`'s `go-mod-caching`) so the 106 build-metrics jobs restore the module cache instead of each re-downloading it. `cache: false` stays on `setup-go` — only the module-cache half of that flag was ever unnecessary.
- **`go-retry.sh`**: adds a `network_re` signature class, separate from the existing `corruption_re`, so transient proxy/network failures are retried with exponential backoff instead of failing the job. It deliberately never wipes the module cache — refetching is exactly what failed, so the bytes already on disk are the one thing worth keeping. Wired into `measure_build.sh`'s two proxy-bound commands.
- **`GOPROXY` pipe fallback**: set to `https://proxy.golang.org|direct` everywhere `go` runs in CI — the shared `setup-go` composite action (via `GITHUB_ENV`, only when unset, so a step that deliberately pins `GOPROXY` still wins), every workflow calling `actions/setup-go` directly, `test-apps.cue`, and the GitLab micro-benchmark job.

No Go source changed.

## Verification

- `go-retry.sh`'s `network_re` matches all 5 real captured failure logs (runs `34373369294`, `34370945663`, `34126208801`, `33887651741`, `33790384982`) and none are misclassified as corruption (which would trigger an unnecessary modcache wipe).
- 9-case unit-test harness against a stubbed `go` binary: network failures retry to success without touching the module or build cache; corruption failures still wipe as before; corruption takes precedence when both signatures are present in the same log; unrelated failures are not retried.
- Comma vs. pipe fallback reproduced locally with two never-before-fetched module versions:
  ```
  GOPROXY='https://127.0.0.1:1|direct'  go list -m ... -> succeeds via direct
  GOPROXY='https://127.0.0.1:1,direct'  go list -m ... -> dial tcp: connect: connection refused
  ```
- `scripts/measure_build.sh --sample net_http --mode standard` run end-to-end: exit 0, valid `metrics.json`, confirming the retry wrapping doesn't break the happy path.
- `make lint/action`, `cue vet`, `make lint/shell` (shellcheck + shfmt), `bash -n` all pass on the changed files.

## Test plan

- [ ] CI green on this PR (existing `static-checks`, `unit-integration-tests`, etc. exercise the composite-action GOPROXY change and the go-retry.sh change indirectly)
- [ ] `build-metrics` run on this PR restores from the new primer job instead of cold-fetching (check the job log for `Cache restored from key:` on the `build-metrics` jobs, not `Cache is not found`)
- [ ] Watch `build-metrics` over the following week for the proxy-failure signature to confirm it stops recurring

## Notes

- Regenerating `test-apps.yml` from `test-apps.cue` surfaced pre-existing, unrelated drift (a `dd-sts-action` policy that differs per environment in the committed file but not in the current `.cue` source) that predates this change — confirmed present on a clean `main` checkout. Left untouched here; filed separately.
- This is Step 1 of a larger CI-proxy-reliability effort (telemetry + broader cache-key/warm-cache work land separately, once this is measured).