### PR TITLE
fix(openfeature): use agentless EVP transport

### DIFF
--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -153,8 +153,14 @@ func newDatadogProvider(config ProviderConfig) *DatadogProvider {
 }
 
 func newDatadogProviderWithSource(config ProviderConfig, source internalffe.Source) *DatadogProvider {
-	evp := newEVPClient()
+	return newDatadogProviderWithSourceAndEVP(config, source, newEVPClient())
+}
 
+func newDatadogProviderWithSourceAndEVP(
+	config ProviderConfig,
+	source internalffe.Source,
+	evp *evpClient,
+) *DatadogProvider {
 	// Create exposure writer
 	writer := newExposureWriterWithEVP(config, evp)
 
@@ -225,7 +231,11 @@ func newDatadogProviderWithSource(config ProviderConfig, source internalffe.Sour
 // lifetime. src.start() runs outside the lock since it launches the poll loop
 // in the background and returns immediately.
 func startWithAgentless(config ProviderConfig, settings internalffe.Settings) (*DatadogProvider, error) {
-	p := newDatadogProviderWithSource(config, internalffe.SourceAgentless)
+	p := newDatadogProviderWithSourceAndEVP(
+		config,
+		internalffe.SourceAgentless,
+		newAgentlessEVPClient(settings),
+	)
 
 	src, err := newAgentlessSource(settings, p.updateConfiguration)
 	if err != nil {

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -144,16 +144,16 @@ var warnLegacyFlaggingProviderOnce = sync.OnceFunc(func() {
 	log.Warn("openfeature: DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED is deprecated; use DD_FEATURE_FLAGS_CONFIGURATION_SOURCE instead")
 })
 
-// newDatadogProvider builds a provider defaulting to the Remote Config
-// source. It exists so the ~60 existing tests exercising evaluation, hooks,
-// and metrics — none of which care about the delivery source — don't need to
-// be touched; production code paths call newDatadogProviderWithSource.
+// newDatadogProvider is a test-only bare provider constructor. Tests that use
+// it exercise evaluation, hook, and metric behavior without starting a
+// delivery source; source-to-transport wiring must be tested through the
+// source-specific start functions.
 func newDatadogProvider(config ProviderConfig) *DatadogProvider {
-	return newDatadogProviderWithSource(config, internalffe.SourceRemoteConfig)
-}
-
-func newDatadogProviderWithSource(config ProviderConfig, source internalffe.Source) *DatadogProvider {
-	return newDatadogProviderWithSourceAndEVP(config, source, newEVPClient())
+	return newDatadogProviderWithSourceAndEVP(
+		config,
+		internalffe.SourceRemoteConfig,
+		newEVPClient(),
+	)
 }
 
 func newDatadogProviderWithSourceAndEVP(

--- a/openfeature/provider_agentless_lifecycle_test.go
+++ b/openfeature/provider_agentless_lifecycle_test.go
@@ -82,6 +82,38 @@ func TestStartWithAgentless_ShutdownMidPoll(t *testing.T) {
 	assert.Less(t, elapsed, 3*time.Second, "Shutdown must not wait out the full request timeout")
 }
 
+func TestStartWithAgentless_ConfiguresAgentlessEVP(t *testing.T) {
+	t.Setenv(flagEvalCountsEnabledEnvVar, "true")
+
+	backend := newFakeUFCBackend(t)
+	backend.setResponses("valid")
+
+	settings := internalffe.Settings{
+		AgentlessBaseURL: backend.server.URL,
+		APIKey:           "api-key",
+		Site:             "datadoghq.eu",
+		PollInterval:     time.Hour,
+		RequestTimeout:   2 * time.Second,
+	}
+	p, err := startWithAgentless(ProviderConfig{}, settings)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, p.ShutdownWithContext(ctx))
+	})
+
+	require.NotNil(t, p.exposureWriter)
+	require.NotNil(t, p.flagEvalLoggingWriter)
+	require.Same(t, p.exposureWriter.evp, p.flagEvalLoggingWriter.evp)
+
+	evp := p.exposureWriter.evp
+	assert.Equal(t, settings.APIKey, evp.apiKey)
+	require.NotNil(t, evp.directURL)
+	assert.Equal(t, "https://event-platform-intake.datadoghq.eu", evp.directURL.String())
+	assert.False(t, evp.fixedLocalRoute)
+}
+
 func TestInitWithContext_DeliveryErrFailsFast(t *testing.T) {
 	p := newDatadogProviderWithSource(ProviderConfig{}, internalffe.SourceAgentless)
 	p.mu.Lock()

--- a/openfeature/provider_agentless_lifecycle_test.go
+++ b/openfeature/provider_agentless_lifecycle_test.go
@@ -24,16 +24,21 @@ func TestTryRegisterAgentless_AfterShutdownRegistersNothing(t *testing.T) {
 	backend := newFakeUFCBackend(t)
 	backend.setResponses("valid")
 
-	p := newDatadogProviderWithSource(ProviderConfig{}, internalffe.SourceAgentless)
+	settings := internalffe.Settings{
+		AgentlessBaseURL: backend.server.URL,
+		PollInterval:     time.Hour,
+		RequestTimeout:   2 * time.Second,
+	}
+	p := newDatadogProviderWithSourceAndEVP(
+		ProviderConfig{},
+		internalffe.SourceAgentless,
+		newAgentlessEVPClient(settings),
+	)
 	p.mu.Lock()
 	p.shutdownCalled = true
 	p.mu.Unlock()
 
-	src, err := newAgentlessSource(internalffe.Settings{
-		AgentlessBaseURL: backend.server.URL,
-		PollInterval:     time.Hour,
-		RequestTimeout:   2 * time.Second,
-	}, p.updateConfiguration)
+	src, err := newAgentlessSource(settings, p.updateConfiguration)
 	require.NoError(t, err)
 
 	assert.False(t, p.tryRegisterAgentless(src))
@@ -115,7 +120,12 @@ func TestStartWithAgentless_ConfiguresAgentlessEVP(t *testing.T) {
 }
 
 func TestInitWithContext_DeliveryErrFailsFast(t *testing.T) {
-	p := newDatadogProviderWithSource(ProviderConfig{}, internalffe.SourceAgentless)
+	settings := internalffe.Settings{}
+	p := newDatadogProviderWithSourceAndEVP(
+		ProviderConfig{},
+		internalffe.SourceAgentless,
+		newAgentlessEVPClient(settings),
+	)
 	p.mu.Lock()
 	p.deliveryErr = errors.New("no API key for managed agentless endpoint")
 	p.mu.Unlock()

--- a/openfeature/rc_subscription_test.go
+++ b/openfeature/rc_subscription_test.go
@@ -128,3 +128,24 @@ func TestStartWithRemoteConfigFastPath(t *testing.T) {
 	require.NotNil(t, cfg, "provider should have config from fast path replay")
 	assert.Contains(t, cfg.Flags, "fast-flag")
 }
+
+func TestStartWithRemoteConfig_ConfiguresAgentEVP(t *testing.T) {
+	t.Setenv(flagEvalCountsEnabledEnvVar, "true")
+	internalffe.ResetForTest()
+	defer internalffe.ResetForTest()
+	internalffe.SetSubscribedForTest(true)
+
+	provider, err := startWithRemoteConfig(ProviderConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, provider.exposureWriter)
+	require.NotNil(t, provider.flagEvalLoggingWriter)
+	require.Same(t, provider.exposureWriter.evp, provider.flagEvalLoggingWriter.evp)
+
+	evp := provider.exposureWriter.evp
+	assert.True(t, evp.fixedLocalRoute)
+	assert.Equal(t, evpRouteLocal, evp.routeMode)
+	assert.Equal(t, evpProxyV2Path, evp.localBase)
+	assert.Empty(t, evp.apiKey)
+	assert.Nil(t, evp.directURL)
+	assert.Nil(t, evp.directClient)
+}

--- a/openfeature/remoteconfig.go
+++ b/openfeature/remoteconfig.go
@@ -22,7 +22,11 @@ import (
 var errInvalidSemverComparand = errors.New("invalid semantic version comparand")
 
 func startWithRemoteConfig(config ProviderConfig) (*DatadogProvider, error) {
-	provider := newDatadogProviderWithSource(config, internalffe.SourceRemoteConfig)
+	provider := newDatadogProviderWithSourceAndEVP(
+		config,
+		internalffe.SourceRemoteConfig,
+		newEVPClient(),
+	)
 
 	// Subscribe via the internal package, which serializes with tracer subscription
 	// and starts RC only if needed (slow path).


### PR DESCRIPTION
## Motivation

Agentless OpenFeature providers successfully poll configuration, but the event plane was still wired to the historical Agent-only EVP client. Without an Agent endpoint, flag evaluation could return the correct value while exposure and flag-evaluation events were sent to a nonexistent local Agent.

This restores the missing provider-to-transport connection so an Agentless provider can send those events directly to intake, while retaining Agent/serverless-init routing when that endpoint is available.

## Changes

- Construct Agentless providers with the fallback-capable Agentless EVP client.
- Share that client between exposure and flag-evaluation writers.
- Add a regression test covering the API key, direct intake URL, shared client identity, and non-fixed routing.

## Decisions

- Keep the existing Agent-first/fallback transport behavior; this patch only connects the Agentless provider to it.
- Share one client so both writers observe the same routing state.
- Keep this fix narrow: no configuration polling or event schema changes.

## Verification

### Unit regression

```text
go test -race -count=1 ./openfeature/...
PASS
```

### Dogfooding build

The Go dogfooding app was rebuilt from this exact PR head:

```text
dd-trace-go commit: d2ceeac61fb72a6a875f919380a61242bb3c2b38
local source mount: /home/bits/dd/worktrees/direct-evp/go-main-dogfood-2e0226650
build: go mod edit -replace github.com/DataDog/dd-trace-go/v2=/opt/dd-trace-go && go mod tidy && go build -o server .
```

The test used a deterministic UFC fixture with `numeric_flag`, allocation `rollout`, variant `pi`, and `doLog: true`. Both rows evaluated to value `3.1415926` with reason `STATIC`.

### EVP route and payload matrix

The direct row had no Agent endpoint variables and no serverless-init process. It used an isolated TLS intake capture to make the exact outbound JSON inspectable. The serverless-init row used Agent endpoint variables and captured the payload after it traversed serverless-init (`Via: trace-agent 7.81.2`). Tokens and timestamps are omitted.

```json
{
  "dd_trace_go_commit": "d2ceeac61fb72a6a875f919380a61242bb3c2b38",
  "subject": "go-pr5346-matrix-20260911-025151",
  "flag": "numeric_flag",
  "expected": {
    "allocation": "rollout",
    "variant": "pi",
    "value": 3.1415926,
    "evaluation_reason": "STATIC"
  },
  "matrix": [
    {
      "mode": "direct",
      "serverless_init": false,
      "agent_endpoint_variables": [],
      "provider_ready": true,
      "routes": {
        "exposure": "https://event-platform-intake.mock-intake/api/v2/exposures",
        "flagevaluation": "https://event-platform-intake.mock-intake/api/v2/flagevaluation"
      },
      "capture_headers": {
        "DD-EVP-ORIGIN": "dd-trace-go",
        "DD-EVP-ORIGIN-VERSION": "v2.11.0-dev.1",
        "Via": null
      },
      "exposure": {
        "count": 1,
        "body": {
          "allocation": {"key": "rollout"},
          "flag": {"key": "numeric_flag"},
          "variant": {"key": "pi"},
          "subject": {
            "id": "go-pr5346-matrix-20260911-025151",
            "attributes": {
              "country": "US",
              "plan": "pro",
              "verification": "dd-trace-go-5346"
            }
          }
        }
      },
      "flagevaluation": {
        "count": 1,
        "body": {
          "flag": {"key": "numeric_flag"},
          "evaluation_count": 1,
          "targeting_key": "sha256_65824c664805017777ce02ec7b4e5f0d957f701fdf61d71109db01325e19f099",
          "variant": {"key": "pi"},
          "allocation": {"key": "rollout"}
        }
      }
    },
    {
      "mode": "serverless-init",
      "serverless_init": true,
      "agent_endpoint_variables": {
        "DD_AGENT_HOST": "serverless-init",
        "DD_TRACE_AGENT_PORT": "8126",
        "DD_TRACE_AGENT_URL": "http://serverless-init:8126"
      },
      "provider_ready": true,
      "routes": {
        "exposure": "http://serverless-init:8126/evp_proxy/v4/api/v2/exposures",
        "flagevaluation": "http://serverless-init:8126/evp_proxy/v4/api/v2/flagevaluation"
      },
      "capture_headers": {"Via": "trace-agent 7.81.2"},
      "exposure": {
        "count": 1,
        "body": {
          "allocation": {"key": "rollout"},
          "flag": {"key": "numeric_flag"},
          "variant": {"key": "pi"},
          "subject": {
            "id": "go-pr5346-matrix-20260911-025151",
            "attributes": {
              "country": "US",
              "plan": "pro",
              "verification": "dd-trace-go-5346"
            }
          }
        }
      },
      "flagevaluation": {
        "count": 1,
        "body": {
          "flag": {"key": "numeric_flag"},
          "evaluation_count": 1,
          "targeting_key": "sha256_65824c664805017777ce02ec7b4e5f0d957f701fdf61d71109db01325e19f099",
          "variant": {"key": "pi"},
          "allocation": {"key": "rollout"}
        }
      }
    }
  ]
}
```

### Real staging intake probe

The same exact binary was also run in direct mode against staging (`DD_SITE=datad0g.com`), without serverless-init or any Agent endpoint variables:

```json
{
  "site": "datad0g.com",
  "serverless_init": false,
  "agent_endpoint_variables": [],
  "exposure": {
    "route": "https://event-platform-intake.datad0g.com/api/v2/exposures",
    "events_sent": 1,
    "result": "success"
  },
  "flagevaluation": {
    "route": "https://event-platform-intake.datad0g.com/api/v2/flagevaluation",
    "events_sent": 1,
    "payloads_sent": 1,
    "result": "success"
  }
}
```

The EVP client only reports these successes after a 2xx response. This staging probe establishes real direct-intake acceptance; the isolated captures above establish the exact request routes and JSON bodies.

OTLP is intentionally not part of this verification. It exercises the separate feature-flag evaluation metric path; this patch connects the exposure and flag-evaluation writers to the EVP transport.
