### PR TITLE
fix(scripts/autoreleasetagger): skip nested git checkouts when discovering modules

### DIFF
--- a/scripts/autoreleasetagger/README.md
+++ b/scripts/autoreleasetagger/README.md
@@ -12,6 +12,12 @@ The repository has a structure consisting of nested modules for all the contribs
 
 You must be on a `release-v<MAJOR>.<MINOR>.x` branch. The tool will refuse to run on `main`, feature branches, or a detached HEAD.
 
+Any directory below `--root` that is itself a separate git checkout — a nested
+git worktree or a submodule, identified by a `.git` entry — is skipped
+entirely. This keeps module discovery scoped to the checkout being released,
+even if the release manager's machine has other worktrees nested inside the
+repository tree.
+
 ## 🛠️ Usage
 
 Run the following command to tag the release:

--- a/scripts/autoreleasetagger/main.go
+++ b/scripts/autoreleasetagger/main.go
@@ -992,6 +992,16 @@ func findModules(root string, excludedDirs []string) (map[string]GoMod, error) {
 			return filepath.SkipDir
 		}
 
+		// A .git entry below the root marks a separate checkout — a nested git
+		// worktree (gitlink file) or a submodule. Its modules are not part of this
+		// release, and rewriting their go.mod mutates someone else's branch.
+		if entry.IsDir() && path != root {
+			if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+				slog.Debug("Skipping nested checkout", "path", path)
+				return filepath.SkipDir
+			}
+		}
+
 		if entry.Name() == "go.mod" {
 			m, err := readModule(path)
 			if err != nil {

--- a/scripts/autoreleasetagger/main_integration_test.go
+++ b/scripts/autoreleasetagger/main_integration_test.go
@@ -1405,6 +1405,52 @@ func TestExcludeModulesSkipsTagCreation(t *testing.T) {
 	}
 }
 
+// TestNestedCheckoutIgnored verifies that a directory containing a .git entry
+// below the root (a nested git worktree checkout or a submodule) is skipped
+// entirely, so its go.mod is never discovered or rewritten.
+func TestNestedCheckoutIgnored(t *testing.T) {
+	t.Parallel()
+	testLogger()
+
+	const (
+		branch  = "release-v2.9.x"
+		version = "v2.9.9-rc.1"
+	)
+
+	tmpDir := scaffoldRepo(t, branch)
+
+	// Simulate a nested git worktree/submodule checkout containing its own
+	// module, with no replace directive back to root — the shape that made the
+	// real failure loud (go mod tidy tries to resolve the release tag from the
+	// proxy) rather than silent.
+	nestedDir := filepath.Join(tmpDir, "nested-checkout")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested checkout dir: %v", err)
+	}
+	nestedGoMod := "module example.com/nested/v2\n\ngo 1.26.0\n\nrequire example.com/root/v2 v2.0.0\n"
+	nestedGoModPath := filepath.Join(nestedDir, "go.mod")
+	if err := os.WriteFile(nestedGoModPath, []byte(nestedGoMod), 0o644); err != nil {
+		t.Fatalf("failed to write nested go.mod: %v", err)
+	}
+	// A .git file (not directory) marks this as a separate checkout, matching
+	// the gitlink shape of a real linked git worktree.
+	if err := os.WriteFile(filepath.Join(nestedDir, ".git"), []byte("gitdir: /elsewhere/.git/worktrees/nested\n"), 0o644); err != nil {
+		t.Fatalf("failed to write nested .git file: %v", err)
+	}
+
+	if err := run(false, "test-remote", true, tmpDir, version, []string{}, []string{}, []string{}); err != nil {
+		t.Fatalf("autoreleasetagger failed: %v", err)
+	}
+
+	got, err := os.ReadFile(nestedGoModPath)
+	if err != nil {
+		t.Fatalf("failed to read nested go.mod after run: %v", err)
+	}
+	if string(got) != nestedGoMod {
+		t.Errorf("nested go.mod was modified:\ngot:\n%s\nwant:\n%s", got, nestedGoMod)
+	}
+}
+
 // assertJSONErrorCode parses the JSON on stderr and asserts the "error" field
 // matches the expected code.
 func assertJSONErrorCode(t *testing.T, stderrOut, wantCode string) {


### PR DESCRIPTION
### What does this PR do?

`findModules` walks the entire tree from `--root`, but `defaultExcludedDirs` compares absolute paths, so exclusion only works relative to the root the tool is run against. A machine with git worktrees nested inside the checkout (e.g. under `.worktrees/`) gets the excluded modules inside those worktrees rediscovered at the worktree's own path and included in the release.

This PR skips any directory below `--root` that itself contains a `.git` entry — a nested git worktree (gitlink file) or a submodule. This generalizes past `.worktrees/` to any nested checkout location, and is a no-op in CI, where a fresh clone has none.

Also documents this behavior in the README's prerequisites section.

### Motivation

While tagging `v2.12.0-dev`, `autoreleasetagger` walked into a nested worktree on the release manager's machine, found `tools/v2fix`'s excluded modules at the worktree's path (which the exclusion list doesn't match), and rewrote their `go.mod` to require the release tag before it existed. Phase 1 aborted mid-run with another branch's `go.mod` left dirty.
