### PR TITLE
fix(openfeature): bound InitWithContext by the configured init timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/klauspost/compress v1.18.7
 	github.com/linkdata/deadlock v0.5.5
 	github.com/minio/simdjson-go v0.4.5
-	github.com/open-feature/go-sdk v1.17.0
+	github.com/open-feature/go-sdk v1.18.0
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3
 	github.com/spaolacci/murmur3 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/open-feature/go-sdk v1.17.0 h1:/OUBBw5d9D61JaNZZxb2Nnr5/EJrEpjtKCTY3rspJQk=
-github.com/open-feature/go-sdk v1.17.0/go.mod h1:lPxPSu1UnZ4E3dCxZi5gV3et2ACi8O8P+zsTGVsDZUw=
+github.com/open-feature/go-sdk v1.18.0 h1:+Ge8LAJjqDwQBqAWaWiTbnsiJ22d5SPQq7/hOiBwpqM=
+github.com/open-feature/go-sdk v1.18.0/go.mod h1:LOlB7jvyi3hz9mp7R2uIwCv+wcabCB4ir76AZJ1z2IQ=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1538,6 +1538,7 @@ github.com/hashicorp/go-kms-wrapping/v2 v2.0.18 h1:DLfC677GfKEpSAFpEWvl1vXsGpEcS
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.18/go.mod h1:t/eaR/mi2mw3klfl1WEAuiLKrlZ/Q8cosmsT+RIPLu0=
 github.com/hashicorp/go-memdb v1.3.4 h1:XSL3NR682X/cVk2IeV0d70N4DZ9ljI885xAEU8IoK3c=
 github.com/hashicorp/go-memdb v1.3.4/go.mod h1:uBTr1oQbtuMgd1SSGoR8YV27eT3sBHbYiNm53bMpgSg=
+github.com/hashicorp/go-memdb v1.3.5/go.mod h1:8IVKKBkVe+fxFgdFOYxzQQNjz+sWCyHCdIC/+5+Vy1Y=
 github.com/hashicorp/go-plugin v1.6.1 h1:P7MR2UP6gNKGPp+y7EZw2kOiq4IR9WiqLvp0XOsVdwI=
 github.com/hashicorp/go-plugin v1.6.1/go.mod h1:XPHFku2tFo3o3QKFgSYo+cghcUhw1NA1hZyMK0PWAw0=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=

--- a/openfeature/doc.go
+++ b/openfeature/doc.go
@@ -32,40 +32,40 @@
 // To use the Datadog OpenFeature provider, create a new provider instance and
 // register it with the OpenFeature SDK:
 //
-//		import (
-//		    ddopenfeature "github.com/DataDog/dd-trace-go/v2/openfeature"
-//		    of "github.com/open-feature/go-sdk/openfeature"
-//		)
+//	import (
+//	    ddopenfeature "github.com/DataDog/dd-trace-go/v2/openfeature"
+//	    of "github.com/open-feature/go-sdk/openfeature"
+//	)
 //
-//		// Create and register the provider
-//		provider, err := ddopenfeature.NewDatadogProvider(ddopenfeature.ProviderConfig{})
-//		if err != nil {
-//		    log.Fatal(err)
-//		}
-//		defer provider.Shutdown()
+//	// Create and register the provider
+//	provider, err := ddopenfeature.NewDatadogProvider(ddopenfeature.ProviderConfig{})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer provider.Shutdown()
 //
-//		// Blocks while waiting for the first configuration, bounded by
-//		// DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS (default 10s).
-//		// On expiry it returns a recoverable PROVIDER_NOT_READY error: delivery keeps
-//		// running and a later configuration transitions the provider to ready.
-//		if err = of.SetProviderAndWait(provider); err != nil {
-//		    log.Printf("feature flags are not ready yet: %v", err)
-//		}
+//	// Blocks while waiting for the first configuration, bounded by
+//	// DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS (default 10s).
+//	// On expiry it returns a recoverable PROVIDER_NOT_READY error: delivery keeps
+//	// running and a later configuration transitions the provider to ready.
+//	if err = of.SetProviderAndWait(provider); err != nil {
+//	    log.Printf("feature flags are not ready yet: %v", err)
+//	}
 //
