### PR TITLE
fix(contrib/labstack/echo.v5): resolve sentinel HTTP errors via HTTPStatusCoder

### DIFF
--- a/contrib/labstack/echo.v5/echotrace.go
+++ b/contrib/labstack/echo.v5/echotrace.go
@@ -151,18 +151,9 @@ func Middleware(opts ...Option) echo.MiddlewareFunc {
 			if err != nil && !shouldIgnoreError(cfg, err) {
 				// It is impossible to determine what the final status code of a request is in echo.
 				// This is the best we can do.
-				if echoErr, ok := cfg.translateError(err); ok {
-					if cfg.isStatusError(echoErr.Code) {
-						finishOpts = append(finishOpts, tracer.WithError(err))
-					}
-					echoStatus = echoErr.Code
-
-				} else {
-					// Any error that is not an *echo.HTTPError will be treated as an error with 500 status code.
-					if cfg.isStatusError(500) {
-						finishOpts = append(finishOpts, tracer.WithError(err))
-					}
-					echoStatus = 500
+				echoStatus = statusFromError(cfg, err)
+				if cfg.isStatusError(echoStatus) {
+					finishOpts = append(finishOpts, tracer.WithError(err))
 				}
 			} else if status := responseStatus(c); status > 0 {
 				if cfg.isStatusError(status) {
@@ -202,6 +193,18 @@ func responseStatus(c *echo.Context) int {
 		return r.Status
 	}
 	return 0
+}
+
+// statusFromError reports the HTTP status echo will send for err: the
+// translator if it matches, else [echo.HTTPStatusCoder], else 500.
+func statusFromError(cfg *config, err error) int {
+	if echoErr, ok := cfg.translateError(err); ok && echoErr != nil && echoErr.Code != 0 {
+		return echoErr.Code
+	}
+	if code := echo.StatusCode(err); code != 0 {
+		return code
+	}
+	return http.StatusInternalServerError
 }
 
 func errorFromStatusCode(statusCode int) error {

--- a/contrib/labstack/echo.v5/echotrace_test.go
+++ b/contrib/labstack/echo.v5/echotrace_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
@@ -404,6 +405,87 @@ func TestStatusError(t *testing.T) {
 	}
 }
 
+// TestSentinelStatusError covers echo v5's unexported status-carrying errors
+// (echo.ErrNotFound, echo.ErrUnauthorized, ...). Unlike v4, where those
+// sentinels are *echo.HTTPError values, in v5 they only satisfy
+// echo.HTTPStatusCoder, so they must not be flattened to a 500.
+func TestSentinelStatusError(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		err      error
+		wantCode string
+		wantErr  bool
+	}{
+		{
+			name:     "unrouted-request",
+			err:      nil, // no handler registered: echo's router returns echo.ErrNotFound
+			wantCode: "404",
+		},
+		{
+			name:     "sentinel-404",
+			err:      echo.ErrNotFound,
+			wantCode: "404",
+		},
+		{
+			name:     "sentinel-401",
+			err:      echo.ErrUnauthorized,
+			wantCode: "401",
+		},
+		{
+			name:     "sentinel-500",
+			err:      echo.ErrInternalServerError,
+			wantCode: "500",
+			wantErr:  true,
+		},
+		{
+			name:     "sentinel-wrapped-503",
+			err:      fmt.Errorf("upstream down: %w", echo.ErrServiceUnavailable),
+			wantCode: "503",
+			wantErr:  true,
+		},
+		{
+			// echo.httpError.Wrap promotes the sentinel to an *echo.HTTPError
+			// keeping its status code.
+			name:     "sentinel-promoted-to-httperror",
+			err:      echo.ErrForbidden.Wrap(errors.New("nope")),
+			wantCode: "403",
+		},
+		{
+			// Errors without a status of their own still fall back to 500.
+			name:     "no-status",
+			err:      errors.New("oh no"),
+			wantCode: "500",
+			wantErr:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			router := echo.New()
+			router.Use(Middleware(WithService("foobar")))
+			if tt.err != nil {
+				router.GET("/err", func(_ *echo.Context) error { return tt.err })
+			}
+
+			r := httptest.NewRequest(http.MethodGet, "/err", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			span := spans[0]
+			assert.Equal(t, tt.wantCode, span.Tag(ext.HTTPCode))
+			assert.Equal(t, tt.wantCode, strconv.Itoa(w.Code), "response status should match the tagged status")
+			if tt.wantErr {
+				assert.NotNil(t, span.Tag(ext.ErrorMsg))
+			} else {
+				assert.NotContains(t, span.Tags(), ext.ErrorMsg)
+			}
+		})
+	}
+}
+
 func TestGetSpanNotInstrumented(t *testing.T) {
 	assert := assert.New(t)
 	router := echo.New()
@@ -543,6 +625,45 @@ func TestWithErrorTranslator(t *testing.T) {
 	assert.Equal("GET", span.Tag(ext.HTTPMethod))
 }
 
+// TestWithErrorTranslatorFallback asserts that a translator which only knows
+// about the application's own error types does not force every other error to
+// a 500: errors echo can resolve a status for keep it.
+func TestWithErrorTranslatorFallback(t *testing.T) {
+	translateError := func(err error) (*echo.HTTPError, bool) {
+		if custom, ok := errors.AsType[*testCustomError](err); ok {
+			return echo.NewHTTPError(custom.TestCode, custom.Error()), true
+		}
+		return nil, false
+	}
+
+	for _, tt := range []struct {
+		name     string
+		err      error
+		wantCode string
+	}{
+		{name: "translated", err: &testCustomError{TestCode: 401}, wantCode: "401"},
+		{name: "sentinel", err: echo.ErrTooManyRequests, wantCode: "429"},
+		{name: "http-error", err: echo.NewHTTPError(http.StatusBadRequest, "bad"), wantCode: "400"},
+		{name: "unknown", err: errors.New("oh no"), wantCode: "500"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			router := echo.New()
+			router.Use(Middleware(WithErrorTranslator(translateError)))
+			router.GET("/err", func(_ *echo.Context) error { return tt.err })
+
+			r := httptest.NewRequest(http.MethodGet, "/err", nil)
+			router.ServeHTTP(httptest.NewRecorder(), r)
+
+			spans := mt.FinishedSpans()
+			require.Len(t, spans, 1)
+			assert.Equal(t, tt.wantCode, spans[0].Tag(ext.HTTPCode))
+		})
+	}
+}
+
 func TestWithErrorCheck(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -596,6 +717,19 @@ func TestWithErrorCheck(t *testing.T) {
 			opts: []Option{
 				WithErrorCheck(func(_ error) bool {
 					return false
+				}),
+			},
+			wantErr: nil,
+		},
+		{
+			// echo.StatusCode is the way to reach the status of a sentinel
+			// error, whose type is unexported.
+			name: "ignore-4xx-sentinel-error",
+			err:  echo.ErrNotFound,
+			opts: []Option{
+				WithErrorCheck(func(err error) bool {
+					code := echo.StatusCode(err)
+					return !(code >= 400 && code < 500)
 				}),
 			},
 			wantErr: nil,

--- a/contrib/labstack/echo.v5/option.go
+++ b/contrib/labstack/echo.v5/option.go
@@ -150,6 +150,11 @@ func WithIgnoreRequest(ignoreRequestFunc IgnoreRequestFunc) OptionFn {
 
 // WithErrorTranslator sets a function to translate Go errors into echo Errors.
 // This is used for extracting the HTTP response status code.
+//
+// fn only needs to cover error types whose status echo itself cannot resolve.
+// When it returns false, the status is taken from [echo.HTTPStatusCoder] if the
+// error implements it ([echo.HTTPError] and package-level sentinels such as
+// [echo.ErrNotFound]); errors carrying no status are reported as 500.
 func WithErrorTranslator(fn func(err error) (*echo.HTTPError, bool)) OptionFn {
 	return func(cfg *config) {
 		cfg.translateError = fn


### PR DESCRIPTION
### What does this PR do?

Echo v5 middleware now takes the HTTP status f errors from the `echo.HTTPStatusCoder` interface. Built-in status errors such as `echo.ErrNotFound` now map to their real status instead of being tagged as 500.

### Motivation

Echo v5 split HTTP errors into the exported `*echo.HTTPError` type and an unexported sentinel `*echo.httpError`. However, they both implement `echo.HTTPStatusCoder` and that is the documented interface for translating errors to status codes. The existing integration only type-asserted `*echo.HTTPError`, so built-in errors (e.g. `echo.ErrNotFound`) were treated as 500s when tagging traces.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).
-->

- [ ] Changed code has unit tests for its functionality at or near 100% coverage.
- [ ] [System-Tests](https://github.com/DataDog/system-tests/) covering this feature have been added and enabled with the va.b.c-dev version tag.
- [ ] There is a benchmark for any new code, or changes to existing code.
- [ ] If this interacts with the agent in a new way, a system test has been added.
- [ ] New code is free of linting errors. You can check this by running `make lint` locally.
- [ ] New code doesn't break existing tests. You can check this by running `make test` locally.
- [ ] Add an appropriate team label so this PR gets put in the right place for the release notes.
- [ ] All generated files are up to date. You can check this by running `make generate` locally.
- [ ] Non-trivial go.mod changes, e.g. adding new modules, are reviewed by @DataDog/dd-trace-go-guild. Make sure all nested modules are up to date by running `make fix-modules` locally.

Unsure? Have a question? Request a review!
