### PR TITLE
ci(orchestrion): allow the workflow to be triggered on demand

### DIFF
--- a/.github/workflows/orchestrion.yml
+++ b/.github/workflows/orchestrion.yml
@@ -11,6 +11,8 @@ on:
         type: boolean
         default: false
         required: false
+  workflow_dispatch: # On-demand runs; the `push` trigger below only covers release-v* branches,
+                     # so `main` is otherwise only exercised by the nightly schedule.
   pull_request:
   push:
     branches:


### PR DESCRIPTION
## What

Adds `workflow_dispatch` to the `on:` block of `.github/workflows/orchestrion.yml`. Two lines, no logic changes.

## Why

The Orchestrion workflow currently has no way to be run against `main` on request. Its triggers are:

- `workflow_call` (from `DataDog/orchestrion`)
- `pull_request`
- `push`, restricted to `release-v*` branches
- `schedule`, nightly at `00:00`

So a green Orchestrion signal on `main` is only obtainable by waiting for the nightly cron. Confirmed empirically: the last 8 `main` runs all have `event: schedule`.

This came up during incident-60559. Confirming Orchestrion was healthy on `main` was a gate for declaring the incident stable, and the only way to get that signal was to wait overnight.

The word `workflow_dispatch` already appears in the file, but only inside `if:` conditions and a comment, which reads as though manual runs are supported when they are not.

## Why no other change is needed

The existing guards already anticipate this event:

- The `generate` job's condition is `github.event_name == 'workflow_dispatch' || inputs.orchestrion-version == ''`, so it runs for a dispatch.
- The `inputs.orchestrion-version != ''` checks that select between the version-pinned path and the local one evaluate false for an undeclared input, so a dispatched run should check out `github.repository` at `github.sha` — the ref it was dispatched on.

I did not add an `orchestrion-version` input for dispatch, to keep this scoped to restoring on-demand runs. That can follow if manually testing a pinned Orchestrion version turns out to be useful.

## Test plan

- [x] `actionlint .github/workflows/orchestrion.yml` — exit code 0, no diagnostics
- [x] `on:` block parses with the trigger present and job count unchanged
- [ ] After merge: dispatch the workflow against `main` and confirm it runs and checks out the dispatched ref. This is the step that actually proves the input-guard reasoning above, since `workflow_dispatch` cannot be exercised from a branch until the trigger exists on the default branch.

Carrying the `ci` / `ci-infrastructure` labels to bypass the active team freeze for incident-60559.