-//		// Create a client and evaluate flags
-//		client := of.NewClient("my-app")
-//		ctx := context.Background()
+//	// Create a client and evaluate flags
+//	client := of.NewClient("my-app")
+//	ctx := context.Background()
 //
-//		// Evaluate a boolean flag with a targetless context
-//		evalCtx := of.NewTargetlessEvaluationContext()
-//		enabled, err := client.BooleanValue(ctx, "new-feature", false, evalCtx)
-//		if err != nil {
-//		    log.Printf("Failed to evaluate flag: %v", err)
-//		}
+//	// Evaluate a boolean flag with a targetless context
+//	evalCtx := of.NewTargetlessEvaluationContext()
+//	enabled, err := client.BooleanValue(ctx, "new-feature", false, evalCtx)
+//	if err != nil {
+//	    log.Printf("Failed to evaluate flag: %v", err)
+//	}
 //
-//		if enabled {
-//		    // Execute new feature code
-//		}
+//	if enabled {
+//	    // Execute new feature code
+//	}
 //
 // # Targeting Context
 //

--- a/openfeature/doc.go
+++ b/openfeature/doc.go
@@ -271,9 +271,11 @@
 //     the added span tags may affect APM billing.
 //
 //   - DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS: Timeout in
-//     milliseconds for Init to wait for the first configuration before returning,
-//     used only by Init (not InitWithContext, which takes its deadline from the
-//     caller's context). Default 10000. An out-of-range (<= 0, or large enough to
+//     milliseconds to wait for the first configuration before returning. Used by
+//     Init, and by InitWithContext when the caller's context carries no deadline
+//     (a context with its own deadline keeps it). This covers the OpenFeature
+//     SDK's SetProviderAndWait, which calls InitWithContext with a background
+//     context. Default 10000. An out-of-range (<= 0, or large enough to
 //     overflow when converted to a time.Duration) or unparseable value falls back
 //     to the default rather than being clamped.
 //

--- a/openfeature/doc.go
+++ b/openfeature/doc.go
@@ -44,10 +44,12 @@
 //		}
 //		defer provider.Shutdown()
 //
-//	 // This can take up to 30 seconds (the default provider initialization timeout) as it waits for initialization
-//		err = of.SetProviderAndWait(provider)
-//		if err != nil {
-//		    log.Fatal(err)
+//		// Blocks while waiting for the first configuration, bounded by
+//		// DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS (default 10s).
+//		// On expiry it returns a recoverable PROVIDER_NOT_READY error: delivery keeps
+//		// running and a later configuration transitions the provider to ready.
+//		if err = of.SetProviderAndWait(provider); err != nil {
+//		    log.Printf("feature flags are not ready yet: %v", err)
 //		}
 //
 //		// Create a client and evaluate flags

--- a/openfeature/doc.go
+++ b/openfeature/doc.go
@@ -275,9 +275,11 @@
 //     Init, and by InitWithContext when the caller's context carries no deadline
 //     (a context with its own deadline keeps it). This covers the OpenFeature
 //     SDK's SetProviderAndWait, which calls InitWithContext with a background
-//     context. Default 10000. An out-of-range (<= 0, or large enough to
-//     overflow when converted to a time.Duration) or unparseable value falls back
-//     to the default rather than being clamped.
+//     context. Expiration returns a PROVIDER_NOT_READY initialization error;
+//     delivery continues and a later configuration transitions the provider to
+//     ready. Default 10000. An out-of-range (<= 0, or large enough to overflow
+//     when converted to a time.Duration) or unparseable value falls back to the
+//     default rather than being clamped.
 //
 // Example (Agentless, the default):
 //

--- a/openfeature/events.go
+++ b/openfeature/events.go
@@ -31,10 +31,10 @@ func (p *DatadogProvider) emitFirstOrChangeEvent(config *universalFlagsConfigura
 		}})
 	case !p.ready:
 		p.ready = true
