### PR TITLE
fix(ci): restore per-env dd-sts-action policy in test-apps.cue

### DIFF
--- a/.github/workflows/test-apps.cue
+++ b/.github/workflows/test-apps.cue
@@ -50,10 +50,12 @@ import "encoding/json"
     {
         name: "prod",
         site: "datadoghq.com",
+        policy: "dd-trace-go",
     },
     {
         name: "staging",
         site: "datad0g.com",
+        policy: "dd-trace-go-staging",
     },
 ]
 
@@ -146,7 +148,7 @@ jobs: {
                         id: "dd-sts",
                         uses: "DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2",
                         with: {
-                            policy: "dd-trace-go",
+                            policy: "\(env.policy)",
                         },
                     },
                     {

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -66,8 +66,8 @@ env:
   DD_ENV: github
   DD_TAGS: 'github_run_id:${{ github.run_id }} github_run_number:${{ github.run_number }} ${{ inputs[''arg: tags''] }}'
 permissions:
-  id-token: write
   contents: read
+  id-token: write
 jobs:
   job-0-0:
     name: unit-of-work/v1 (prod)


### PR DESCRIPTION
## What does this PR do?

Restores the per-environment `policy` field in `test-apps.cue` for the `DataDog/dd-sts-action` step, threading it through `#envs` the same way `site` already is.

## Motivation

`test-apps.cue`'s `dd-sts-action` step hardcoded a single `policy: "dd-trace-go"`, but the committed `test-apps.yml` alternates `dd-trace-go` / `dd-trace-go-staging` per environment. PR #4661 added that split because staging jobs need org-2 API keys, but it patched the generated YAML directly without updating the CUE source. No CI check regenerates `test-apps.yml` from `test-apps.cue` (the "Generate Check" workflow only runs `go generate ./...`), so the drift went uncaught. Any future edit to `test-apps.cue` would have silently reverted the staging policy back to `dd-trace-go`.

## Test plan

- [x] `cd .github/workflows && touch test-apps.cue && make test-apps.yml` reproduces the exact alternating policy across all 10 jobs (5 scenarios × prod/staging), zero diff on any `policy:` line.
- [x] Ran the regeneration 3 times in a row: byte-identical output.
- [x] `actionlint .github/workflows/test-apps.yml`: clean.
- [x] `git diff --stat` against `main`: only test-apps.cue and test-apps.yml change.

## Note

Regeneration also normalizes the top-level `permissions:` key order (`contents`/`id-token` swap) in `test-apps.yml`. That's unrelated to the policy fix. I confirmed with `git stash` that it reproduces identically even without the policy change, so it's most likely leftover from the committed file last being generated with a different `cue` version (no version is pinned for this tool). It has no functional effect, since YAML mapping order doesn't change GitHub Actions permission semantics.
