### PR TITLE
ci(smoke-tests): resolve orchestrion/all against the commit under test

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -428,6 +428,7 @@ jobs:
         id: resolve
         run: |-
           set -euo pipefail
+          root=github.com/DataDog/dd-trace-go/v2
           module=github.com/DataDog/dd-trace-go/orchestrion/all/v2
 
           # Build the throwaway consumer outside the workspace, so no go.work or replace
@@ -443,6 +444,28 @@ jobs:
           # forces each contrib module to resolve.
           printf '//go:build tools\n\npackage tools\n\nimport _ "%s"\n' "$module" > orchestrion.tool.go
 
+          # Resolve the root module at the commit under test rather than at its last
+          # published tag. orchestrion/all's own `replace $root => ../..` only applies while
+          # orchestrion/all is the main module; as a dependency it is ignored, so the consumer
+          # falls back to the `require` on the newest dev tag. Any package added to the root
+          # module since that tag is then missing -- orchestrion.tool.go imports seven of
+          # them -- and every such addition reds main until the next tag is cut.
+          #
+          # This has to be a `replace` rather than a second `go get`: the pseudo-version of a
+          # commit past `vX.Y.0-dev.N` sorts below that tag (`dev.0.<ts>-<sha>` < `dev.N`), so
+          # requesting both versions is a downgrade that `go get` refuses. A main-module
+          # `replace` is applied after version selection and sidesteps the ordering.
+          #
+          # Contrib modules keep resolving from their published tags on purpose: a new nested
+          # module landing without one is the failure this job exists to catch.
+          pseudo=$(go list -m -f '{{.Version}}' "$root@$REF")
+          echo "Pinning $root to $pseudo ($REF)"
+          go mod edit -replace "$root=$root@$pseudo"
+
+          # Captured before tidy so the assertion below compares against what $REF should
+          # resolve to, not against whatever ends up in go.mod.
+          want=$(go list -m -f '{{.Version}}' "$module@$REF")
+
           echo "::group::go get $module@$REF"
           go get "$module@$REF"
           echo "::endgroup::"
@@ -450,6 +473,14 @@ jobs:
           echo "::group::go mod tidy"
           go mod tidy
           echo "::endgroup::"
+
+          # Without the pin, `go mod tidy` silently settles on an older published
+          # orchestrion/all and the job passes while testing a commit nobody asked about.
+          got=$(go list -m -f '{{.Version}}' "$module")
+          if [[ "$got" != "$want" ]]; then
+            echo "::error::expected $module@$want, resolved $got"
+            exit 1
+          fi
       - name: Explain how to fix this
         if: failure() && steps.resolve.outcome == 'failure'
         run: |-


### PR DESCRIPTION
### What does this PR do?

Pins the root `dd-trace-go/v2` module to the commit under test in the
`check-orchestrion-all-resolves` job, so the check no longer depends on the last
published dev tag containing every package `orchestrion/all` imports.

Contrib modules keep resolving from their published tags. A new nested module
landing without one is the failure this job exists to catch, and that still fails.

Also adds a post-`tidy` assertion. Without the pin, `go mod tidy` quietly settles on
an older published `orchestrion/all` and the job passes having tested nothing, which
is what happened while I was working the fix out.

### Motivation

Root cause of [IR-60559](https://app.datadoghq.com/incidents/60559).

`orchestrion/all`'s `replace ... => ../..` only applies while `orchestrion/all` is the
main module. As a dependency it is ignored, so the throwaway consumer takes the
`require` on `v2.11.0-dev.1` and cannot find `crashtracker`:

```
github.com/DataDog/dd-trace-go/v2/crashtracker: module .../v2@latest
found (v2.10.1), but does not contain package .../v2/crashtracker
```

`crashtracker` is the first root-module import added to `orchestrion.tool.go` since
this check landed in #5091, so this is the first time the check has met a new
package. Every `main` commit has failed since #5027 merged on 2026-09-10.

This has to be a `replace` rather than a second `go get`: the pseudo-version of a
commit past `vX.Y.0-dev.N` sorts *below* that tag (`dev.0.<ts>-<sha>` < `dev.N`), so
asking for both versions is a downgrade that `go get` refuses outright.

### What this does not fix

The check was reporting something true. `go get github.com/DataDog/dd-trace-go/orchestrion/all/v2@main`
still fails for external consumers until a dev tag containing `crashtracker` is cut.

This PR decouples CI from the tagging cadence; it does not restore that guarantee.
Enforcing it belongs in the release pipeline, which is the only place able to act on
it. Cutting `v2.11.0-dev.2` is still worth doing on its own merits.

### Test plan

Ran the patched step verbatim against `8ae7d5494`, the commit currently failing on
`main`:

| | result |
|---|---|
| before | `go mod tidy` fails with the error above |
| after | exit 0, resolving `orchestrion/all/v2 v2.11.0-dev.0.20260911043200-8ae7d549421c` |

The resolved version is the commit's own pseudo-version rather than `v2.10.1`, which
confirms the new assertion is comparing against the right thing.

`actionlint` and `shellcheck` are both clean on the changed job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