-		if !p.firstReadyDelegated {
+		if !p.initialReadyHandoffComplete {
 			// The SDK emits its own ProviderReady when Init returns, so
 			// emitting the first transition here fires handlers twice.
-			p.firstReadyDelegated = true
+			p.initialReadyHandoffComplete = true
 			return
 		}
 		p.emitEvent(openfeature.Event{EventType: openfeature.ProviderReady, ProviderEventDetails: openfeature.ProviderEventDetails{

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -106,9 +106,11 @@ type DatadogProvider struct {
 	// rather than ProviderStale. Used to re-emit ProviderReady on every
 	// not-ready-to-ready transition, not just the first one. // +checklocks:mu
 	ready bool
-	// firstReadyDelegated records that the first ready transition was left to
-	// the SDK, which emits its own ProviderReady from Init. // +checklocks:mu
-	firstReadyDelegated bool
+	// initialReadyHandoffComplete records that Init's one-time synthetic event
+	// outcome is known. If configuration arrives before Init returns, the first
+	// ready event is left to the SDK. If Init returns an error first, a later
+	// configuration must emit ProviderReady itself. // +checklocks:mu
+	initialReadyHandoffComplete bool
 }
 
 // NewDatadogProvider creates a new Datadog OpenFeature provider with default configuration.
@@ -388,20 +390,22 @@ func (p *DatadogProvider) InitWithContext(ctx context.Context, _ openfeature.Eva
 		if err := p.waitForConfigurationUpdate(ctx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				// The caller explicitly asked to stop waiting, unlike a deadline
-				// which we deliberately tolerate below: report this as a real
-				// failure rather than telling the SDK initialization succeeded.
+				// which may come from the configured fallback below.
+				p.initialReadyHandoffComplete = true
 				return &openfeature.ProviderInitError{
 					ErrorCode: openfeature.ProviderNotReadyCode,
 					Message:   "initialization was canceled before configuration arrived",
 				}
 			}
-			// Timed out with delivery still running. This is not an error: Go's
-			// ErrorState does not block evaluation, and configuration arriving
-			// later promotes the provider to ReadyState (updateConfiguration
-			// also starts the writers below at that point, so nothing is lost
-			// by giving up here).
+			// Delivery remains active after a timeout. Mark the initial SDK
+			// handoff complete so a later configuration emits ProviderReady and
+			// recovers the SDK from this not-ready initialization result.
+			p.initialReadyHandoffComplete = true
 			log.Warn("openfeature: init did not receive configuration before its deadline; the provider will become ready once configuration arrives")
-			return nil
+			return &openfeature.ProviderInitError{
+				ErrorCode: openfeature.ProviderNotReadyCode,
+				Message:   "initialization timed out before configuration arrived",
+			}
 		}
 	}
 

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -320,12 +320,10 @@ func (p *DatadogProvider) Metadata() openfeature.Metadata {
 }
 
 // Init initializes the provider. For the Datadog provider,
-// this is waiting for the first configuration to be loaded.
+// this is waiting for the first configuration to be loaded, bounded by
+// DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS.
 func (p *DatadogProvider) Init(evaluationContext openfeature.EvaluationContext) error {
-	// Use a background context with a reasonable timeout for backward compatibility
-	ctx, cancel := context.WithTimeout(context.Background(), internalconfig.Get().FlaggingProviderInitTimeout())
-	defer cancel()
-	return p.InitWithContext(ctx, evaluationContext)
+	return p.InitWithContext(context.Background(), evaluationContext)
 }
 
 // waitForConfigurationUpdate waits for a configuration update or context
@@ -351,8 +349,17 @@ func (p *DatadogProvider) waitForConfigurationUpdate(ctx context.Context) error 
 
 // InitWithContext initializes the provider with context support.
 // This method respects context cancellation and timeouts, allowing users
-// to cancel the initialization process if needed.
+// to cancel the initialization process if needed. A context without a
+// deadline gets DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS.
 func (p *DatadogProvider) InitWithContext(ctx context.Context, _ openfeature.EvaluationContext) error {
+	// The SDK's SetProviderAndWait calls this directly with context.Background(),
+	// never Init, so the timeout has to be applied here or it waits forever.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, internalconfig.Get().FlaggingProviderInitTimeout())
+		defer cancel()
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/openfeature/provider_agentless_lifecycle_test.go
+++ b/openfeature/provider_agentless_lifecycle_test.go
@@ -189,3 +189,42 @@ func TestDatadogProvider_ConcurrentLifecycleRace(t *testing.T) {
 	defer cancel()
 	require.NoError(t, p.ShutdownWithContext(ctx))
 }
+
+// TestInitWithContext_UndeadlinedContextHonorsInitTimeout pins the regression
+// that hung the parametric weblog: the OpenFeature SDK's SetProviderAndWait
+// calls InitWithContext directly with context.Background(), never Init, so a
+// timeout applied only in Init left the caller waiting forever.
+func TestInitWithContext_UndeadlinedContextHonorsInitTimeout(t *testing.T) {
+	internalconfig.SetUseFreshConfig(true)
+	t.Cleanup(func() { internalconfig.SetUseFreshConfig(false) })
+	t.Setenv("DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS", "200")
+
+	p := newDatadogProvider(ProviderConfig{})
+
+	start := time.Now()
+	err := runWithDeadline(t, 10*time.Second, func() error {
+		return p.InitWithContext(context.Background(), openfeature.EvaluationContext{})
+	})
+
+	// Timing out with delivery still running stays a non-error: configuration
+	// arriving later promotes the provider to ready.
+	assert.NoError(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"an undeadlined context must still be bounded by the configured init timeout")
+}
+
+// TestSetProviderAndWait_DoesNotHangWithoutConfiguration exercises the same
+// bug through the SDK entry point customers actually call.
+func TestSetProviderAndWait_DoesNotHangWithoutConfiguration(t *testing.T) {
+	internalconfig.SetUseFreshConfig(true)
+	t.Cleanup(func() { internalconfig.SetUseFreshConfig(false) })
+	t.Setenv("DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS", "200")
+
+	p := newDatadogProvider(ProviderConfig{})
+
+	err := runWithDeadline(t, 10*time.Second, func() error {
+		return openfeature.SetProviderAndWait(p)
+	})
+
+	assert.NoError(t, err)
+}

--- a/openfeature/provider_agentless_lifecycle_test.go
+++ b/openfeature/provider_agentless_lifecycle_test.go
@@ -205,19 +205,27 @@ func TestInitWithContext_UndeadlinedContextHonorsInitTimeout(t *testing.T) {
 	err := runWithDeadline(t, 10*time.Second, func() error {
 		return p.InitWithContext(context.Background(), openfeature.EvaluationContext{})
 	})
+	elapsed := time.Since(start)
 
-	// Timing out with delivery still running stays a non-error: configuration
-	// arriving later promotes the provider to ready.
-	assert.NoError(t, err)
+	var initErr *openfeature.ProviderInitError
+	if assert.ErrorAs(t, err, &initErr) {
+		assert.Equal(t, openfeature.ProviderNotReadyCode, initErr.ErrorCode)
+	}
+	// Guard both sides of the configured timeout: returning immediately and
+	// silently substituting the much longer default must both fail this test.
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond,
+		"initialization must wait for the configured timeout before reporting not ready")
 	// A small multiple of the configured 200ms, so a hard-coded longer timeout
 	// (the 10s default included) still fails this.
-	assert.Less(t, time.Since(start), 2*time.Second,
+	assert.Less(t, elapsed, 2*time.Second,
 		"an undeadlined context must be bounded by the configured init timeout, not a fixed one")
 }
 
-// TestSetProviderAndWait_DoesNotHangWithoutConfiguration exercises the same
-// bug through the SDK entry point customers actually call.
-func TestSetProviderAndWait_DoesNotHangWithoutConfiguration(t *testing.T) {
+// TestSetProviderAndWait_TimeoutThenLateConfigurationTransitionsToReady
+// exercises the complete customer-visible lifecycle. SetProviderAndWait must
+// not report READY when its wait ends without configuration, while delivery
+// must remain registered so a later configuration can recover the provider.
+func TestSetProviderAndWait_TimeoutThenLateConfigurationTransitionsToReady(t *testing.T) {
 	internalconfig.SetUseFreshConfig(true)
 	t.Cleanup(func() { internalconfig.SetUseFreshConfig(false) })
 	t.Setenv("DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS", "200")
@@ -225,11 +233,48 @@ func TestSetProviderAndWait_DoesNotHangWithoutConfiguration(t *testing.T) {
 	openfeature.Shutdown() // drop providers and handlers left by other tests
 	t.Cleanup(openfeature.Shutdown)
 
+	readyEvents := make(chan openfeature.EventDetails, 2)
+	readyCallback := func(details openfeature.EventDetails) {
+		readyEvents <- details
+	}
+	openfeature.AddHandler(openfeature.ProviderReady, &readyCallback)
+
 	p := newDatadogProvider(ProviderConfig{})
 
 	err := runWithDeadline(t, 10*time.Second, func() error {
 		return openfeature.SetProviderAndWait(p)
 	})
 
-	assert.NoError(t, err)
+	var initErr *openfeature.ProviderInitError
+	if assert.ErrorAs(t, err, &initErr) {
+		assert.Equal(t, openfeature.ProviderNotReadyCode, initErr.ErrorCode)
+	}
+	assert.Nil(t, p.getConfiguration())
+	assert.NotEqual(t, openfeature.ReadyState, openfeature.NewDefaultClient().State(),
+		"SetProviderAndWait must not report READY before the first configuration")
+
+	select {
+	case <-readyEvents:
+		t.Error("ProviderReady was emitted before the first configuration")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Delivery continues after the bounded initialization wait. The first late
+	// configuration must be observable as the recovery transition to READY.
+	p.updateConfiguration(createTestConfig())
+
+	select {
+	case <-readyEvents:
+	case <-time.After(time.Second):
+		t.Fatal("late configuration did not emit ProviderReady")
+	}
+	assert.Eventually(t, func() bool {
+		return openfeature.NewDefaultClient().State() == openfeature.ReadyState
+	}, time.Second, time.Millisecond, "late configuration must promote the SDK state to READY")
+
+	result := p.BooleanEvaluation(context.Background(), "bool-flag", false, openfeature.FlattenedContext{
+		"targetingKey": "user-123",
+		"country":      "US",
+	})
+	assert.True(t, result.Value, "evaluation must succeed after late readiness recovery")
 }

--- a/openfeature/provider_agentless_lifecycle_test.go
+++ b/openfeature/provider_agentless_lifecycle_test.go
@@ -209,8 +209,10 @@ func TestInitWithContext_UndeadlinedContextHonorsInitTimeout(t *testing.T) {
 	// Timing out with delivery still running stays a non-error: configuration
 	// arriving later promotes the provider to ready.
 	assert.NoError(t, err)
-	assert.Less(t, time.Since(start), 5*time.Second,
-		"an undeadlined context must still be bounded by the configured init timeout")
+	// A small multiple of the configured 200ms, so a hard-coded longer timeout
+	// (the 10s default included) still fails this.
+	assert.Less(t, time.Since(start), 2*time.Second,
+		"an undeadlined context must be bounded by the configured init timeout, not a fixed one")
 }
 
 // TestSetProviderAndWait_DoesNotHangWithoutConfiguration exercises the same
@@ -219,6 +221,9 @@ func TestSetProviderAndWait_DoesNotHangWithoutConfiguration(t *testing.T) {
 	internalconfig.SetUseFreshConfig(true)
 	t.Cleanup(func() { internalconfig.SetUseFreshConfig(false) })
 	t.Setenv("DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS", "200")
+
+	openfeature.Shutdown() // drop providers and handlers left by other tests
+	t.Cleanup(openfeature.Shutdown)
 
 	p := newDatadogProvider(ProviderConfig{})
 

--- a/openfeature/provider_test.go
+++ b/openfeature/provider_test.go
@@ -612,6 +612,9 @@ func TestConcurrentEvaluations(t *testing.T) {
 }
 
 func TestSetProviderWithContextAndWaitTimeout(t *testing.T) {
+	openfeature.Shutdown()
+	t.Cleanup(openfeature.Shutdown)
+
 	// Create a provider that doesn't have configuration loaded
 	// This will cause InitWithContext to wait for configuration
 	provider := newDatadogProvider(ProviderConfig{})
@@ -620,12 +623,12 @@ func TestSetProviderWithContextAndWaitTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	// A timeout while a delivery source is still running (no deliveryErr) is
-	// deliberately not an error: Go's ErrorState doesn't block evaluation, and
-	// configuration arriving later promotes the provider. See InitWithContext.
 	err := openfeature.SetProviderWithContextAndWait(ctx, provider)
-	if err != nil {
-		t.Errorf("expected nil (init timeout is transient, not an error), got: %v", err)
+	if err == nil {
+		t.Fatal("expected initialization timeout to report the provider as not ready")
+	}
+	if state := openfeature.NewDefaultClient().State(); state == openfeature.ReadyState {
+		t.Error("provider must not be READY before receiving configuration")
 	}
 }
 
@@ -683,13 +686,14 @@ func TestInitWithContext_ShutdownDuringWaitReturnsPromptly(t *testing.T) {
 func TestInitWithContext_LateConfigurationStillBecomesReady(t *testing.T) {
 	provider := newDatadogProvider(ProviderConfig{})
 
-	// Init gives up on its deadline while delivery is still running. That is
-	// deliberately not an error, so the provider must still pick up a
-	// configuration that arrives afterwards.
+	// Init gives up on its deadline while delivery is still running. It reports
+	// not ready, but the provider must still pick up a later configuration.
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	if err := provider.InitWithContext(ctx, openfeature.EvaluationContext{}); err != nil {
-		t.Fatalf("a deadline with delivery still running must not be reported as an error, got: %v", err)
+	err := provider.InitWithContext(ctx, openfeature.EvaluationContext{})
+	var initErr *openfeature.ProviderInitError
+	if !errors.As(err, &initErr) || initErr.ErrorCode != openfeature.ProviderNotReadyCode {
+		t.Fatalf("expected a ProviderInitError with ProviderNotReadyCode, got: %v", err)
 	}
 	if provider.getConfiguration() != nil {
 		t.Fatal("no configuration should be stored yet")
@@ -702,8 +706,11 @@ func TestInitWithContext_LateConfigurationStillBecomesReady(t *testing.T) {
 		t.Error("a configuration arriving after Init's deadline must still be stored")
 	}
 
-	// The SDK already emitted its own ProviderReady when Init returned nil on
-	// the deadline, so this transition is recorded but not re-emitted.
+	event := drainEvent(t, provider.EventChannel())
+	if event.EventType != openfeature.ProviderReady {
+		t.Errorf("expected ProviderReady for the late configuration, got %v", event.EventType)
+	}
+
 	provider.mu.RLock()
 	ready := provider.ready
 	provider.mu.RUnlock()


### PR DESCRIPTION
### What does this PR do?

Two related changes to provider initialization:

1. Applies `DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS` inside `InitWithContext` when the caller's context carries no deadline, rather than only in `Init`. `Init` now delegates to `InitWithContext`, so the timeout has a single source of truth.
2. Reports an expired initialization wait as `PROVIDER_NOT_READY` instead of returning `nil`, so the SDK no longer reports READY when no configuration ever arrived. Delivery keeps running, and a later configuration emits `ProviderReady` to recover the provider.

Requires `open-feature/go-sdk` v1.18.0: in v1.17.0 the SDK unregisters provider event handlers after a failed initialization, which would strand the provider with no way to recover once configuration arrived.

### Motivation

The OpenFeature Go SDK checks whether a provider implements `ContextAwareStateHandler`. `DatadogProvider` does, so `openfeature.SetProviderAndWait` calls `InitWithContext` directly — never `Init` — and hands it `context.Background()`:

    of.SetProviderAndWait(provider)
      -> setProvider(provider, false)
      -> initNewAndShutdownOld(context.Background(), ...)   openfeature_api.go:340
      -> initializerWithContext(ctx)                        openfeature_api.go:366
      -> provider.InitWithContext(ctx, ...)                 <- no deadline

`Init` was the only place the timeout was applied. On that path `InitWithContext` looped on `for p.configuration == nil` against a context that never cancels, so it waited forever for the first configuration.

The effect was user-facing: `SetProviderAndWait` is the documented way to block until a provider is ready, and an application using it hung at startup for as long as Datadog was unreachable, with `DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS` silently ignored.

Found while bringing up the FFE configuration-source parametric system tests for Go: the weblog's `/ffe/start` never returned, and the suite hung instead of completing in about 20 seconds.

### Cross-SDK parity

Reporting the timeout as not-ready matches the other tracers:

| Tracer | On initialization timeout |
|---|---|
| dd-trace-py | raises `ProviderNotReadyError` (`_provider.py:312`) |
| dd-trace-js | rejects `initialize()` and calls `setError` |
| dd-trace-go (this PR) | `ProviderInitError` / `ProviderNotReadyCode` |
| dd-trace-dotnet | logs a warning only (`FeatureFlagsModule.cs:272`) |

Returning `nil` left Go as the outlier alongside .NET.

### Reviewer's Checklist

- [x] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [x] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [x] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
