### PR TITLE
ci(static-checks): disable overlapping lint caches

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,6 +4,10 @@ inputs:
   go-version:
     required: true
     description: Go version to setup.
+  cache:
+    required: false
+    default: "true"
+    description: Whether to restore and save Go build and module caches.
   tools-bin:
     required: true
     description: Directory to installs tools to.
@@ -36,7 +40,7 @@ runs:
       id: setup-go
       with:
         go-version: ${{ inputs.go-version }}
-        cache: true
+        cache: ${{ inputs.cache }}
         check-latest: true
 
     # Callers that run a tool exporting its own GOROOT into $GITHUB_ENV before this

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -189,7 +189,6 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Restore golangci-lint cache
-        if: false # Temporary benchmark: measure lint without the explicit cache.
         id: golangci-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -222,7 +221,7 @@ jobs:
           filter_mode: nofilter
 
       - name: Save golangci-lint cache
-        if: false # Temporary benchmark: measure lint without the explicit cache.
+        if: steps.golangci-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -184,19 +184,6 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Record checked-out commit
-        id: checkout
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore golangci-lint cache
-        id: golangci-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/golangci-lint
-          key: golangci-v1-${{ runner.os }}-${{ runner.arch }}-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ inputs.go-version || 'stable' }}-${{ hashFiles('.golangci.yml', 'internal/orchestrion/_integration/.golangci.yml') }}-${{ hashFiles('**/go.mod', '**/go.sum') }}-${{ steps.checkout.outputs.sha }}
-          restore-keys: |
-            golangci-v1-${{ runner.os }}-${{ runner.arch }}-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ inputs.go-version || 'stable' }}-${{ hashFiles('.golangci.yml', 'internal/orchestrion/_integration/.golangci.yml') }}-
-
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
         with:
@@ -219,13 +206,6 @@ jobs:
           reporter: github-pr-review
           workdir: internal/orchestrion/_integration
           filter_mode: nofilter
-
-      - name: Save golangci-lint cache
-        if: steps.golangci-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/golangci-lint
-          key: ${{ steps.golangci-cache.outputs.cache-primary-key }}
 
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -184,11 +184,25 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Record checked-out commit
+        id: checkout
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore golangci-lint cache
+        id: golangci-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-v1-${{ runner.os }}-${{ runner.arch }}-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ inputs.go-version || 'stable' }}-${{ hashFiles('.golangci.yml', 'internal/orchestrion/_integration/.golangci.yml') }}-${{ hashFiles('**/go.mod', '**/go.sum') }}-${{ steps.checkout.outputs.sha }}
+          restore-keys: |
+            golangci-v1-${{ runner.os }}-${{ runner.arch }}-${{ env.GOLANGCI_LINT_VERSION }}-go-${{ inputs.go-version || 'stable' }}-${{ hashFiles('.golangci.yml', 'internal/orchestrion/_integration/.golangci.yml') }}-
+
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
         with:
+          cache: false
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
-          go_version: ${{ inputs.go-version }}
+          go_version: ${{ inputs.go-version || 'stable' }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
           fail_level: error
           reporter: github-pr-review
@@ -197,18 +211,27 @@ jobs:
       - name: golangci-lint (internal/orchestrion/_integration)
         uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
         with:
+          cache: false
           golangci_lint_flags: "--timeout 10m --disable=gocritic" # We are hitting timeout when there is no cache
-          go_version: ${{ inputs.go-version }}
+          go_version: ${{ inputs.go-version || 'stable' }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
           fail_level: error
           reporter: github-pr-review
           workdir: internal/orchestrion/_integration
           filter_mode: nofilter
 
+      - name: Save golangci-lint cache
+        if: steps.golangci-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ steps.golangci-cache.outputs.cache-primary-key }}
+
       - name: Setup Go and development tools
         uses: ./.github/actions/setup-go
         with:
           go-version: ${{ inputs.go-version || 'stable' }}
+          cache: "false"
           tools-dir: ${{ github.workspace }}/_tools
           tools-bin: ${{ github.workspace }}/bin
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           cache: false
           golangci_lint_flags: "--timeout 10m" # We are hitting timeout when there is no cache
-          go_version: ${{ inputs.go-version || 'stable' }}
+          go_version: ${{ inputs.go-version }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
           fail_level: error
           reporter: github-pr-review
@@ -213,7 +213,7 @@ jobs:
         with:
           cache: false
           golangci_lint_flags: "--timeout 10m --disable=gocritic" # We are hitting timeout when there is no cache
-          go_version: ${{ inputs.go-version || 'stable' }}
+          go_version: ${{ inputs.go-version }}
           golangci_lint_version: ${{ env.GOLANGCI_LINT_VERSION }}
           fail_level: error
           reporter: github-pr-review

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -189,6 +189,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Restore golangci-lint cache
+        if: false # Temporary benchmark: measure lint without the explicit cache.
         id: golangci-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -221,7 +222,7 @@ jobs:
           filter_mode: nofilter
 
       - name: Save golangci-lint cache
-        if: steps.golangci-cache.outputs.cache-hit != 'true'
+        if: false # Temporary benchmark: measure lint without the explicit cache.
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint


### PR DESCRIPTION
### What does this PR do?

Removes lint-specific caching from the `lint` job.
This fixes an [issue with overlapping cache restores failing during extraction](https://github.com/DataDog/dd-trace-go/actions/runs/34531286327/job/103052508935#step:4:103) and, most importantly **stops the job from writing 1.4 GiB, virtually useless cache artifacts that pollute this repo's cache allowance, which is 10 GiB**.

### Motivation

`dd-trace-go`'s GitHub actions [Caches](https://github.com/DataDog/dd-trace-go/actions/caches) are practically not working today.
The amount of data uploaded to cache on every commit is so large, that a single commit CI run normally faces cache eviction before it even finishes.

One large cuprid is the `lint` cache, which has a 1% cache hit rate in the last 30 days and creates a 1.4 GiB upload for every commit. Given the 10 GiB global limit, a 1% hit rate 1.4 GiB artifact is not helpful.

The reason the artifact is so large is because it included not only lint-related caching (~/.cache/golangci-lint), but also the whole `GOMODCACHE` and `GOCACHE` which are already cached/restore in the `lint` job.

I tested replacing the large archives with one of only, `~/.cache/golangci-lint`, at 1.5–1.8 MiB, but the cache hit rate for anything but retries was too low to justify the added complexity and maintenance, since this would be a new custom cache key to maintain.

Cached runs were also just a bit faster, even on reruns, not significant. So even in the best scenario, that cache is of little use.

**One possible follow up that could save time in `lint` is running the linting processes in parallel, separate jobs, instead of serially like today (Root golangci-lint; internal/orchestrion/_integration golangci-lint; make lint/errlog).**

I'll try to continue improving CI caching, since it's still going to be facing constant eviction, but there's a lot of other caches to improve!

### Reviewer's Checklist

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.
