### PR TITLE
fix(tracer): flush telemetry when Stop is called

### DIFF
--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -234,6 +234,16 @@ func TestRepeatStartRecordsEnvDiffOnActiveClient(t *testing.T) {
 }
 
 func TestTracerStopFlushesTelemetry(t *testing.T) {
+	Start()
+	defer globalconfig.SetServiceName("")
+	require.NotNil(t, telemetry.GlobalClient())
+
+	Stop()
+
+	assert.Nil(t, telemetry.GlobalClient())
+}
+
+func TestTracerStopDoesNotStopForeignTelemetry(t *testing.T) {
 	telemetryClient := new(telemetrytest.RecordClient)
 	defer telemetry.MockClient(telemetryClient)()
 
@@ -241,5 +251,8 @@ func TestTracerStopFlushesTelemetry(t *testing.T) {
 	defer globalconfig.SetServiceName("")
 	Stop()
 
-	assert.True(t, telemetryClient.Stopped)
+	// Profiler or another product already owns the global client. Stop must
+	// not call StopApp on it.
+	assert.False(t, telemetryClient.Stopped)
+	assert.Equal(t, telemetry.Client(telemetryClient), telemetry.GlobalClient())
 }

--- a/ddtrace/tracer/telemetry_test.go
+++ b/ddtrace/tracer/telemetry_test.go
@@ -232,3 +232,14 @@ func TestRepeatStartRecordsEnvDiffOnActiveClient(t *testing.T) {
 	require.True(t, ok, "expected config.repeat_start_env_diff to be recorded on the active telemetry client")
 	assert.Equal(t, float64(1), handle.Get())
 }
+
+func TestTracerStopFlushesTelemetry(t *testing.T) {
+	telemetryClient := new(telemetrytest.RecordClient)
+	defer telemetry.MockClient(telemetryClient)()
+
+	Start()
+	defer globalconfig.SetServiceName("")
+	Stop()
+
+	assert.True(t, telemetryClient.Stopped)
+}

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -1276,7 +1276,14 @@ func (t *tracer) Stop() {
 		t.logFile.Close()
 	}
 	if t.telemetry != nil {
-		t.telemetry.Close()
+		if telemetry.GlobalClient() != t.telemetry {
+			// StartApp ignored this client because another product already owns
+			// the global one. Close the leftover so its ticker does not leak.
+			t.telemetry.Close()
+		}
+		// api.go: tracer.Stop should StopApp so pending logs and metrics flush.
+		telemetry.StopApp()
+		t.telemetry = nil
 	}
 	t.config.httpClient.CloseIdleConnections()
 }

--- a/ddtrace/tracer/tracer.go
+++ b/ddtrace/tracer/tracer.go
@@ -1271,19 +1271,22 @@ func (t *tracer) Stop() {
 	}
 	appsec.Stop()
 	remoteconfig.Stop()
+	// Flush telemetry before closing the log file so StopApp diagnostics still land.
+	if t.telemetry != nil {
+		client := t.telemetry
+		t.telemetry = nil
+		if telemetry.GlobalClient() == client {
+			// We own the global client; StopApp flushes pending logs and metrics.
+			telemetry.StopApp()
+		} else {
+			// StartApp ignored this client because another product already owns
+			// the global one. Close the leftover so its ticker does not leak.
+			client.Close()
+		}
+	}
 	// Close log file last to account for any logs from the above calls
 	if t.logFile != nil {
 		t.logFile.Close()
-	}
-	if t.telemetry != nil {
-		if telemetry.GlobalClient() != t.telemetry {
-			// StartApp ignored this client because another product already owns
-			// the global one. Close the leftover so its ticker does not leak.
-			t.telemetry.Close()
-		}
-		// api.go: tracer.Stop should StopApp so pending logs and metrics flush.
-		telemetry.StopApp()
-		t.telemetry = nil
 	}
 	t.config.httpClient.CloseIdleConnections()
 }


### PR DESCRIPTION
Fixes #5249

tracer.Stop was only closing the telemetry client, so the last logs and metrics never flushed.

Stop now calls StopApp when the tracer started a client, which sends app stop, flushes, then closes. If StartApp skipped the tracer client because another product already owned the global client, that leftover still gets Close so the ticker does not leak.