### PR TITLE
fix(openfeature): validate local EVP proxy capabilities

### DIFF
--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -131,8 +131,8 @@ func newEVPClientBase() *evpClient {
 }
 
 // evpAgentBaseURL keeps an explicit Agent URL prefix while removing a known
-// trace intake endpoint. Serverless relays commonly require DD_TRACE_AGENT_URL
-// to include that endpoint even though /info and /evp_proxy are rooted beside it.
+// trace intake endpoint. DD_TRACE_AGENT_URL may name that endpoint even though
+// /info and /evp_proxy are sibling routes.
 func evpAgentBaseURL(agentURL *url.URL) *url.URL {
 	u := *agentURL
 	u.Path = strings.TrimRight(u.Path, "/")

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -229,7 +229,8 @@ func (c *evpClient) send(
 	}
 
 	u := *baseURL
-	u.Path = joinEVPPath(basePath, endpoint)
+	u.Path = joinEVPPath(u.Path, basePath, endpoint)
+	u.RawPath = ""
 	requestURL := u.String()
 	var wroteRequest atomic.Bool
 	trace := &httptrace.ClientTrace{
@@ -312,7 +313,8 @@ func (c *evpClient) discoverLocalRoute() string {
 	}
 
 	u := *c.agentURL
-	u.Path = "/info"
+	u.Path = joinEVPPath(u.Path, "/info")
+	u.RawPath = ""
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u.String(), nil)
 	if err != nil {
 		return ""
@@ -327,12 +329,30 @@ func (c *evpClient) discoverLocalRoute() string {
 	}
 
 	var info struct {
-		Endpoints []string `json:"endpoints"`
+		Endpoints              []string `json:"endpoints"`
+		EVPProxyAllowedHeaders []string `json:"evp_proxy_allowed_headers"`
 	}
 	if err := c.jsonConfig.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&info); err != nil {
 		return ""
 	}
+	if !supportsEVPProxyIdentityHeaders(info.EVPProxyAllowedHeaders) {
+		return ""
+	}
 	return selectEVPProxyPath(info.Endpoints)
+}
+
+func supportsEVPProxyIdentityHeaders(headers []string) bool {
+	hasOrigin := false
+	hasOriginVersion := false
+	for _, header := range headers {
+		switch {
+		case strings.EqualFold(strings.TrimSpace(header), headerEVPOrigin):
+			hasOrigin = true
+		case strings.EqualFold(strings.TrimSpace(header), headerEVPOriginVersion):
+			hasOriginVersion = true
+		}
+	}
+	return hasOrigin && hasOriginVersion
 }
 
 func selectEVPProxyPath(endpoints []string) string {
@@ -348,8 +368,17 @@ func selectEVPProxyPath(endpoints []string) string {
 	return ""
 }
 
-func joinEVPPath(basePath, endpoint string) string {
-	return strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(endpoint, "/")
+func joinEVPPath(parts ...string) string {
+	joined := ""
+	for _, part := range parts {
+		if part = strings.Trim(part, "/"); part != "" {
+			joined += "/" + part
+		}
+	}
+	if joined == "" {
+		return "/"
+	}
+	return joined
 }
 
 func (c *evpClient) canUseDirect() bool {

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -184,8 +184,7 @@ func (c *evpClient) postRaw(endpoint, eventName string, body []byte) error {
 			return nil
 		}
 
-		var statusErr *evpHTTPStatusError
-		if errors.As(result.err, &statusErr) {
+		if statusErr, ok := errors.AsType[*evpHTTPStatusError](result.err); ok {
 			replay := statusErr.statusCode == http.StatusNotFound ||
 				statusErr.statusCode == http.StatusMethodNotAllowed
 			if !replay && !shouldSwitchFutureRoute(statusErr.statusCode) {

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -120,6 +120,7 @@ func newEVPClientBase() *evpClient {
 	} else {
 		httpClient = internal.DefaultHTTPClient(defaultHTTPTimeout, false)
 	}
+	agentURL = evpAgentBaseURL(agentURL)
 	return &evpClient{
 		httpClient: httpClient,
 		agentURL:   agentURL,
@@ -127,6 +128,22 @@ func newEVPClientBase() *evpClient {
 		now:        time.Now,
 		cooldown:   defaultEVPRouteRecoveryCooldown,
 	}
+}
+
+// evpAgentBaseURL keeps an explicit Agent URL prefix while removing a known
+// trace intake endpoint. Serverless relays commonly require DD_TRACE_AGENT_URL
+// to include that endpoint even though /info and /evp_proxy are rooted beside it.
+func evpAgentBaseURL(agentURL *url.URL) *url.URL {
+	u := *agentURL
+	u.Path = strings.TrimRight(u.Path, "/")
+	for _, endpoint := range []string{"/v0.4/traces", "/v0.5/traces", "/v1.0/traces"} {
+		if basePath, ok := strings.CutSuffix(u.Path, endpoint); ok {
+			u.Path = basePath
+			break
+		}
+	}
+	u.RawPath = ""
+	return &u
 }
 
 func refuseEVPRedirect(*http.Request, []*http.Request) error {

--- a/openfeature/evp.go
+++ b/openfeature/evp.go
@@ -186,11 +186,12 @@ func (c *evpClient) postRaw(endpoint, eventName string, body []byte) error {
 
 		var statusErr *evpHTTPStatusError
 		if errors.As(result.err, &statusErr) {
-			if statusErr.statusCode != http.StatusNotFound &&
-				statusErr.statusCode != http.StatusMethodNotAllowed {
+			replay := statusErr.statusCode == http.StatusNotFound ||
+				statusErr.statusCode == http.StatusMethodNotAllowed
+			if !replay && !shouldSwitchFutureRoute(statusErr.statusCode) {
 				return result.err
 			}
-			if c.leaveLocalRoute() {
+			if direct := c.leaveLocalRoute(); direct && replay {
 				return c.sendDirect(endpoint, eventName, body)
 			}
 			return result.err
@@ -369,20 +370,27 @@ func selectEVPProxyPath(endpoints []string) string {
 }
 
 func joinEVPPath(parts ...string) string {
-	joined := ""
+	var joined strings.Builder
 	for _, part := range parts {
 		if part = strings.Trim(part, "/"); part != "" {
-			joined += "/" + part
+			joined.WriteByte('/')
+			joined.WriteString(part)
 		}
 	}
-	if joined == "" {
+	if joined.Len() == 0 {
 		return "/"
 	}
-	return joined
+	return joined.String()
 }
 
 func (c *evpClient) canUseDirect() bool {
 	return c.directClient != nil && c.directURL != nil && c.apiKey != ""
+}
+
+func shouldSwitchFutureRoute(statusCode int) bool {
+	return statusCode == http.StatusForbidden ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode >= http.StatusInternalServerError && statusCode < 600
 }
 
 // leaveLocalRoute selects direct intake for future events when available.

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -399,7 +399,60 @@ func TestAgentlessEVPDoesNotReplayAmbiguousResponses(t *testing.T) {
 			if got := directCalls.Load(); got != 0 {
 				t.Fatalf("direct calls = %d, want 0", got)
 			}
+			if err := c.postRaw(exposureEndpoint, "exposure", nil); err != nil {
+				t.Fatalf("future post through direct route: %v", err)
+			}
+			if got := directCalls.Load(); got != 1 {
+				t.Fatalf("future direct calls = %d, want 1", got)
+			}
 		})
+	}
+}
+
+func TestAgentlessEVPNonReplayableResponseWithoutCredentialsEntersCooldown(t *testing.T) {
+	var ready atomic.Bool
+	var infoCalls atomic.Int32
+	var eventCalls atomic.Int32
+	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			infoCalls.Add(1)
+			_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`)
+			return
+		}
+		eventCalls.Add(1)
+		if ready.Load() {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer agent.Close()
+
+	c := testAgentlessEVPClient(t, agent, nil, "")
+	now := time.Unix(100, 0)
+	c.now = func() time.Time { return now }
+	c.cooldown = time.Minute
+
+	if err := c.postRaw(exposureEndpoint, "exposure", nil); err == nil {
+		t.Fatal("first post returned nil, want status error")
+	}
+	ready.Store(true)
+	if err := c.postRaw(exposureEndpoint, "exposure", nil); !errors.Is(err, errNoEVPRoute) {
+		t.Fatalf("post during cooldown error = %v, want %v", err, errNoEVPRoute)
+	}
+	if got := eventCalls.Load(); got != 1 {
+		t.Fatalf("local posts during cooldown = %d, want 1", got)
+	}
+
+	now = now.Add(time.Minute)
+	if err := c.postRaw(exposureEndpoint, "exposure", nil); err != nil {
+		t.Fatalf("post after cooldown: %v", err)
+	}
+	if got := infoCalls.Load(); got != 2 {
+		t.Fatalf("/info calls = %d, want 2", got)
+	}
+	if got := eventCalls.Load(); got != 2 {
+		t.Fatalf("local posts after recovery = %d, want 2", got)
 	}
 }
 

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -286,6 +286,42 @@ func TestAgentlessEVPPreservesAgentURLPath(t *testing.T) {
 	}
 }
 
+func TestAgentlessEVPStripsKnownTraceEndpointAndPreservesPrefix(t *testing.T) {
+	for _, traceEndpoint := range []string{"/v0.4/traces", "/v0.5/traces", "/v1.0/traces"} {
+		t.Run(traceEndpoint, func(t *testing.T) {
+			const agentPrefix = "/agent-prefix"
+			var infoCalls atomic.Int32
+			var eventCalls atomic.Int32
+			agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case agentPrefix + "/info":
+					infoCalls.Add(1)
+					_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"],`+compatibleEVPProxyHeadersJSON+`}`)
+				case agentPrefix + evpProxyV4Path + exposureEndpoint:
+					eventCalls.Add(1)
+					w.WriteHeader(http.StatusAccepted)
+				default:
+					t.Errorf("unexpected path %q", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer agent.Close()
+
+			t.Setenv("DD_TRACE_AGENT_URL", agent.URL+agentPrefix+traceEndpoint)
+			c := newAgentlessEVPClient(internalffe.Settings{})
+			if err := c.postRaw(exposureEndpoint, "exposure", nil); err != nil {
+				t.Fatal(err)
+			}
+			if got := infoCalls.Load(); got != 1 {
+				t.Fatalf("/info calls = %d, want 1", got)
+			}
+			if got := eventCalls.Load(); got != 1 {
+				t.Fatalf("event calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestAgentlessEVPNoRouteRecoversAfterCooldown(t *testing.T) {
 	var ready atomic.Bool
 	var infoCalls atomic.Int32
@@ -731,7 +767,7 @@ func TestAgentOnlyEVPClientKeepsV2Route(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer agent.Close()
-	t.Setenv("DD_TRACE_AGENT_URL", agent.URL+"/agent-prefix")
+	t.Setenv("DD_TRACE_AGENT_URL", agent.URL+"/agent-prefix/v1.0/traces")
 
 	body := []byte(`{"context":{"service":"test-service"},"flagEvaluations":[]}`)
 	c := newEVPClient()

--- a/openfeature/evp_test.go
+++ b/openfeature/evp_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/internal/version"
 )
 
+const compatibleEVPProxyHeadersJSON = `"evp_proxy_allowed_headers":["DD-EVP-ORIGIN","DD-EVP-ORIGIN-VERSION"]`
+
 func TestBuildDirectEVPURL(t *testing.T) {
 	tests := map[string]struct {
 		site string
@@ -124,7 +126,7 @@ func TestAgentlessEVPRouteSelectionAndCredentials(t *testing.T) {
 			agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/info" {
 					w.Header().Set("Content-Type", "application/json")
-					_, _ = io.WriteString(w, `{"endpoints":["`+strings.Join(tt.endpoints, `","`)+`"]}`)
+					_, _ = io.WriteString(w, `{"endpoints":["`+strings.Join(tt.endpoints, `","`)+`"],`+compatibleEVPProxyHeadersJSON+`}`)
 					return
 				}
 				localPath = r.URL.Path
@@ -181,6 +183,109 @@ func TestAgentlessEVPRouteSelectionAndCredentials(t *testing.T) {
 	}
 }
 
+func TestAgentlessEVPRequiresIdentityHeaderForwarding(t *testing.T) {
+	tests := map[string]struct {
+		infoJSON  string
+		wantLocal bool
+	}{
+		"missing capability": {
+			infoJSON: `{"endpoints":["/evp_proxy/v4"]}`,
+		},
+		"null capability": {
+			infoJSON: `{"endpoints":["/evp_proxy/v4"],"evp_proxy_allowed_headers":null}`,
+		},
+		"origin only": {
+			infoJSON: `{"endpoints":["/evp_proxy/v4"],"evp_proxy_allowed_headers":["DD-EVP-ORIGIN"]}`,
+		},
+		"origin version only": {
+			infoJSON: `{"endpoints":["/evp_proxy/v4"],"evp_proxy_allowed_headers":["DD-EVP-ORIGIN-VERSION"]}`,
+		},
+		"both case insensitive": {
+			infoJSON:  `{"endpoints":["/evp_proxy/v4"],"evp_proxy_allowed_headers":["dd-evp-origin-version","dd-evp-origin"]}`,
+			wantLocal: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var localPosts atomic.Int32
+			agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/info" {
+					_, _ = io.WriteString(w, tt.infoJSON)
+					return
+				}
+				localPosts.Add(1)
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer agent.Close()
+
+			var directPosts atomic.Int32
+			direct := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				directPosts.Add(1)
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer direct.Close()
+
+			c := testAgentlessEVPClient(t, agent, direct, "api-key")
+			if err := c.postRaw(exposureEndpoint, "exposure", nil); err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantLocal {
+				if got := localPosts.Load(); got != 1 {
+					t.Fatalf("local posts = %d, want 1", got)
+				}
+				if got := directPosts.Load(); got != 0 {
+					t.Fatalf("direct posts = %d, want 0", got)
+				}
+				return
+			}
+			if got := localPosts.Load(); got != 0 {
+				t.Fatalf("local posts = %d, want 0", got)
+			}
+			if got := directPosts.Load(); got != 1 {
+				t.Fatalf("direct posts = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestAgentlessEVPPreservesAgentURLPath(t *testing.T) {
+	const agentBasePath = "/agent-prefix"
+	var infoCalls atomic.Int32
+	var eventCalls atomic.Int32
+	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case agentBasePath + "/info":
+			infoCalls.Add(1)
+			_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"],`+compatibleEVPProxyHeadersJSON+`}`)
+		case agentBasePath + evpProxyV4Path + exposureEndpoint:
+			eventCalls.Add(1)
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer agent.Close()
+
+	c := testAgentlessEVPClient(t, agent, nil, "")
+	agentURL, err := url.Parse(agent.URL + agentBasePath + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.agentURL = agentURL
+	if err := c.postRaw(exposureEndpoint, "exposure", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := infoCalls.Load(); got != 1 {
+		t.Fatalf("prefixed /info calls = %d, want 1", got)
+	}
+	if got := eventCalls.Load(); got != 1 {
+		t.Fatalf("prefixed event calls = %d, want 1", got)
+	}
+}
+
 func TestAgentlessEVPNoRouteRecoversAfterCooldown(t *testing.T) {
 	var ready atomic.Bool
 	var infoCalls atomic.Int32
@@ -189,7 +294,7 @@ func TestAgentlessEVPNoRouteRecoversAfterCooldown(t *testing.T) {
 		if r.URL.Path == "/info" {
 			infoCalls.Add(1)
 			if ready.Load() {
-				_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2"]}`)
+				_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`)
 			} else {
 				_, _ = io.WriteString(w, `{"endpoints":[]}`)
 			}
@@ -233,7 +338,7 @@ func TestAgentlessEVPRejectedLocalRouteReplaysDirect(t *testing.T) {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/info" {
-					_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"]}`)
+					_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"],`+compatibleEVPProxyHeadersJSON+`}`)
 					return
 				}
 				w.WriteHeader(status)
@@ -268,7 +373,7 @@ func TestAgentlessEVPDoesNotReplayAmbiguousResponses(t *testing.T) {
 			const secret = "response-body-must-not-escape"
 			agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/info" {
-					_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2"]}`)
+					_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`)
 					return
 				}
 				w.WriteHeader(status)
@@ -340,7 +445,7 @@ func TestAgentlessEVPTransportFailureChangesOnlyFutureRouting(t *testing.T) {
 	}
 	agentClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path == "/info" {
-			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"]}`), nil
+			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`), nil
 		}
 		localPosts.Add(1)
 		return nil, errors.New("ambiguous transport failure")
@@ -388,7 +493,7 @@ func TestAgentlessEVPDefinitivePreSendFailureReplaysDirect(t *testing.T) {
 	}
 	agentClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path == "/info" {
-			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"]}`), nil
+			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`), nil
 		}
 		return nil, syscall.ECONNREFUSED
 	})}
@@ -426,7 +531,7 @@ func TestAgentlessEVPDoesNotReplayWrittenRequest(t *testing.T) {
 	}
 	agentClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path == "/info" {
-			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"]}`), nil
+			return response(http.StatusOK, `{"endpoints":["/evp_proxy/v2"],`+compatibleEVPProxyHeadersJSON+`}`), nil
 		}
 		if trace := httptrace.ContextClientTrace(r.Context()); trace != nil && trace.WroteRequest != nil {
 			trace.WroteRequest(httptrace.WroteRequestInfo{})
@@ -524,7 +629,7 @@ func TestAgentlessEVPSerializesInitialDiscovery(t *testing.T) {
 	agent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/info" {
 			infoCalls.Add(1)
-			_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"]}`)
+			_, _ = io.WriteString(w, `{"endpoints":["/evp_proxy/v4"],`+compatibleEVPProxyHeadersJSON+`}`)
 			return
 		}
 		eventCalls.Add(1)
@@ -573,14 +678,14 @@ func TestAgentOnlyEVPClientKeepsV2Route(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer agent.Close()
-	t.Setenv("DD_TRACE_AGENT_URL", agent.URL)
+	t.Setenv("DD_TRACE_AGENT_URL", agent.URL+"/agent-prefix")
 
 	body := []byte(`{"context":{"service":"test-service"},"flagEvaluations":[]}`)
 	c := newEVPClient()
 	if err := c.postRaw(flagEvalLoggingEndpoint, "flag evaluation", body); err != nil {
 		t.Fatal(err)
 	}
-	wantPath := evpProxyV2Path + flagEvalLoggingEndpoint
+	wantPath := "/agent-prefix" + evpProxyV2Path + flagEvalLoggingEndpoint
 	if gotPath != wantPath {
 		t.Fatalf("path = %q, want %q", gotPath, wantPath)
 	}


### PR DESCRIPTION
## Motivation

We are shipping agentless CDN-delivered Feature Flags configuration to simplify customer deployments. The SDK telemetry produced by those evaluations still needs a reliable network path off the process: prefer an auto-discovered Agent or serverless proxy when it can carry the required event identity, and otherwise use direct EVP intake.

The Agentless selector previously discarded path prefixes configured in `DD_TRACE_AGENT_URL` and selected a local EVP endpoint without verifying that the relay could forward `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION`. A prefixed gateway could therefore be addressed incorrectly, while an older relay could silently strip the logical Go SDK identity. It also kept future batches on a local relay after non-replayable HTTP failures instead of moving subsequent delivery to the already-configured direct route.

## Changes

- Preserve the configured Agent URL path for both `/info` discovery and local EVP event requests.
- Require `/info` to advertise forwarding support for both EVP identity headers before Agentless mode selects a local v4 or v2 route.
- Fall back to direct intake when the local capability is absent and direct credentials are available.
- Never replay the current batch after local 403/429/5xx; switch only later batches to direct intake, or enter the bounded unavailable/cooldown state when direct credentials are absent.
- Add coverage for missing, null, partial, and case-insensitive header capability advertisements, path prefixes, future-only switching, and no-credential cooldown.

## Decisions

- Header capability checks and fallback transitions apply only to Agentless discovery. The historical Remote Configuration and Agent-only client remains fixed to EVP v2 and does not perform `/info` discovery or acquire direct credentials.
- HTTP header names are matched case-insensitively.
- Missing or partial capability advertisement is treated as an incompatible local relay rather than risking unattributed telemetry.
- A local 403/429/5xx is not proof that the relay rejected the payload before processing, so it cannot justify same-batch replay. It does prove the selected route is unhealthy enough to switch future batches when direct intake is configured.
- This PR changes only the Go SDK. It does not modify `system-tests` or dogfooding infrastructure.

## Validation

Base: `9af1f1e1a8ce55bdd68bb2aa8c27fdf41299301d`

Candidate: `88f2f3287a84292d8fab12f87d5fc80425cff415`

- `TMPDIR=/home/bits/dd/.codex-tmp/go-tmp GOCACHE=/home/bits/dd/.codex-tmp/go-cache GOTMPDIR=/home/bits/dd/.codex-tmp/go-tmp go test ./openfeature` — passed.
- `TMPDIR=/home/bits/dd/.codex-tmp/go-tmp GOCACHE=/home/bits/dd/.codex-tmp/go-cache GOTMPDIR=/home/bits/dd/.codex-tmp/go-tmp go test -race ./openfeature -run 'Test.*EVP|TestNewDatadogProvider.*Agentless'` — passed.
- `TMPDIR=/home/bits/dd/.codex-tmp/go-tmp GOCACHE=/home/bits/dd/.codex-tmp/go-cache GOTMPDIR=/home/bits/dd/.codex-tmp/go-tmp bin/golangci-lint run ./...` — `0 issues`.
- `git diff --check` — passed.
- GitHub verification for all five PR commits — `verified: true`, reason `valid`.

- Exact-candidate `net-http` system tests passed direct exposure, flag-evaluation, and shutdown delivery `3/3`, plus serverless-init exposure and flag-evaluation delivery `2/2`, through DataDog/system-tests#7604 on the shared #7299 foundation.
- This SDK PR does not modify `system-tests` or `ffe-dogfooding`; dogfooding was not run in this validation pass.

