### PR TITLE
fix(civisibility): allow environment to enable ATR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -340,6 +340,10 @@ Once a new environment variable is added to the codebase, Datadog maintainers wi
 
 Upon each tracer release, new configuration keys are automatically tagged by our [CI pipeline](./.gitlab/config-validation.yml) to track when they were introduced.
 
+#### Overriding automatic test retries
+
+`DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` explicitly overrides the automatic test retries setting returned by the CI Visibility backend. When the variable is unset or has an invalid boolean value, the tracer preserves the backend setting. Set it to `true` to enable automatic test retries or `false` to disable them regardless of the backend setting.
+
 #### Code coverage report flags
 
 `DD_CODE_COVERAGE_FLAGS` attaches a comma-separated list of flags to uploaded code coverage reports. Whitespace around each flag is trimmed, empty entries are discarded, and order and duplicate flags are preserved. A maximum of 32 normalized flags is accepted; if the value contains more, the report is uploaded without flags and a warning is logged.

--- a/internal/civisibility/constants/env.go
+++ b/internal/civisibility/constants/env.go
@@ -29,8 +29,7 @@ const (
 	// CIVisibilityTestSessionNameEnvironmentVariable indicate the test session name to be used on CI Visibility payloads
 	CIVisibilityTestSessionNameEnvironmentVariable = "DD_TEST_SESSION_NAME"
 
-	// CIVisibilityFlakyRetryEnabledEnvironmentVariable kill-switch that allows to explicitly disable retries even if the remote setting is enabled.
-	// This environment variable should be set to "0" or "false" to disable the flaky retry feature.
+	// CIVisibilityFlakyRetryEnabledEnvironmentVariable overrides the remote automatic test retries setting when explicitly set.
 	CIVisibilityFlakyRetryEnabledEnvironmentVariable = "DD_CIVISIBILITY_FLAKY_RETRY_ENABLED"
 
 	// CIVisibilityEarlyFlakeDetectionEnabledEnvironmentVariable overrides the remote EFD setting when explicitly set.

--- a/internal/civisibility/integrations/civisibility_features.go
+++ b/internal/civisibility/integrations/civisibility_features.go
@@ -204,11 +204,7 @@ func ensureSettingsInitialization(serviceName string) {
 		slowTestRetries.ThirtyS = capEarlyFlakeDetectionRetries(slowTestRetries.ThirtyS, earlyFlakeDetectionMaxRetries)
 		slowTestRetries.FiveM = capEarlyFlakeDetectionRetries(slowTestRetries.FiveM, earlyFlakeDetectionMaxRetries)
 
-		// check if flaky test retries is disabled by env-vars
-		if ciSettings.FlakyTestRetriesEnabled && !internal.BoolEnv(constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable, true) {
-			log.Warn("civisibility: flaky test retries was disabled by the environment variable")
-			ciSettings.FlakyTestRetriesEnabled = false
-		}
+		applyFlakyRetryEnabledEnvironmentOverride(ciSettings)
 
 		// check if impacted tests is disabled by env-vars
 		if ciSettings.ImpactedTestsEnabled && !internal.BoolEnv(constants.CIVisibilityImpactedTestsDetectionEnabled, true) {
@@ -278,6 +274,22 @@ func capEarlyFlakeDetectionRetries(retries, maxRetries int) int {
 		return maxRetries
 	}
 	return retries
+}
+
+func applyFlakyRetryEnabledEnvironmentOverride(ciSettings *net.SettingsResponseData) {
+	if ciSettings == nil {
+		return
+	}
+	enabled, configured := internal.BoolEnvNoDefault(constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable)
+	if !configured || enabled == ciSettings.FlakyTestRetriesEnabled {
+		return
+	}
+	state := "disabled"
+	if enabled {
+		state = "enabled"
+	}
+	log.Warn("civisibility: automatic test retries were %s by the %s environment variable", state, constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable)
+	ciSettings.FlakyTestRetriesEnabled = enabled
 }
 
 func applyEarlyFlakeDetectionEnabledEnvironmentOverride(ciSettings *net.SettingsResponseData) {

--- a/internal/civisibility/integrations/civisibility_features_test.go
+++ b/internal/civisibility/integrations/civisibility_features_test.go
@@ -208,6 +208,37 @@ func TestEnsureSettingsInitializationGitUploadDisabledDoesNotStartUploadOrRetryS
 	assert.Len(t, closeActions, 0)
 }
 
+func TestEnsureSettingsInitializationFlakyRetryEnvironmentOverrideEnablesRetries(t *testing.T) {
+	resetCIVisibilityStateForTesting()
+	t.Cleanup(resetCIVisibilityStateForTesting)
+	t.Setenv(constants.CIVisibilityGitUploadEnabledEnvironmentVariable, "false")
+	t.Setenv(constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable, "true")
+	t.Setenv(constants.CIVisibilityFlakyRetryCountEnvironmentVariable, "2")
+	t.Setenv(constants.CIVisibilityTotalFlakyRetryCountEnvironmentVariable, "5")
+
+	newCIVisibilityClientWithServiceNameFunc = func(_ string) civisibilitynet.Client {
+		return &mockCIVisibilityClient{
+			getSettings: func() (*civisibilitynet.SettingsResponseData, error) {
+				return &civisibilitynet.SettingsResponseData{FlakyTestRetriesEnabled: false}, nil
+			},
+		}
+	}
+	uploadRepositoryChangesFunc = func() (int64, error) {
+		t.Fatal("repository upload should not start when git upload is disabled")
+		return 0, nil
+	}
+
+	ensureSettingsInitialization("service")
+	ensureAdditionalFeaturesInitialization("service")
+
+	assert.True(t, ciVisibilitySettings.FlakyTestRetriesEnabled)
+	assert.Equal(t, FlakyRetriesSetting{
+		RetryCount:               2,
+		TotalRetryCount:          5,
+		RemainingTotalRetryCount: 5,
+	}, ciVisibilityFlakyRetriesSettings)
+}
+
 func TestEnsureSettingsInitializationGitUploadDisabledSettingsErrorDoesNotRegisterCloseAction(t *testing.T) {
 	resetCIVisibilityStateForTesting()
 	t.Cleanup(resetCIVisibilityStateForTesting)

--- a/internal/civisibility/integrations/civisibility_offline_test.go
+++ b/internal/civisibility/integrations/civisibility_offline_test.go
@@ -341,6 +341,48 @@ func TestApplyEarlyFlakeDetectionEnabledEnvironmentOverride(t *testing.T) {
 	}
 }
 
+func TestApplyFlakyRetryEnabledEnvironmentOverride(t *testing.T) {
+	key := constants.CIVisibilityFlakyRetryEnabledEnvironmentVariable
+	previous, previouslySet := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if previouslySet {
+			_ = os.Setenv(key, previous)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+
+	tests := []struct {
+		name          string
+		remoteEnabled bool
+		override      string
+		overrideSet   bool
+		want          bool
+	}{
+		{name: "unset preserves disabled remote setting", want: false},
+		{name: "unset preserves enabled remote setting", remoteEnabled: true, want: true},
+		{name: "true enables disabled remote setting", override: "true", overrideSet: true, want: true},
+		{name: "false disables enabled remote setting", remoteEnabled: true, override: "false", overrideSet: true, want: false},
+		{name: "invalid preserves remote setting", remoteEnabled: true, override: "invalid", overrideSet: true, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.overrideSet {
+				t.Setenv(key, tt.override)
+			}
+			settings := civisibilitynet.SettingsResponseData{FlakyTestRetriesEnabled: tt.remoteEnabled}
+
+			applyFlakyRetryEnabledEnvironmentOverride(&settings)
+
+			assert.Equal(t, tt.want, settings.FlakyTestRetriesEnabled)
+		})
+	}
+}
+
 func writeSettingsManifestCache(t *testing.T, requireGit bool, impactedTestsEnabled bool, testsSkipping bool) string {
 	t.Helper()
 

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -307,7 +307,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "true"
+        "default": null
       }
     ],
     "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED": [

--- a/internal/env/supported_configurations.json
+++ b/internal/env/supported_configurations.json
@@ -305,7 +305,7 @@
     ],
     "DD_CIVISIBILITY_FLAKY_RETRY_ENABLED": [
       {
-        "implementation": "A",
+        "implementation": "B",
         "type": "boolean",
         "default": null
       }


### PR DESCRIPTION
## What does this change do?

Treats `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` as an explicit override of the remote Automatic Test Retries setting:

- unset preserves the backend setting;
- `true` enables ATR even when the backend setting is disabled;
- `false` disables ATR even when the backend setting is enabled;
- invalid values preserve the backend setting.

The retry count, total retry budget, retry selection, and process-retry coordinator continue to use the existing implementation.

## Why?

Previously this environment variable was only a kill switch. Setting it to `true` could not enable ATR when CI Visibility returned `flaky_test_retries_enabled=false`. This prevented controlled CI validation of ATR and process-isolated retries when the project-level CI Visibility configuration could not be changed.

This behavior is needed by the experiment in https://github.com/ddoghq/dd-go/pull/11717.

## Validation

- `go test ./internal/civisibility/integrations -count=1`
- `go test -race ./internal/civisibility/integrations -count=1`
- `go vet ./internal/civisibility/integrations`
- `./bin/golangci-lint run ./internal/civisibility/integrations`
- `make format/go`
- `git diff --check`